### PR TITLE
feat: end screen and loop config

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,9 @@ uv run python -m app.cli batch \
 - **IA** : agressive, kite, support, teamplay.
 - **Équipes** : passer de 1v1 → 2v2 → FFA → Battle Royale.
 - **Rendu** : couleurs, arènes, effets visuels.
-- **FPS / résolution** : modifier `app/core/config.py`.
+- **Boucle & fin de match** : freeze 120 ms, ralenti ×0.35, bannière « VICTOIRE » puis fondu vers le début (400 ms).
+- **Configuration externe** : `app/config.json` regroupe canvas, palette (bleu/orange), HUD (titre, watermark) et paramètres d'**end screen** (textes, slow-mo, fade...).
+- **FPS / résolution** : ajuster `canvas` dans `app/config.json`.
 
 ---
 

--- a/app/config.json
+++ b/app/config.json
@@ -1,0 +1,16 @@
+{
+  "canvas": {"width": 1080, "height": 1920, "fps": 60},
+  "theme": {
+    "team_a": {"primary": [0, 102, 204], "hp_gradient": [[102, 178, 255], [0, 51, 102]]},
+    "team_b": {"primary": [255, 102, 0], "hp_gradient": [[255, 178, 102], [102, 51, 0]]}
+  },
+  "hud": {"title": "Battle Balls", "watermark": "@battleballs"},
+  "end_screen": {
+    "victory_text": "VICTOIRE : {team}",
+    "subtitle_text": "{weapon} remporte le duel !",
+    "slowmo": 0.35,
+    "slowmo_duration": 0.6,
+    "freeze_ms": 120,
+    "fade_ms": 400
+  }
+}

--- a/app/render/hud.py
+++ b/app/render/hud.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import pygame
 
+from app.render.theme import Theme, draw_horizontal_gradient
+
 
 class Hud:
     """Draw heads-up display elements."""
 
-    def __init__(self) -> None:
+    def __init__(self, theme: Theme) -> None:
         pygame.font.init()
+        self.theme = theme
         self.title_font = pygame.font.Font(None, 72)
         self.bar_font = pygame.font.Font(None, 48)
         self.watermark_font = pygame.font.Font(None, 36)
@@ -21,26 +24,34 @@ class Hud:
     def draw_hp_bars(
         self, surface: pygame.Surface, hp_a: float, hp_b: float, labels: tuple[str, str]
     ) -> None:
-        """Draw two symmetrical health bars with labels."""
+        """Draw two symmetrical health bars with labels using theme gradients."""
         bar_width = 300
         bar_height = 25
         margin = 40
-        # Left bar
+
+        # Left bar (team A)
         left_rect = pygame.Rect(margin, 120, bar_width, bar_height)
-        pygame.draw.rect(surface, (100, 0, 0), left_rect)
+        draw_horizontal_gradient(
+            surface, left_rect, *self.theme.team_a.hp_gradient
+        )
         pygame.draw.rect(
-            surface, (200, 0, 0), (left_rect.x, left_rect.y, int(bar_width * hp_a), bar_height)
+            surface,
+            self.theme.team_a.primary,
+            (left_rect.x, left_rect.y, int(bar_width * hp_a), bar_height),
         )
         label_a = self.bar_font.render(labels[0], True, (255, 255, 255))
         surface.blit(label_a, (left_rect.x, left_rect.y - 30))
-        # Right bar
+
+        # Right bar (team B)
         right_rect = pygame.Rect(
             surface.get_width() - margin - bar_width, 120, bar_width, bar_height
         )
-        pygame.draw.rect(surface, (0, 100, 0), right_rect)
+        # Gradient drawn right-to-left
+        grad_start, grad_end = self.theme.team_b.hp_gradient
+        draw_horizontal_gradient(surface, right_rect, grad_end, grad_start)
         pygame.draw.rect(
             surface,
-            (0, 200, 0),
+            self.theme.team_b.primary,
             (
                 right_rect.x + bar_width - int(bar_width * hp_b),
                 right_rect.y,
@@ -49,11 +60,27 @@ class Hud:
             ),
         )
         label_b = self.bar_font.render(labels[1], True, (255, 255, 255))
-        surface.blit(label_b, (right_rect.x + bar_width - label_b.get_width(), right_rect.y - 30))
+        surface.blit(
+            label_b,
+            (right_rect.x + bar_width - label_b.get_width(), right_rect.y - 30),
+        )
 
