### PR TITLE
feat/renderer-and-hud

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -14,7 +14,7 @@ app = typer.Typer(help="Génération de vidéos satisfaction (TikTok).")
 
 @app.command()
 def run(seconds: int = 3, seed: int = 0, out: Path = Path("out.mp4")) -> None:
-    """Run a single stub match and export a video."""
+    """Run a single match and export a video."""
     random.seed(seed)
     recorder = Recorder(settings.width, settings.height, settings.fps, out)
     run_match(seconds, recorder)

--- a/app/game/match.py
+++ b/app/game/match.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+from math import sqrt
+
 from app.core.config import settings
+from app.render.hud import Hud
+from app.render.renderer import Renderer
 from app.video.recorder import Recorder
 from app.world.entities import Ball
 from app.world.physics import PhysicsWorld
@@ -10,16 +14,53 @@ from app.world.projectiles import Projectile
 def run_match(seconds: int, recorder: Recorder) -> None:
     """Run a minimal game loop and record frames."""
     world = PhysicsWorld()
-    entities: list[Ball] = [Ball.spawn(world, (settings.width / 2, settings.height / 2))]
+    renderer = Renderer(settings.width, settings.height)
+    hud = Hud()
+
+    ball_a = Ball.spawn(world, (settings.width * 0.25, settings.height * 0.5))
+    ball_b = Ball.spawn(world, (settings.width * 0.75, settings.height * 0.5))
+    ball_a.body.velocity = (200.0, 150.0)
+    ball_b.body.velocity = (-200.0, 150.0)
+    entities: list[Ball] = [ball_a, ball_b]
     projectiles: list[Projectile] = []
 
     total_frames = int(seconds * settings.fps)
-    for frame in range(total_frames):
+    for _ in range(total_frames):
         for entity in entities:
             entity.cap_speed()
         for projectile in projectiles:
             projectile.step(settings.dt)
         world.step(settings.dt)
+
+        renderer.clear()
+        for projectile in projectiles:
+            proj_pos = (
+                float(projectile.body.position.x),
+                float(projectile.body.position.y),
+            )
+            renderer.draw_projectile(proj_pos, int(projectile.shape.radius), (255, 255, 0))
+        for idx, entity in enumerate(entities):
+            pos = (float(entity.body.position.x), float(entity.body.position.y))
+            radius = int(entity.shape.radius)
+            base_color = settings.ball_color
+            team_color = (255, 0, 0) if idx == 0 else (0, 0, 255)
+            renderer.draw_ball(pos, radius, base_color, team_color)
+            vx, vy = entity.body.velocity
+            speed = sqrt(vx * vx + vy * vy)
+            gaze = (vx / speed, vy / speed) if speed else (0.0, 0.0)
+            renderer.draw_eyes(pos, gaze, radius, team_color)
+
+        hud.draw_title(renderer.surface, "Qui gagne : Katana ou Shuriken ?")
+        hud.draw_hp_bars(
+            renderer.surface,
+            ball_a.health / ball_a.stats.max_health,
+            ball_b.health / ball_b.stats.max_health,
+            ("Katana", "Shuriken"),
+        )
+        hud.draw_watermark(renderer.surface)
+
+        renderer.present()
+        frame = renderer.capture_frame()
         recorder.add_frame(frame)
 
     recorder.close()

