### PR TITLE
feat: add orbital weapons

### DIFF
--- a/app/weapons/__init__.py
+++ b/app/weapons/__init__.py
@@ -8,6 +8,7 @@ weapon_registry: Registry[Weapon] = Registry()
 
 # Import weapon modules to register them
 from . import katana as _katana  # noqa: F401,E402
+from . import orbital as _orbital  # noqa: F401,E402
 from . import shuriken as _shuriken  # noqa: F401,E402
 
 __all__ = ["Weapon", "weapon_registry"]

--- a/app/weapons/orbital.py
+++ b/app/weapons/orbital.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from app.core.types import Damage, EntityId, Vec2
+
+from . import weapon_registry
+from .base import Weapon, WorldView
+
+
+@dataclass(slots=True)
+class _Satellite:
+    """Rectangular element orbiting around the weapon owner."""
+
+    width: float
+    height: float
+    radius: float
+    angle: float
+
+
+class OrbitalWeapon(Weapon):
+    """Weapon managing satellites rotating around its owner."""
+
+    satellites: list[_Satellite]
+
+    def __init__(
+        self, name: str, damage: Damage, speed: float, satellites: list[_Satellite]
+    ) -> None:
+        super().__init__(name=name, cooldown=0.0, damage=damage, speed=speed)
+        self.satellites = satellites
+
+    def _fire(self, owner: EntityId, view: WorldView, direction: Vec2) -> None:
+        return None
+
+    def update(self, owner: EntityId, view: WorldView, dt: float) -> None:
+        enemy = view.get_enemy(owner)
+        if enemy is None:
+            return
+        enemy_pos = view.get_position(enemy)
+        owner_pos = view.get_position(owner)
+        for sat in self.satellites:
+            sat.angle = (sat.angle + self.speed * dt) % math.tau
+            cx = owner_pos[0] + math.cos(sat.angle) * sat.radius
+            cy = owner_pos[1] + math.sin(sat.angle) * sat.radius
+            if abs(enemy_pos[0] - cx) <= sat.width / 2 and abs(enemy_pos[1] - cy) <= sat.height / 2:
+                view.deal_damage(enemy, self.damage)
+
+
+class KatanaOrbital(OrbitalWeapon):
+    """Single thin blade orbiting around the owner."""
+
+    def __init__(self) -> None:
+        satellites = [_Satellite(width=80.0, height=12.0, radius=60.0, angle=0.0)]
+        super().__init__(name="katana_orbital", damage=Damage(18), speed=4.0, satellites=satellites)
+
+
+class ShurikenOrbital(OrbitalWeapon):
+    """Three small squares orbiting around the owner."""
+
+    def __init__(self) -> None:
+        satellites = [
+            _Satellite(width=16.0, height=16.0, radius=50.0, angle=0.0),
+            _Satellite(width=16.0, height=16.0, radius=50.0, angle=math.tau / 3),
+            _Satellite(width=16.0, height=16.0, radius=50.0, angle=2 * math.tau / 3),
+        ]
+        super().__init__(
+            name="shuriken_orbital", damage=Damage(10), speed=4.0, satellites=satellites
+        )
+
+
+weapon_registry.register("katana_orbital", KatanaOrbital)
+weapon_registry.register("shuriken_orbital", ShurikenOrbital)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package."""

--- a/tests/test_weapons.py
+++ b/tests/test_weapons.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from app.core.types import Damage, EntityId, Vec2
+from app.weapons.base import WorldView
+from app.weapons.orbital import KatanaOrbital, ShurikenOrbital
+
+
+@dataclass
+class DummyView(WorldView):
+    enemy: EntityId
+    owner_pos: Vec2
+    enemy_pos: Vec2
+    damage_values: list[float] = field(default_factory=list)
+
+    def get_enemy(self, owner: EntityId) -> EntityId | None:
+        return self.enemy
+
+    def get_position(self, eid: EntityId) -> Vec2:
+        return self.enemy_pos if eid == self.enemy else self.owner_pos
+
+    def get_health_ratio(self, eid: EntityId) -> float:
+        return 1.0
+
+    def deal_damage(self, eid: EntityId, damage: Damage) -> None:
+        self.damage_values.append(damage.amount)
+
+    def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:
+        return None
+
+    def spawn_projectile(self, *args: object, **kwargs: object) -> None:
+        return None
+
+
+def test_katana_orbital_hits_enemy() -> None:
+    weapon = KatanaOrbital()
+    owner = EntityId(1)
+    enemy = EntityId(2)
+    view = DummyView(enemy=enemy, owner_pos=(0.0, 0.0), enemy_pos=(60.0, 0.0))
+    weapon.update(owner, view, 0.0)
+    assert view.damage_values == [weapon.damage.amount]
+
+
+def test_shuriken_orbital_hits_enemy() -> None:
+    weapon = ShurikenOrbital()
+    owner = EntityId(1)
+    enemy = EntityId(2)
+    view = DummyView(enemy=enemy, owner_pos=(0.0, 0.0), enemy_pos=(50.0, 0.0))
+    weapon.update(owner, view, 0.0)
+    assert view.damage_values == [weapon.damage.amount]


### PR DESCRIPTION
## Summary
- implement `OrbitalWeapon` with rotating satellites
- add `KatanaOrbital` and `ShurikenOrbital`
- register orbital weapons and provide unit tests

## Testing
- `uv run ruff check .`
- `uv run mypy app/weapons/orbital.py app/weapons/__init__.py tests/test_weapons.py tests/__init__.py`
- `uv run pytest tests/test_weapons.py`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68acce22f838832a93943384bce3151c