### PR TITLE
feat: add resizable display scaling

### DIFF
--- a/app/display.py
+++ b/app/display.py
@@ -1,0 +1,119 @@
+"""Utilities for rendering to a resizable window.
+
+This module provides a ``Display`` class that scales a fixed-size surface to
+fill the available window while preserving the 9:16 aspect ratio. Black bars are
+added as necessary (letterboxing or pillarboxing) to avoid any deformation.
+
+The internal rendering resolution remains constant, typically ``1080×1920`` for
+TikTok-style vertical videos. The window can be resized freely or toggled to
+fullscreen, and the content will scale accordingly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+try:  # pragma: no cover - optional at import time
+    import pygame
+except ModuleNotFoundError:  # pragma: no cover - allows tests without pygame
+    pygame = None
+
+if TYPE_CHECKING:  # pragma: no cover - only for type checking
+    import pygame as _pygame
+
+Size = tuple[int, int]
+
+
+def calculate_scale(window_size: Size, target_size: Size) -> float:
+    """Return the maximal uniform scale factor for *target_size* within *window_size*.
+
+    Parameters
+    ----------
+    window_size:
+        Current width and height of the window.
+    target_size:
+        Fixed base resolution to fit inside the window.
+
+    Returns
+    -------
+    float
+        Scale factor that preserves aspect ratio.
+
+    Raises
+    ------
+    ValueError
+        If any dimension is non-positive.
+    """
+    win_w, win_h = window_size
+    tgt_w, tgt_h = target_size
+    if win_w <= 0 or win_h <= 0 or tgt_w <= 0 or tgt_h <= 0:
+        msg = "window and target dimensions must be positive"
+        raise ValueError(msg)
+    return min(win_w / tgt_w, win_h / tgt_h)
+
+
+@dataclass(slots=True)
+class Display:
+    """Resizable window that preserves a fixed aspect ratio.
+
+    Parameters
+    ----------
+    target_width:
+        Width of the internal rendering surface.
+    target_height:
+        Height of the internal rendering surface.
+    """
+
+    target_width: int
+    target_height: int
+    _is_fullscreen: bool = field(init=False, default=False)
+    _flags: int = field(init=False, default=0)
+    _window: _pygame.Surface = field(init=False)
+
+    def __post_init__(self) -> None:
+        if pygame is None:  # pragma: no cover - defensive
+            msg = "pygame is required for Display"
+            raise RuntimeError(msg)
+        self._flags = pygame.RESIZABLE
+        self._window = pygame.display.set_mode(self.target_size, self._flags)
+
+    @property
+    def target_size(self) -> Size:
+        """Return the fixed internal rendering size."""
+        return (self.target_width, self.target_height)
+
+    def handle_event(self, event: pygame.event.Event) -> None:
+        """Handle resize and fullscreen toggle events."""
+        if pygame is None:  # pragma: no cover
+            return
+        if event.type == pygame.VIDEORESIZE and not self._is_fullscreen:
+            self._window = pygame.display.set_mode(event.size, self._flags)
+        elif event.type == pygame.KEYDOWN and event.key == pygame.K_f:
+            self.toggle_fullscreen()
+
+    def toggle_fullscreen(self) -> None:
+        """Toggle fullscreen mode."""
+        if pygame is None:  # pragma: no cover
+            return
+        if self._is_fullscreen:
+            self._window = pygame.display.set_mode(self._window.get_size(), self._flags)
+        else:
+            self._window = pygame.display.set_mode((0, 0), pygame.FULLSCREEN)
+        self._is_fullscreen = not self._is_fullscreen
+
+    def present(self, surface: pygame.Surface) -> None:
+        """Scale *surface* to the window while preserving aspect ratio."""
+        if pygame is None:  # pragma: no cover
+            return
+        window = pygame.display.get_surface()
+        if window is None:
+            return
+        win_size = window.get_size()
+        scale = calculate_scale(win_size, self.target_size)
+        scaled_size = (int(self.target_width * scale), int(self.target_height * scale))
+        scaled_surface = pygame.transform.smoothscale(surface, scaled_size)
+        window.fill((0, 0, 0))
+        offset = ((win_size[0] - scaled_size[0]) // 2, (win_size[1] - scaled_size[1]) // 2)
+        window.blit(scaled_surface, offset)
+        pygame.display.flip()

--- a/app/render/renderer.py
+++ b/app/render/renderer.py
@@ -10,6 +10,7 @@ import pygame
 
 from app.core.config import settings
 from app.core.types import Color, Vec2
+from app.display import Display
 from app.render.hud import Hud
 
 
@@ -61,8 +62,12 @@ class Renderer:
 
         # ``convert_alpha`` requires an initialized display surface. Even in headless mode
         # a tiny hidden window is created so sprites can be loaded safely.
-        pygame.display.set_mode((width, height) if display else (1, 1))
-        self._window: pygame.Surface | None = pygame.display.get_surface() if display else None
+        self._display: Display | None
+        if display:
+            self._display = Display(width, height)
+        else:
+            pygame.display.set_mode((1, 1))
+            self._display = None
 
         self.surface = pygame.Surface((width, height), flags=pygame.SRCALPHA)
         self._balls: dict[Color, _BallState] = {}
@@ -231,9 +236,8 @@ class Renderer:
 
     def present(self) -> None:
         """Advance to the next frame and update the display if enabled."""
-        if self._window is not None:
-            self._window.blit(self.surface, (0, 0))
-            pygame.display.flip()
+        if self._display is not None:
+            self._display.present(self.surface)
         self.frame_index += 1
 
     def capture_frame(self) -> np.ndarray:

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pytest
+
+from app.display import calculate_scale
+
+
+@pytest.mark.parametrize(
+    ("window", "expected"),
+    [
+        ((1080, 1920), 1.0),
+        ((540, 960), 0.5),
+        ((1920, 1080), 0.5625),
+        ((3840, 2160), 1.125),
+    ],
+)
+def test_calculate_scale(window: tuple[int, int], expected: float) -> None:
+    assert calculate_scale(window, (1080, 1920)) == pytest.approx(expected)
+
+
+def test_calculate_scale_invalid() -> None:
+    with pytest.raises(ValueError):
+        calculate_scale((0, 100), (1080, 1920))


### PR DESCRIPTION
## Summary
- add `Display` utility to scale fixed-resolution rendering to a resizable window with letterboxing support
- integrate `Display` into `Renderer` for real-time scaling
- cover scale calculation with unit tests

## Testing
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest tests/test_display.py`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install pygame numpy pydantic typer pymunk` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ada2b6a7c0832abde7df534ecc26e7