### PR TITLE
feat: apply textured ball skins and colored pupils

### DIFF
--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import numpy as np
+
+from app.core.config import settings
 from app.render.renderer import Renderer
 
 
@@ -18,3 +21,13 @@ def test_set_hp_updates_display() -> None:
     renderer = Renderer(100, 200)
     renderer.set_hp(0.25, 0.75)
     assert renderer._hp_display == [0.25, 0.75]
+
+
+def test_draw_eyes_team_color() -> None:
+    renderer = Renderer(100, 100)
+    renderer.clear()
+    team_color = settings.theme.team_a.primary
+    renderer.draw_eyes((50.0, 50.0), (0.0, 0.0), 10, team_color)
+    renderer.present()
+    frame = renderer.capture_frame()
+    assert (frame == np.array(team_color)).all(axis=-1).any()


### PR DESCRIPTION
## Summary
- render balls using team-specific textured skins
- animate gaze with colored pupils inside white sclera
- add test verifying pupil color matches team

## Testing
- `uv run ruff check app/render/renderer.py tests/test_renderer.py`
- `uv run mypy app/render/renderer.py tests/test_renderer.py`
- `uv run --extra dev pytest` *(failed: Failed to download toml==0.10.2)*


------
https://chatgpt.com/codex/tasks/task_e_68ae259d6b18832a91a0b6a68c04f0e6