### PR TITLE
feat: add weapon speed attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ uv run python -m app.cli batch \
 ## ⚙️ Configuration personnalisée
 
 - **Armes** disponibles : `app/weapons/`
+- Chaque arme expose un attribut `speed` (float) indiquant la vitesse de son projectile ou de son effet. Par exemple, la `Shuriken` voyage à `600.0` unités par seconde, tandis que la `Katana` reste à `0.0`.
 - **IA** : agressive, kite, support, teamplay.
 - **Équipes** : passer de 1v1 → 2v2 → FFA → Battle Royale.
 - **Rendu** : couleurs, arènes, effets visuels.

--- a/app/weapons/base.py
+++ b/app/weapons/base.py
@@ -39,11 +39,26 @@ class WorldView(Protocol):
 
 @dataclass(slots=True)
 class Weapon:
-    """Base weapon with a cooldown timer."""
+    """Base weapon with a cooldown timer.
+
+    Attributes
+    ----------
+    name:
+        Unique weapon identifier.
+    cooldown:
+        Minimum delay in seconds between two consecutive shots.
+    damage:
+        Amount of damage inflicted on each successful hit.
+    speed:
+        Velocity of the weapon's projectile or effect in units per second.
+    _timer:
+        Internal cooldown tracker used to throttle fire rate.
+    """
 
     name: str
     cooldown: float
     damage: Damage
+    speed: float = 0.0
     _timer: float = 0.0
 
     def step(self, dt: float) -> None:

--- a/app/weapons/katana.py
+++ b/app/weapons/katana.py
@@ -12,7 +12,7 @@ class Katana(Weapon):
     """Close-range melee weapon."""
 
     def __init__(self) -> None:
-        super().__init__(name="katana", cooldown=0.6, damage=Damage(18))
+        super().__init__(name="katana", cooldown=0.6, damage=Damage(18), speed=0.0)
 
     def _fire(self, owner: EntityId, view: WorldView, direction: Vec2) -> None:
         enemy = view.get_enemy(owner)

--- a/app/weapons/shuriken.py
+++ b/app/weapons/shuriken.py
@@ -10,11 +10,10 @@ class Shuriken(Weapon):
     """Ranged projectile weapon."""
 
     def __init__(self) -> None:
-        super().__init__(name="shuriken", cooldown=0.4, damage=Damage(10))
+        super().__init__(name="shuriken", cooldown=0.4, damage=Damage(10), speed=600.0)
 
     def _fire(self, owner: EntityId, view: WorldView, direction: Vec2) -> None:
-        speed = 600.0
-        velocity = (direction[0] * speed, direction[1] * speed)
+        velocity = (direction[0] * self.speed, direction[1] * self.speed)
         position = view.get_position(owner)
         view.spawn_projectile(
             owner,

--- a/tests/unit/test_weapons.py
+++ b/tests/unit/test_weapons.py
@@ -13,6 +13,7 @@ from app.video.recorder import NullRecorder, Recorder
 from app.weapons import weapon_registry
 from app.weapons.base import Weapon, WorldView
 from app.weapons.katana import Katana
+from app.weapons.shuriken import Shuriken
 
 
 @dataclass
@@ -52,6 +53,15 @@ def test_katana_cooldown_and_damage() -> None:
     weapon.step(0.6)
     weapon.trigger(owner, view, (1.0, 0.0))
     assert view.damage_values == [18, 18]
+
+
+def test_weapon_speed_attribute() -> None:
+    """Weapons expose their projectile speed on the base class."""
+    katana = Katana()
+    shuriken = Shuriken()
+
+    assert katana.speed == 0.0
+    assert shuriken.speed == 600.0
 
 
 class SpyWeapon(Weapon):


### PR DESCRIPTION
## Summary
- add `speed` field to `Weapon` dataclass
- set specific speeds for Katana and Shuriken
- document and test weapon speed

## Testing
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `uv sync --all-extras --dev` *(fails: tunnel error when fetching toml)*

------
https://chatgpt.com/codex/tasks/task_e_68acc9bdcd80832a8de05b4155b99d37