### PR TITLE
feat: add vertical offset for horizontal aiming

### DIFF
--- a/app/ai/policy.py
+++ b/app/ai/policy.py
@@ -13,6 +13,7 @@ class SimplePolicy:
     """Very small deterministic combat policy."""
 
     style: Literal["aggressive", "kiter"]
+    vertical_offset: float = 0.1
 
     def decide(self, me: EntityId, view: WorldView) -> tuple[Vec2, Vec2, bool]:
         """Return acceleration, facing vector and fire decision."""
@@ -43,4 +44,10 @@ class SimplePolicy:
             face = direction
             if dist <= 300 and direction[0] * face[0] + direction[1] * face[1] >= cos_thresh:
                 fire = True
+
+        if abs(dy) <= 1e-6:
+            offset_face = (direction[0], self.vertical_offset)
+            norm = math.hypot(*offset_face) or 1.0
+            face = (offset_face[0] / norm, offset_face[1] / norm)
+
         return accel, face, fire

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from app.ai.policy import SimplePolicy
 from app.core.types import Damage, EntityId, Vec2
 from app.weapons.base import WorldView
+from app.weapons.shuriken import Shuriken
 
 
 @dataclass
@@ -13,6 +14,7 @@ class DummyView(WorldView):
     enemy: EntityId
     pos_me: Vec2
     pos_enemy: Vec2
+    last_velocity: Vec2 | None = field(default=None, init=False)
 
     def get_enemy(self, owner: EntityId) -> EntityId | None:  # noqa: D401
         return self.enemy
@@ -26,8 +28,17 @@ class DummyView(WorldView):
     def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:  # noqa: D401
         return
 
-    def spawn_projectile(self, *args, **kwargs) -> None:  # noqa: D401, ANN002
-        return
+    def spawn_projectile(
+        self,
+        owner: EntityId,
+        position: Vec2,
+        velocity: Vec2,
+        radius: float,
+        damage: Damage,
+        knockback: float,
+        ttl: float,
+    ) -> None:  # noqa: D401
+        self.last_velocity = velocity
 
 
 def test_kiter_moves_away() -> None:
@@ -36,3 +47,17 @@ def test_kiter_moves_away() -> None:
     accel, face, fire = policy.decide(EntityId(1), view)
     assert accel[0] < 0  # moves left, away from enemy
     assert fire is True
+
+
+def test_horizontal_alignment_has_vertical_component() -> None:
+    me = EntityId(1)
+    enemy = EntityId(2)
+    view = DummyView(me, enemy, (0.0, 0.0), (50.0, 0.0))
+    policy = SimplePolicy("aggressive")
+    weapon = Shuriken()
+    accel, face, fire = policy.decide(me, view)
+    assert fire is True
+    assert face[1] != 0.0
+    weapon.trigger(me, view, face)
+    assert view.last_velocity is not None
+    assert view.last_velocity[1] != 0.0


### PR DESCRIPTION
## Summary
- ensure SimplePolicy adds a vertical offset when enemies are horizontally aligned
- cover SimplePolicy with a test asserting vertical projectile direction

## Testing
- `uv run ruff check .`
- `uv run mypy app/ai/policy.py tests/test_policy.py`
- `uv run pytest tests/test_policy.py`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_68ac6cf46d40832a9f057ba189f7b7c2