-    def draw_watermark(self, surface: pygame.Surface, text: str = "@battleballs") -> None:
+    def draw_watermark(self, surface: pygame.Surface, text: str) -> None:
         """Draw a small watermark at the bottom-left corner."""
         mark = self.watermark_font.render(text, True, (255, 255, 255))
         rect = mark.get_rect()
         rect.bottomleft = (10, surface.get_height() - 10)
         surface.blit(mark, rect)
+
+    def draw_victory_banner(
+        self, surface: pygame.Surface, title: str, subtitle: str
+    ) -> None:
+        """Draw the final victory banner at the center of the screen."""
+        title_surf = self.title_font.render(title, True, (255, 255, 255))
+        sub_surf = self.bar_font.render(subtitle, True, (255, 255, 255))
+        center_x = surface.get_width() // 2
+        center_y = surface.get_height() // 2
+        title_rect = title_surf.get_rect(center=(center_x, center_y - 30))
+        sub_rect = sub_surf.get_rect(center=(center_x, center_y + 20))
+        surface.blit(title_surf, title_rect)
+        surface.blit(sub_surf, sub_rect)

--- a/app/render/theme.py
+++ b/app/render/theme.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.core.types import Color
+
+
+@dataclass(frozen=True)
+class TeamColors:
+    """Color definitions for a team."""
+
+    primary: Color
+    hp_gradient: tuple[Color, Color]
+
+
+@dataclass(frozen=True)
+class Theme:
+    """Complete color palette for the renderer and HUD."""
+
+    team_a: TeamColors
+    team_b: TeamColors
+
+
+def draw_horizontal_gradient(
+    surface: 'pygame.Surface',
+    rect: 'pygame.Rect',
+    start: Color,
+    end: Color,
+) -> None:
+    """Draw a left-to-right linear gradient on the given surface."""
+    import pygame
+
+    for x in range(rect.width):
+        ratio = x / rect.width
+        r = int(start[0] + (end[0] - start[0]) * ratio)
+        g = int(start[1] + (end[1] - start[1]) * ratio)
+        b = int(start[2] + (end[2] - start[2]) * ratio)
+        pygame.draw.line(
+            surface,
+            (r, g, b),
+            (rect.x + x, rect.y),
+            (rect.x + x, rect.y + rect.height),
+        )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.core import config
+
+
+def test_load_settings_from_file(tmp_path: Path) -> None:
+    cfg = {
+        "canvas": {"width": 100, "height": 200, "fps": 30},
+        "hud": {"title": "X", "watermark": "Y"},
+    }
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps(cfg))
+    settings = config.load_settings(path)
+    assert settings.width == 100
+    assert settings.height == 200
+    assert settings.fps == 30
+    assert settings.hud.title == "X"
+    assert settings.hud.watermark == "Y"

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -2,15 +2,16 @@ from __future__ import annotations
 
 from app.render.hud import Hud
 from app.render.renderer import Renderer
+from app.core.config import settings
 
 
 def test_hud_draws_without_errors() -> None:
     renderer = Renderer(100, 200)
-    hud = Hud()
+    hud = Hud(settings.theme)
     renderer.clear()
     hud.draw_title(renderer.surface, "Test")
     hud.draw_hp_bars(renderer.surface, 0.5, 0.5, ("A", "B"))
-    hud.draw_watermark(renderer.surface)
+    hud.draw_watermark(renderer.surface, settings.hud.watermark)
     renderer.present()
     frame = renderer.capture_frame()
     assert frame.shape == (200, 100, 3)


### PR DESCRIPTION
## Summary
- add JSON-configurable canvas, theme, HUD, and end screen parameters
- implement blue/orange theme with gradient HP bars and victory banner
- extend match loop with freeze, slow-mo replay, and fade-to-start sequence

## Testing
- `uv run pytest` *(failed: Failed to fetch: `https://pypi.org/simple/pygame/`)*
- `uv run pre-commit run --files README.md app/core/config.py app/game/match.py app/render/hud.py app/render/theme.py tests/test_hud.py tests/test_config.py` *(failed: Failed to fetch: `https://pypi.org/simple/bandit/`)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3fd652d0832a9aed67cf10b807ae