### PR TITLE
refactor: load weapon sprites from dedicated directories

### DIFF
--- a/app/weapons/assets.py
+++ b/app/weapons/assets.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import pygame
+
+from app.render.sprites import load_sprite
+
+
+def load_weapon_sprite(
+    name: str,
+    *,
+    scale: float = 1.0,
+    max_dim: float | None = None,
+) -> pygame.Surface:
+    """Load the sprite for a weapon stored under ``assets/<name>/weapon.png``.
+
+    Parameters
+    ----------
+    name:
+        Identifier of the weapon whose sprite to load.
+    scale:
+        Optional scaling factor applied to the sprite.
+    max_dim:
+        If provided, resize the sprite so that its longest side equals
+        ``max_dim`` while preserving aspect ratio. ``scale`` is ignored when
+        ``max_dim`` is given.
+    """
+    path = f"{name}/weapon.png"
+    return load_sprite(path, scale=scale, max_dim=max_dim)

--- a/app/weapons/katana.py
+++ b/app/weapons/katana.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import pygame
 
 from app.core.types import Damage, EntityId, Vec2
-from app.render.sprites import load_sprite
 from app.world.entities import DEFAULT_BALL_RADIUS
 
 from . import weapon_registry
+from .assets import load_weapon_sprite
 from .base import Weapon, WorldView
 from .effects import OrbitingSprite
 
@@ -18,7 +18,10 @@ class Katana(Weapon):
         super().__init__(name="katana", cooldown=0.0, damage=Damage(18), speed=4.0)
         self._initialized = False
         blade_height = DEFAULT_BALL_RADIUS * 3.0
-        self._sprite = pygame.transform.rotate(load_sprite("katana.png", max_dim=blade_height), -90)
+        self._sprite = pygame.transform.rotate(
+            load_weapon_sprite("katana", max_dim=blade_height),
+            -90,
+        )
 
     def _fire(self, owner: EntityId, view: WorldView, direction: Vec2) -> None:
         return None

--- a/app/weapons/shuriken.py
+++ b/app/weapons/shuriken.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from app.core.types import Damage, EntityId, Vec2
-from app.render.sprites import load_sprite
 from app.world.entities import DEFAULT_BALL_RADIUS
 
 from . import weapon_registry
+from .assets import load_weapon_sprite
 from .base import Weapon, WorldView
 
 
@@ -15,7 +15,7 @@ class Shuriken(Weapon):
         super().__init__(name="shuriken", cooldown=0.4, damage=Damage(10), speed=600.0)
         self._radius = DEFAULT_BALL_RADIUS / 3.0
         sprite_size = self._radius * 2.0
-        self._sprite = load_sprite("shuriken.png", max_dim=sprite_size)
+        self._sprite = load_weapon_sprite("shuriken", max_dim=sprite_size)
 
     def _fire(self, owner: EntityId, view: WorldView, direction: Vec2) -> None:
         velocity = (direction[0] * self.speed, direction[1] * self.speed)


### PR DESCRIPTION
## Summary
- factor weapon sprite loader to assets/<weapon>/weapon.png
- adjust katana and shuriken to use per-weapon sprite paths

## Testing
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68ae241b6600832a8c00435407cc7207