### PR TITLE
feat: add display mode without video

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Le code est **modulaire**, **extensible** et **typé**, pensé pour créer **des
 - 🧠 **IA configurable** : agressive, kite, support… ou comportements personnalisés.
 - 🎨 **Rendu vertical 1080×1920** optimisé pour TikTok.
 - 🎥 **Export vidéo automatique** en `.mp4` via [imageio-ffmpeg](https://imageio.readthedocs.io/).
+- 🖥️ **Mode affichage** sans enregistrement grâce à l'option `--display`.
 - 🔄 **Reproductibilité totale** grâce aux seeds (mêmes combats → mêmes résultats).
 - 🧩 **Architecture plug-in** : ajout d'armes, IA ou effets visuels sans toucher au moteur.
 - 🔊 **Effets sonores & particules** (prévu pour la v2).
@@ -108,8 +109,16 @@ uv run python -m app.cli run \
   --out out/katana_vs_shuriken.mp4
 ```
 
-📌 **Résultat :**  
+📌 **Résultat :**
 Une vidéo **1080×1920, 60 FPS, .mp4**, prête pour TikTok.
+
+Pour afficher la simulation sans enregistrer de vidéo, ajoutez `--display` :
+
+```bash
+uv run python -m app.cli run --display
+```
+
+Aucun fichier vidéo n'est créé dans ce mode.
 
 ---
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -7,7 +7,8 @@ import typer
 
 from app.core.config import settings
 from app.game.match import run_match
-from app.video.recorder import Recorder
+from app.render.renderer import Renderer
+from app.video.recorder import NullRecorder, Recorder
 
 app = typer.Typer(help="Génération de vidéos satisfaction (TikTok).")
 
@@ -19,12 +20,21 @@ def run(
     weapon_a: str = "katana",
     weapon_b: str = "shuriken",
     out: Path = Path("out.mp4"),
+    display: bool = typer.Option(
+        False, "--display/--no-display", help="Display simulation instead of recording"
+    ),
 ) -> None:
-    """Run a single match and export a video."""
+    """Run a single match and optionally export a video."""
     random.seed(seed)
-    recorder = Recorder(settings.width, settings.height, settings.fps, out)
-    run_match(seconds, weapon_a, weapon_b, recorder)
-    typer.echo(f"Saved video to {recorder.path}")
+    if display:
+        renderer = Renderer(settings.width, settings.height, display=True)
+        recorder = NullRecorder()
+    else:
+        recorder = Recorder(settings.width, settings.height, settings.fps, out)
+        renderer = Renderer(settings.width, settings.height)
+    run_match(seconds, weapon_a, weapon_b, recorder, renderer)
+    if not display:
+        typer.echo(f"Saved video to {recorder.path}")
 
 
 @app.command()

--- a/app/game/match.py
+++ b/app/game/match.py
@@ -90,10 +90,24 @@ class _MatchView(WorldView):
         self.projectiles.append(proj)
 
 
-def run_match(seconds: int, weapon_a: str, weapon_b: str, recorder: Recorder) -> EntityId | None:  # noqa: C901
-    """Run a minimal match and record frames."""
+def run_match(
+    seconds: int,
+    weapon_a: str,
+    weapon_b: str,
+    recorder: Recorder,
+    renderer: Renderer | None = None,
+) -> EntityId | None:  # noqa: C901
+    """Run a minimal match and record frames.
+
+    Args:
+        seconds: Duration of the match in seconds.
+        weapon_a: Name of the first weapon.
+        weapon_b: Name of the second weapon.
+        recorder: Target recorder for rendered frames.
+        renderer: Optional renderer instance. If omitted, an off-screen renderer is used.
+    """
     world = PhysicsWorld()
-    renderer = Renderer(settings.width, settings.height)
+    renderer = renderer or Renderer(settings.width, settings.height)
     hud = Hud(settings.theme)
 
     ball_a = Ball.spawn(world, (settings.width * 0.25, settings.height * 0.5))

--- a/app/video/recorder.py
+++ b/app/video/recorder.py
@@ -27,3 +27,13 @@ class Recorder:
     def close(self) -> None:
         """Finalize and close the video file."""
         self.writer.close()
+
+
+class NullRecorder:
+    """Recorder that discards frames and writes nothing."""
+
+    def add_frame(self, _frame: np.ndarray) -> None:  # noqa: D401 - same interface
+        """Ignore a pre-rendered frame."""
+
+    def close(self) -> None:  # noqa: D401 - same interface
+        """No-op close method."""

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -29,3 +29,28 @@ def test_run_creates_video(tmp_path: Path) -> None:
     assert result.exit_code == 0
     video_path = out if out.exists() else out.with_suffix(".gif")
     assert video_path.exists()
+
+
+def test_run_display_mode_no_file(tmp_path: Path) -> None:
+    runner = CliRunner()
+    out = tmp_path / "test.mp4"
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--seconds",
+            "1",
+            "--seed",
+            "1",
+            "--weapon-a",
+            "katana",
+            "--weapon-b",
+            "shuriken",
+            "--out",
+            str(out),
+            "--display",
+        ],
+    )
+    assert result.exit_code == 0
+    assert not out.exists()
+    assert not out.with_suffix(".gif").exists()


### PR DESCRIPTION
## Summary
- allow renderer to optionally open a display window and remove dummy driver when visible
- add a NullRecorder for runs without video export
- support `--display` flag in CLI and document usage

## Testing
- `uv run pre-commit run --files app/render/renderer.py app/video/recorder.py app/cli.py app/game/match.py tests/test_cli_run.py README.md` *(fails: Failed to download `pydantic-core==2.33.2`)*
- `uv run pytest` *(fails: Failed to download `rich==14.1.0`)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5b775b8c832a939de0d191f3e792