### PR TITLE
feat: centralize weapon effects pipeline

### DIFF
--- a/app/weapons/__init__.py
+++ b/app/weapons/__init__.py
@@ -1,4 +1,17 @@
-"""Weapon plugins."""
+"""Weapon plugins and registry.
+
+Third-party packages can extend the game by registering new weapons::
+
+    from app.weapons import weapon_registry, Weapon
+
+    class MyWeapon(Weapon):
+        ...
+
+    weapon_registry.register("my_weapon", MyWeapon)
+
+All modules importing this package will automatically discover registered
+weapons.
+"""
 
 from app.core.registry import Registry
 

--- a/app/weapons/base.py
+++ b/app/weapons/base.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Protocol
 
 from app.core.types import Damage, EntityId, Vec2
+from app.render.renderer import Renderer
 
 
 class WorldView(Protocol):
@@ -24,6 +25,9 @@ class WorldView(Protocol):
     def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:
         """Apply an impulse to the entity's body."""
 
+    def spawn_effect(self, effect: WeaponEffect) -> None:
+        """Register a new weapon effect to be processed by the match."""
+
     def spawn_projectile(
         self,
         owner: EntityId,
@@ -33,8 +37,29 @@ class WorldView(Protocol):
         damage: Damage,
         knockback: float,
         ttl: float,
-    ) -> None:
-        """Spawn a projectile owned by *owner*."""
+    ) -> WeaponEffect:
+        """Spawn a projectile owned by *owner* and register it."""
+
+
+class WeaponEffect(Protocol):
+    """Dynamic entity created by a weapon."""
+
+    owner: EntityId
+
+    def step(self, dt: float) -> bool:
+        """Advance state and return ``True`` while the effect is active."""
+
+    def collides(self, view: WorldView, position: Vec2, radius: float) -> bool:
+        """Return ``True`` if the effect intersects a circle at *position*."""
+
+    def on_hit(self, view: WorldView, target: EntityId) -> bool:
+        """Handle a collision with *target* and return ``True`` to keep the effect."""
+
+    def draw(self, renderer: Renderer, view: WorldView) -> None:
+        """Render the effect on *renderer*."""
+
+    def destroy(self) -> None:
+        """Clean up resources when the effect is removed."""
 
 
 @dataclass(slots=True)

--- a/app/weapons/orbital.py
+++ b/app/weapons/orbital.py
@@ -3,15 +3,18 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 
+import pygame
+
 from app.core.types import Damage, EntityId, Vec2
+from app.render.renderer import Renderer
 
 from . import weapon_registry
-from .base import Weapon, WorldView
+from .base import Weapon, WeaponEffect, WorldView
 
 
 @dataclass(slots=True)
-class _Satellite:
-    """Rectangular element orbiting around the weapon owner."""
+class _SatelliteSpec:
+    """Static parameters describing a satellite."""
 
     width: float
     height: float
@@ -19,39 +22,82 @@ class _Satellite:
     angle: float
 
 
+@dataclass(slots=True)
+class SatelliteEffect(WeaponEffect):
+    """Rectangular element orbiting around the weapon owner."""
+
+    owner: EntityId
+    damage: Damage
+    width: float
+    height: float
+    radius: float
+    angle: float
+    speed: float
+
+    def step(self, dt: float) -> bool:
+        self.angle = (self.angle + self.speed * dt) % math.tau
+        return True
+
+    def collides(self, view: WorldView, position: Vec2, radius: float) -> bool:
+        owner_pos = view.get_position(self.owner)
+        cx = owner_pos[0] + math.cos(self.angle) * self.radius
+        cy = owner_pos[1] + math.sin(self.angle) * self.radius
+        return abs(position[0] - cx) <= self.width / 2 and abs(position[1] - cy) <= self.height / 2
+
+    def on_hit(self, view: WorldView, target: EntityId) -> bool:
+        view.deal_damage(target, self.damage)
+        return True
+
+    def draw(self, renderer: Renderer, view: WorldView) -> None:
+        owner_pos = view.get_position(self.owner)
+        cx = owner_pos[0] + math.cos(self.angle) * self.radius
+        cy = owner_pos[1] + math.sin(self.angle) * self.radius
+        rect = pygame.Rect(0, 0, int(self.width), int(self.height))
+        rect.center = (int(cx), int(cy))
+        pygame.draw.rect(renderer.surface, (255, 255, 255), rect)
+
+    def destroy(self) -> None:
+        return None
+
+
 class OrbitalWeapon(Weapon):
     """Weapon managing satellites rotating around its owner."""
 
