### PR TITLE
refactor(cli): compute display dimensions lazily

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Image de prévisualisation à venir.
 - 🧠 **IA configurable** : agressive, kite, support… ou comportements personnalisés.
 - 🎨 **Rendu vertical 1080×1920** optimisé pour TikTok.
 - 🎥 **Export vidéo automatique** en `.mp4` via [imageio-ffmpeg](https://imageio.readthedocs.io/).
-- 🖥️ **Mode affichage** sans enregistrement grâce à l'option `--display`.
+- 🖥️ **Mode affichage** sans enregistrement (`--display`), fenêtre à moitié de la taille originale pour tenir sur l'écran.
 - 🔄 **Reproductibilité totale** grâce aux seeds (mêmes combats → mêmes résultats).
 - 🧩 **Architecture plug-in** : ajout d'armes, IA ou effets visuels sans toucher au moteur.
 - 🔊 **Effets sonores & particules** (prévu pour la v2).

--- a/app/cli.py
+++ b/app/cli.py
@@ -28,11 +28,10 @@ def run(
     """Run a single match and optionally export a video."""
     random.seed(seed)
 
-    display_width = settings.width // 2
-    display_height = settings.height // 2
-
     recorder: Recorder | NullRecorder
     if display:
+        display_width = settings.width // 2
+        display_height = settings.height // 2
         renderer = Renderer(display_width, display_height, display=True)
         recorder = NullRecorder()
     else:

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -73,7 +73,7 @@ def test_run_timeout(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
 
 
 def test_run_display_mode_no_file(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
-    captured: dict[str, int | bool] = {}
+    renderer_args: dict[str, int | bool] = {}
 
     original_init = Renderer.__init__
 
@@ -83,9 +83,9 @@ def test_run_display_mode_no_file(tmp_path: Path, monkeypatch: MonkeyPatch) -> N
         height: int = settings.height,
         display: bool = False,
     ) -> None:
-        captured["width"] = width
-        captured["height"] = height
-        captured["display"] = display
+        renderer_args["width"] = width
+        renderer_args["height"] = height
+        renderer_args["display"] = display
         original_init(self, width, height, display=display)
 
     monkeypatch.setattr(Renderer, "__init__", spy_init)
@@ -109,9 +109,11 @@ def test_run_display_mode_no_file(tmp_path: Path, monkeypatch: MonkeyPatch) -> N
     )
 
     assert result.exit_code == 0
-    assert captured["width"] == settings.width // 2
-    assert captured["height"] == settings.height // 2
-    assert captured["display"] is True
+    half_width = settings.width // 2
+    half_height = settings.height // 2
+    assert renderer_args["width"] == half_width
+    assert renderer_args["height"] == half_height
+    assert renderer_args["display"] is True
     # En mode display, aucun fichier ne doit être créé
     assert not out.exists()
     assert not out.with_suffix(".gif").exists()


### PR DESCRIPTION
## Summary
- compute half-size display dimensions only when display mode is active
- clarify display mode size in README
- refine display-mode CLI test

## Testing
- `uv run ruff check app/cli.py tests/test_cli_run.py`
- `uv run mypy app/cli.py tests/test_cli_run.py`
- `PYTHONPATH=.venv/lib/python3.13/site-packages python -m pytest tests/test_cli_run.py::test_run_display_mode_no_file -q`
- `uv run --with bandit bandit -q -r app/cli.py tests/test_cli_run.py` *(fails: Failed to fetch: `https://pypi.org/simple/bandit/`)*
- `uv run --with pip-audit pip-audit` *(fails: Failed to fetch: `https://pypi.org/simple/pip-audit/`)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9b8eb210832a9f2f594a0140f79b