--- a/app/render/hud.py
+++ b/app/render/hud.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pygame
+
+
+class Hud:
+    """Draw heads-up display elements."""
+
+    def __init__(self) -> None:
+        pygame.font.init()
+        self.title_font = pygame.font.Font(None, 72)
+        self.bar_font = pygame.font.Font(None, 48)
+        self.watermark_font = pygame.font.Font(None, 36)
+
+    def draw_title(self, surface: pygame.Surface, text: str) -> None:
+        """Render the main title centered at the top of the screen."""
+        title = self.title_font.render(text, True, (255, 255, 255))
+        rect = title.get_rect(center=(surface.get_width() // 2, 60))
+        surface.blit(title, rect)
+
+    def draw_hp_bars(
+        self, surface: pygame.Surface, hp_a: float, hp_b: float, labels: tuple[str, str]
+    ) -> None:
+        """Draw two symmetrical health bars with labels."""
+        bar_width = 300
+        bar_height = 25
+        margin = 40
+        # Left bar
+        left_rect = pygame.Rect(margin, 120, bar_width, bar_height)
+        pygame.draw.rect(surface, (100, 0, 0), left_rect)
+        pygame.draw.rect(
+            surface, (200, 0, 0), (left_rect.x, left_rect.y, int(bar_width * hp_a), bar_height)
+        )
+        label_a = self.bar_font.render(labels[0], True, (255, 255, 255))
+        surface.blit(label_a, (left_rect.x, left_rect.y - 30))
+        # Right bar
+        right_rect = pygame.Rect(
+            surface.get_width() - margin - bar_width, 120, bar_width, bar_height
+        )
+        pygame.draw.rect(surface, (0, 100, 0), right_rect)
+        pygame.draw.rect(
+            surface,
+            (0, 200, 0),
+            (
+                right_rect.x + bar_width - int(bar_width * hp_b),
+                right_rect.y,
+                int(bar_width * hp_b),
+                bar_height,
+            ),
+        )
+        label_b = self.bar_font.render(labels[1], True, (255, 255, 255))
+        surface.blit(label_b, (right_rect.x + bar_width - label_b.get_width(), right_rect.y - 30))
+
+    def draw_watermark(self, surface: pygame.Surface, text: str = "@battleballs") -> None:
+        """Draw a small watermark at the bottom-left corner."""
+        mark = self.watermark_font.render(text, True, (255, 255, 255))
+        rect = mark.get_rect()
+        rect.bottomleft = (10, surface.get_height() - 10)
+        surface.blit(mark, rect)

--- a/app/render/renderer.py
+++ b/app/render/renderer.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import os
+import random
+from dataclasses import dataclass, field
+
+import numpy as np
+import pygame
+
+from app.core.config import settings
+from app.core.types import Color, Vec2
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+
+@dataclass(slots=True)
+class _BallState:
+    """Visual state for a single ball."""
+
+    prev_pos: Vec2 | None = None
+    trail: list[tuple[Vec2, float]] = field(default_factory=list)
+    blink_timer: int = field(default_factory=lambda: random.randint(60, 180))
+    blink_progress: int = 0
+
+
+class Renderer:
+    """Off-screen renderer producing frames for the recorder."""
+
+    def __init__(self, width: int = settings.width, height: int = settings.height) -> None:
+        pygame.init()
+        pygame.font.init()
+        self.width = width
+        self.height = height
+        self.surface = pygame.Surface((width, height), flags=pygame.SRCALPHA)
+        self._balls: dict[Color, _BallState] = {}
+        self.frame_index = 0
+        self.background = (10, 10, 10)
+        self.arena_color = (20, 20, 20)
+
+    def clear(self) -> None:
+        """Clear frame and draw arena background."""
+        self.surface.fill(self.background)
+        margin = 20
+        arena_rect = pygame.Rect(margin, margin, self.width - 2 * margin, self.height - 2 * margin)
+        pygame.draw.rect(self.surface, self.arena_color, arena_rect, border_radius=30)
+
+    def _get_state(self, key: Color) -> _BallState:
+        return self._balls.setdefault(key, _BallState())
+
+    def _draw_trail(self, state: _BallState, color: Color, radius: int) -> None:
+        updated: list[tuple[Vec2, float]] = []
+        for pos, alpha in state.trail:
+            if alpha <= 10:
+                continue
+            trail_color = (*color, int(alpha))
+            pygame.draw.circle(self.surface, trail_color, pos, radius // 2)
+            updated.append((pos, alpha * 0.7))
+        state.trail = updated
+
+    def draw_ball(self, pos: Vec2, radius: int, color: Color, team_color: Color) -> None:
+        """Draw a ball with a team ring and glossy highlight."""
+        state = self._get_state(team_color)
+        if state.prev_pos is not None:
+            vx = pos[0] - state.prev_pos[0]
+            vy = pos[1] - state.prev_pos[1]
+            speed = (vx * vx + vy * vy) ** 0.5
+            state.trail.append((pos, min(255.0, speed * 10.0)))
+        state.prev_pos = pos
+        self._draw_trail(state, team_color, radius)
+        pygame.draw.circle(self.surface, color, pos, radius)
+        pygame.draw.circle(self.surface, team_color, pos, radius + 3, width=3)
+        highlight_pos = (pos[0] - radius * 0.3, pos[1] - radius * 0.3)
+        pygame.draw.circle(self.surface, (255, 255, 255, 80), highlight_pos, int(radius * 0.3))
+
+    def draw_projectile(self, pos: Vec2, radius: int, color: Color) -> None:
+        """Draw a simple projectile."""
+        pygame.draw.circle(self.surface, color, pos, radius)
+
+    def draw_eyes(self, pos: Vec2, gaze: Vec2, radius: int, team_color: Color) -> None:
+        """Draw eyes with a blinking effect looking towards *gaze*."""
+        state = self._get_state(team_color)
+        if state.blink_progress > 0:
+            state.blink_progress -= 1
+            left = (pos[0] - radius * 0.3, pos[1] - radius * 0.2)
+            right = (pos[0] + radius * 0.3, pos[1] - radius * 0.2)
+            pygame.draw.line(self.surface, (0, 0, 0), left, (left[0] + radius * 0.2, left[1]), 2)
+            pygame.draw.line(self.surface, (0, 0, 0), right, (right[0] + radius * 0.2, right[1]), 2)
+            return
+        state.blink_timer -= 1
+        if state.blink_timer <= 0:
+            state.blink_timer = random.randint(60, 180)
+            state.blink_progress = 5
+        offset = (gaze[0] * radius * 0.3, gaze[1] * radius * 0.3)
+        for dx in (-radius * 0.3, radius * 0.3):
+            center = (pos[0] + dx + offset[0], pos[1] - radius * 0.2 + offset[1])
+            pygame.draw.circle(self.surface, (0, 0, 0), center, int(radius * 0.15))
+
+    def present(self) -> None:
+        """Advance frame counter."""
+        self.frame_index += 1
+
+    def capture_frame(self) -> np.ndarray:
+        """Return the current frame as a NumPy array."""
+        array = pygame.surfarray.array3d(self.surface)
+        return np.swapaxes(array, 0, 1)

--- a/app/video/recorder.py
+++ b/app/video/recorder.py
@@ -5,22 +5,6 @@ from pathlib import Path
 import imageio
 import numpy as np
 
-from app.core.config import settings
-from app.core.types import Color
-
-_DIGITS = {
-    "0": ("111", "101", "101", "101", "111"),
-    "1": ("010", "110", "010", "010", "111"),
-    "2": ("111", "001", "111", "100", "111"),
-    "3": ("111", "001", "111", "001", "111"),
-    "4": ("101", "101", "111", "001", "001"),
-    "5": ("111", "100", "111", "001", "111"),
-    "6": ("111", "100", "111", "101", "111"),
-    "7": ("111", "001", "010", "010", "010"),
-    "8": ("111", "101", "111", "101", "111"),
-    "9": ("111", "101", "111", "001", "111"),
-}
-
 
 class Recorder:
     """Write frames to an MP4 file with GIF fallback."""
@@ -36,25 +20,10 @@ class Recorder:
             self.path = self.path.with_suffix(".gif")
             self.writer = imageio.get_writer(self.path, fps=fps)
 
-    def _draw_number(self, frame: np.ndarray, number: int, color: Color) -> None:
-        scale = 8
-        x = 10
-        y = 10
-        for char in str(number):
-            pattern = _DIGITS[char]
-            for row, line in enumerate(pattern):
-                for col, bit in enumerate(line):
-                    if bit == "1":
-                        x0 = x + col * scale
-                        y0 = y + row * scale
-                        frame[y0 : y0 + scale, x0 : x0 + scale] = color
-            x += (len(pattern[0]) + 1) * scale
-
-    def add_frame(self, frame_number: int) -> None:
-        frame = np.zeros((self.height, self.width, 3), dtype=np.uint8)
-        frame[:, :] = np.array(settings.background_color, dtype=np.uint8)
-        self._draw_number(frame, frame_number, (255, 255, 255))
+    def add_frame(self, frame: np.ndarray) -> None:
+        """Append a pre-rendered frame to the output video."""
         self.writer.append_data(frame)
 
     def close(self) -> None:
+        """Finalize and close the video file."""
         self.writer.close()

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from app.render.hud import Hud
+from app.render.renderer import Renderer
+
+
+def test_hud_draws_without_errors() -> None:
+    renderer = Renderer(100, 200)
+    hud = Hud()
+    renderer.clear()
+    hud.draw_title(renderer.surface, "Test")
+    hud.draw_hp_bars(renderer.surface, 0.5, 0.5, ("A", "B"))
+    hud.draw_watermark(renderer.surface)
+    renderer.present()
+    frame = renderer.capture_frame()
+    assert frame.shape == (200, 100, 3)

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from app.render.renderer import Renderer
+
+
+def test_capture_frame_shape() -> None:
+    renderer = Renderer(100, 200)
+    renderer.clear()
+    renderer.draw_ball((50.0, 100.0), 10, (255, 255, 255), (255, 0, 0))
+    renderer.draw_eyes((50.0, 100.0), (1.0, 0.0), 10, (255, 0, 0))
+    renderer.present()
+    frame = renderer.capture_frame()
+    assert frame.shape == (200, 100, 3)
+    assert frame.sum() > 0


### PR DESCRIPTION
## Summary
- implement off-screen renderer with trails, eyes, and frame capture
- add HUD for title, HP bars, and watermark
- integrate renderer and HUD into match and CLI run

## Testing
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab691cbf48832aa900bdd2cd125516