### PR TITLE
fix: initialize hidden display for sprite loading

### DIFF
--- a/app/render/renderer.py
+++ b/app/render/renderer.py
@@ -52,13 +52,18 @@ class Renderer:
         """
         if not display:
             os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
         pygame.init()
         pygame.font.init()
+
         self.width = width
         self.height = height
-        self._window: pygame.Surface | None = (
-            pygame.display.set_mode((width, height)) if display else None
-        )
+
+        # ``convert_alpha`` requires an initialized display surface. Even in headless mode
+        # a tiny hidden window is created so sprites can be loaded safely.
+        pygame.display.set_mode((width, height) if display else (1, 1))
+        self._window: pygame.Surface | None = pygame.display.get_surface() if display else None
+
         self.surface = pygame.Surface((width, height), flags=pygame.SRCALPHA)
         self._balls: dict[Color, _BallState] = {}
         self.frame_index = 0

--- a/app/render/sprites.py
+++ b/app/render/sprites.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from functools import cache
 from pathlib import Path
 
@@ -19,6 +20,12 @@ def load_sprite(name: str, scale: float = 1.0) -> pygame.Surface:
     scale:
         Optional scaling factor applied to the loaded image.
     """
+    if not pygame.get_init():
+        os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+        pygame.init()
+    if pygame.display.get_surface() is None:
+        pygame.display.set_mode((1, 1))
+
     image = pygame.image.load((ASSET_DIR / name).as_posix()).convert_alpha()
     if scale != 1.0:
         size = (int(image.get_width() * scale), int(image.get_height() * scale))


### PR DESCRIPTION
## Summary
- ensure a minimal hidden display surface is created so sprites load correctly in headless runs
- auto-initialize pygame and dummy video driver in `load_sprite`

## Testing
- `ruff check app/render/renderer.py`
- `mypy app/render/renderer.py`
- `ruff check app/render/sprites.py`
- `mypy app/render/sprites.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68ad9b8c3c84832a9781b3604e72d98d