### PR TITLE
feat: enforce match timeout in CLI and game loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,19 +97,22 @@ uv run python -m app.cli --help
 
 ## 🎮 Lancer un match simple
 
-Exemple : **Katana VS Shuriken**, durée 22s, seed = 42 :
+Exemple : **Katana VS Shuriken**, seed = 42 :
 
 ```bash
 uv run python -m app.cli run \
   --weapon-a katana \
   --weapon-b shuriken \
-  --seconds 22 \
   --seed 42 \
   --out out/katana_vs_shuriken.mp4
 ```
 
-📌 **Résultat :**  
+📌 **Résultat :**
 Une vidéo **1080×1920, 60 FPS, .mp4**, prête pour TikTok.
+
+⏱️ *La durée du match dépend de la dynamique du jeu.*
+Si aucun vainqueur n’est déterminé après **2 minutes**, le moteur interrompt
+automatiquement la simulation et renvoie un **message d’erreur**.
 
 ---
 

--- a/app/render/theme.py
+++ b/app/render/theme.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+import pygame
+
 from app.core.types import Color
 
 
@@ -22,13 +24,12 @@ class Theme:
 
 
 def draw_horizontal_gradient(
-    surface: 'pygame.Surface',
-    rect: 'pygame.Rect',
+    surface: pygame.Surface,
+    rect: pygame.Rect,
     start: Color,
     end: Color,
 ) -> None:
     """Draw a left-to-right linear gradient on the given surface."""
-    import pygame
 
     for x in range(rect.width):
         ratio = x / rect.width

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from app.core.config import settings
 from app.render.hud import Hud
 from app.render.renderer import Renderer
-from app.core.config import settings
 
 
 def test_hud_draws_without_errors() -> None:


### PR DESCRIPTION
## Summary
- add `MatchTimeout` and time-limited loop to `run_match`
- handle timeout in CLI `run` command and remove seconds option
- document new behaviour and update tests

## Testing
- `ruff check app/game/match.py app/cli.py app/render/theme.py tests/test_cli_run.py tests/test_hud.py`
- `mypy app`
- `mypy tests/test_cli_run.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac5b8471bc832a902e870d1687fc48