-    satellites: list[_Satellite]
+    _specs: list[_SatelliteSpec]
+    _initialized: bool
 
     def __init__(
-        self, name: str, damage: Damage, speed: float, satellites: list[_Satellite]
+        self, name: str, damage: Damage, speed: float, satellites: list[_SatelliteSpec]
     ) -> None:
         super().__init__(name=name, cooldown=0.0, damage=damage, speed=speed)
-        self.satellites = satellites
+        self._specs = satellites
+        self._initialized = False
 
     def _fire(self, owner: EntityId, view: WorldView, direction: Vec2) -> None:
         return None
 
     def update(self, owner: EntityId, view: WorldView, dt: float) -> None:
-        enemy = view.get_enemy(owner)
-        if enemy is None:
-            return
-        enemy_pos = view.get_position(enemy)
-        owner_pos = view.get_position(owner)
-        for sat in self.satellites:
-            sat.angle = (sat.angle + self.speed * dt) % math.tau
-            cx = owner_pos[0] + math.cos(sat.angle) * sat.radius
-            cy = owner_pos[1] + math.sin(sat.angle) * sat.radius
-            if abs(enemy_pos[0] - cx) <= sat.width / 2 and abs(enemy_pos[1] - cy) <= sat.height / 2:
-                view.deal_damage(enemy, self.damage)
+        if not self._initialized:
+            for spec in self._specs:
+                view.spawn_effect(
+                    SatelliteEffect(
+                        owner=owner,
+                        damage=self.damage,
+                        width=spec.width,
+                        height=spec.height,
+                        radius=spec.radius,
+                        angle=spec.angle,
+                        speed=self.speed,
+                    )
+                )
+            self._initialized = True
 
 
 class KatanaOrbital(OrbitalWeapon):
     """Single thin blade orbiting around the owner."""
 
     def __init__(self) -> None:
-        satellites = [_Satellite(width=80.0, height=12.0, radius=60.0, angle=0.0)]
+        satellites = [_SatelliteSpec(width=80.0, height=12.0, radius=60.0, angle=0.0)]
         super().__init__(name="katana_orbital", damage=Damage(18), speed=4.0, satellites=satellites)
 
 
@@ -60,9 +106,9 @@ class ShurikenOrbital(OrbitalWeapon):
 
     def __init__(self) -> None:
         satellites = [
-            _Satellite(width=16.0, height=16.0, radius=50.0, angle=0.0),
-            _Satellite(width=16.0, height=16.0, radius=50.0, angle=math.tau / 3),
-            _Satellite(width=16.0, height=16.0, radius=50.0, angle=2 * math.tau / 3),
+            _SatelliteSpec(width=16.0, height=16.0, radius=50.0, angle=0.0),
+            _SatelliteSpec(width=16.0, height=16.0, radius=50.0, angle=math.tau / 3),
+            _SatelliteSpec(width=16.0, height=16.0, radius=50.0, angle=2 * math.tau / 3),
         ]
         super().__init__(
             name="shuriken_orbital", damage=Damage(10), speed=4.0, satellites=satellites

--- a/app/world/projectiles.py
+++ b/app/world/projectiles.py
@@ -1,17 +1,22 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from math import sqrt
+from typing import cast
 
 import pymunk
 
 from app.core.types import Damage, EntityId, Vec2
+from app.render.renderer import Renderer
+from app.weapons.base import WeaponEffect, WorldView
 from app.world.physics import PhysicsWorld
 
 
 @dataclass(slots=True)
-class Projectile:
+class Projectile(WeaponEffect):
     """Dynamic projectile with a limited lifetime."""
 
+    world: PhysicsWorld
     owner: EntityId
     body: pymunk.Body
     shape: pymunk.Circle
@@ -40,9 +45,41 @@ class Projectile:
         shape.elasticity = 1.0
         shape.friction = 0.0
         world.space.add(body, shape)
-        return cls(owner=owner, body=body, shape=shape, damage=damage, knockback=knockback, ttl=ttl)
+        return cls(
+            world=world,
+            owner=owner,
+            body=body,
+            shape=shape,
+            damage=damage,
+            knockback=knockback,
+            ttl=ttl,
+        )
 
     def step(self, dt: float) -> bool:
-        """Advance state and return True if still alive."""
+        """Advance state and return ``True`` while the projectile is alive."""
         self.ttl -= dt
         return self.ttl > 0
+
+    def collides(self, view: WorldView, position: Vec2, radius: float) -> bool:
+        pos = self.body.position
+        dx = float(pos.x) - position[0]
+        dy = float(pos.y) - position[1]
+        rad = cast(float, self.shape.radius) + radius
+        return dx * dx + dy * dy <= rad * rad
+
+    def on_hit(self, view: WorldView, target: EntityId) -> bool:
+        view.deal_damage(target, self.damage)
+        target_pos = view.get_position(target)
+        pos = self.body.position
+        dx = pos.x - target_pos[0]
+        dy = pos.y - target_pos[1]
+        norm = sqrt(dx * dx + dy * dy) or 1.0
+        view.apply_impulse(target, dx / norm * self.knockback, dy / norm * self.knockback)
+        return False
+
+    def draw(self, renderer: Renderer, view: WorldView) -> None:
+        pos = (float(self.body.position.x), float(self.body.position.y))
+        renderer.draw_projectile(pos, int(self.shape.radius), (255, 255, 0))
+
+    def destroy(self) -> None:
+        self.world.space.remove(self.body, self.shape)

--- a/tests/unit/test_policy_angles.py
+++ b/tests/unit/test_policy_angles.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 
 from app.ai.policy import SimplePolicy
 from app.core.types import Damage, EntityId, Vec2
-from app.weapons.base import WorldView
+from app.weapons.base import WeaponEffect, WorldView
 from app.weapons.shuriken import Shuriken
 
 
@@ -31,6 +31,9 @@ class DummyView(WorldView):
     def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:  # noqa: D401
         return
 
+    def spawn_effect(self, effect: WeaponEffect) -> None:  # noqa: D401
+        return
+
     def spawn_projectile(
         self,
         owner: EntityId,
@@ -40,8 +43,28 @@ class DummyView(WorldView):
         damage: Damage,
         knockback: float,
         ttl: float,
-    ) -> None:  # noqa: D401
+    ) -> WeaponEffect:  # noqa: D401
         self.last_velocity = velocity
+
+        class _Dummy(WeaponEffect):
+            owner: EntityId = owner
+
+            def step(self, dt: float) -> bool:
+                return False
+
+            def collides(self, view: WorldView, position: Vec2, radius: float) -> bool:
+                return False
+
+            def on_hit(self, view: WorldView, target: EntityId) -> bool:
+                return False
+
+            def draw(self, renderer: object, view: WorldView) -> None:
+                return None
+
+            def destroy(self) -> None:
+                return None
+
+        return _Dummy()
 
 
 def test_policy_angle_has_vertical_component() -> None:

--- a/tests/unit/test_weapons.py
+++ b/tests/unit/test_weapons.py
@@ -11,7 +11,7 @@ from app.game.match import MatchTimeout, run_match
 from app.render.renderer import Renderer
 from app.video.recorder import NullRecorder, Recorder
 from app.weapons import weapon_registry
-from app.weapons.base import Weapon, WorldView
+from app.weapons.base import Weapon, WeaponEffect, WorldView
 from app.weapons.katana import Katana
 from app.weapons.shuriken import Shuriken
 
@@ -37,8 +37,29 @@ class DummyView(WorldView):
     def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:  # noqa: D401
         return
 
-    def spawn_projectile(self, *args: object, **kwargs: object) -> None:  # noqa: D401
+    def spawn_effect(self, effect: WeaponEffect) -> None:  # noqa: D401
         return
+
+    def spawn_projectile(self, *args: object, **kwargs: object) -> WeaponEffect:  # noqa: D401
+        class _Dummy(WeaponEffect):
+            owner: EntityId = EntityId(0)
+
+            def step(self, dt: float) -> bool:
+                return False
+
+            def collides(self, view: WorldView, position: Vec2, radius: float) -> bool:
+                return False
+
+            def on_hit(self, view: WorldView, target: EntityId) -> bool:
+                return False
+
+            def draw(self, renderer: object, view: WorldView) -> None:
+                return None
+
+            def destroy(self) -> None:
+                return None
+
+        return _Dummy()
 
 
 def test_katana_cooldown_and_damage() -> None:


### PR DESCRIPTION
## Summary
- add `WeaponEffect` protocol for reusable weapon entities
- manage effect updates and collisions centrally in match loop
- document weapon registry for plugin extensions

## Testing
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest` *(fails: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68acd20f29a8832a91b7035e3a263739