### PR TITLE
feat: add modular weapon audio system

### DIFF
--- a/app/audio/__init__.py
+++ b/app/audio/__init__.py
@@ -1,0 +1,6 @@
+"""Audio module providing sound playback for weapons."""
+
+from .engine import AudioEngine
+from .weapons import WeaponAudio
+
+__all__ = ["AudioEngine", "WeaponAudio"]

--- a/app/audio/engine.py
+++ b/app/audio/engine.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+"""Low-level audio engine based on :mod:`pygame.mixer`.
+
+The engine loads sounds, precomputes six pitch variations using linear
+resampling and caches them in memory. Each playback selects a variation at
+random and applies a short fade-in to avoid clicks. A cooldown prevents the
+same sound from being triggered too frequently.
+"""
+
+from pathlib import Path
+import random
+import threading
+import time
+from typing import Dict, List
+
+import numpy as np
+import pygame
+import pygame.sndarray
+
+
+class AudioEngine:
+    """Play sounds with pitch variations and spam protection."""
+
+    SAMPLE_RATE: int = 48_000
+    CHANNELS: int = 2
+    BUFFER: int = 1024
+    DEFAULT_VOLUME: float = 0.8
+    COOLDOWN_MS: int = 80
+    FADE_MS: int = 5
+    PITCH_FACTORS: List[float] = [2 ** (s / 12) for s in (-3, -2, -1, 0, 1, 2)]
+
+    def __init__(self) -> None:
+        pygame.mixer.init(
+            frequency=self.SAMPLE_RATE,
+            channels=self.CHANNELS,
+            buffer=self.BUFFER,
+        )
+        self._cache: Dict[str, List[pygame.mixer.Sound]] = {}
+        self._lengths: Dict[str, float] = {}
+        self._last_play: Dict[str, float] = {}
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def shutdown(self) -> None:
+        """Stop all sounds and quit the mixer."""
+        pygame.mixer.stop()
+        pygame.mixer.quit()
+
+    def stop_all(self) -> None:
+        """Fade out all playing sounds."""
+        pygame.mixer.fadeout(self.FADE_MS)
+
+    def get_length(self, path: str) -> float:
+        """Return the length in seconds of ``path``."""
+        self._ensure_variations(path)
+        return self._lengths[path]
+
+    def play_variation(self, path: str, volume: float | None = None) -> bool:
+        """Play ``path`` with a random pitch variation.
+
+        Parameters
+        ----------
+        path:
+            Path to the sound file.
+        volume:
+            Optional volume between 0 and 1. Defaults to ``DEFAULT_VOLUME``.
+
+        Returns
+        -------
+        bool
+            ``True`` if the sound was played, ``False`` if skipped due to
+            cooldown.
+        """
+        now = time.perf_counter()
+        with self._lock:
+            last = self._last_play.get(path)
+            if last is not None and (now - last) * 1000 < self.COOLDOWN_MS:
+                return False
+            sounds = self._ensure_variations(path)
+            sound = random.choice(sounds)
+            sound.set_volume(volume if volume is not None else self.DEFAULT_VOLUME)
+            sound.play(fade_ms=self.FADE_MS)
+            self._last_play[path] = now
+            return True
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_variations(self, path: str) -> List[pygame.mixer.Sound]:
+        if path not in self._cache:
+            if not Path(path).is_file():
+                msg = f"Sound file not found: {path}"
+                raise FileNotFoundError(msg)
+            original = pygame.mixer.Sound(path)
+            array = pygame.sndarray.array(original)
+            self._lengths[path] = original.get_length()
+            variations: List[pygame.mixer.Sound] = []
+            for factor in self.PITCH_FACTORS:
+                resampled = self._resample(array, factor)
+                sound = pygame.sndarray.make_sound(resampled)
+                variations.append(sound)
+            self._cache[path] = variations
+        return self._cache[path]
+
+    @staticmethod
+    def _resample(array: np.ndarray, factor: float) -> np.ndarray:
+        """Resample ``array`` by ``factor`` using linear interpolation."""
+        original = array.astype(np.float32)
+        if original.ndim == 1:
+            length = original.shape[0]
+            new_length = int(length / factor)
+            indices = np.arange(new_length) * factor
+            resampled = np.interp(indices, np.arange(length), original)
+            resampled = np.clip(resampled, -32768, 32767).astype(np.int16)
+            return resampled
+        length = original.shape[0]
+        new_length = int(length / factor)
+        indices = np.arange(new_length) * factor
+        resampled = np.empty((new_length, original.shape[1]), dtype=np.float32)
+        for channel in range(original.shape[1]):
+            resampled[:, channel] = np.interp(
+                indices, np.arange(length), original[:, channel]
+            )
+        resampled = np.clip(resampled, -32768, 32767).astype(np.int16)
+        return resampled

--- a/app/audio/weapons.py
+++ b/app/audio/weapons.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+"""High level helpers to play weapon related sounds."""
+
+import threading
+import time
+from pathlib import Path
+from typing import Literal, Optional
+
+from .engine import AudioEngine
+
+
+_DEFAULT_ENGINE: AudioEngine | None = None
+
+
+def _get_default_engine() -> AudioEngine:
+    """Return a shared :class:`AudioEngine` instance."""
+    global _DEFAULT_ENGINE
+    if _DEFAULT_ENGINE is None:
+        _DEFAULT_ENGINE = AudioEngine()
+    return _DEFAULT_ENGINE
+
+
+class WeaponAudio:
+    """Manage sounds for a single weapon."""
+
+    def __init__(
+        self,
+        type: Literal["melee", "throw"],
+        name: str,
+        *,
+        base_dir: str = "assets/weapons",
+        engine: Optional[AudioEngine] = None,
+        idle_gap: float = 1.0,
+    ) -> None:
+        self._type = type
+        self._name = name
+        self._engine = engine or _get_default_engine()
+        self._idle_gap = idle_gap
+        self._idle_thread: threading.Thread | None = None
+        self._idle_running = threading.Event()
+
+        base = Path(base_dir) / name
+        self._idle_path: str | None
+        self._touch_path: str | None
+        self._throw_path: str | None
+        if type == "melee":
+            self._idle_path = str(base / "idle.ogg")
+            self._touch_path = str(base / "touch.ogg")
+            self._throw_path = None
+        elif type == "throw":
+            self._idle_path = None
+            self._touch_path = str(base / "touch.ogg")
+            self._throw_path = str(base / "throw.ogg")
+        else:
+            msg = f"Unknown weapon type: {type}"
+            raise ValueError(msg)
+
+    # ------------------------------------------------------------------
+    # Melee idle management
+    # ------------------------------------------------------------------
+    def start_idle(self) -> None:
+        """Start looping the idle sound for melee weapons."""
+        if self._type != "melee" or self._idle_path is None:
+            raise RuntimeError("Idle sound is only available for melee weapons")
+        if self._idle_thread and self._idle_thread.is_alive():
+            return
+        self._idle_running.set()
+        self._idle_thread = threading.Thread(target=self._idle_loop, daemon=True)
+        self._idle_thread.start()
+
+    def _idle_loop(self) -> None:
+        assert self._idle_path is not None
+        while self._idle_running.is_set():
+            self._engine.play_variation(self._idle_path)
+            length = self._engine.get_length(self._idle_path)
+            time.sleep(length + self._idle_gap)
+
+    def stop_idle(self) -> None:
+        """Stop the idle loop for melee weapons."""
+        if self._idle_thread and self._idle_thread.is_alive():
+            self._idle_running.clear()
+            self._idle_thread.join()
+            self._idle_thread = None
+            self._engine.stop_all()
+
+    # ------------------------------------------------------------------
+    # Events
+    # ------------------------------------------------------------------
+    def on_throw(self) -> None:
+        """Play the throw sound for throwable weapons."""
+        if self._throw_path is None:
+            raise RuntimeError("This weapon type cannot throw")
+        self._engine.play_variation(self._throw_path)
+
+    def on_touch(self) -> None:
+        """Play the touch/hit sound for any weapon."""
+        if self._touch_path is None:
+            raise RuntimeError("Touch sound not configured")
+        self._engine.play_variation(self._touch_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "imageio-ffmpeg>=0.5.0",
   "typer>=0.12.0",
   "pydantic-settings>=2.4.0",
+  "numpy>=2.3.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_audio_engine.py
+++ b/tests/test_audio_engine.py
@@ -1,0 +1,20 @@
+import os
+import time
+
+from app.audio.engine import AudioEngine
+
+
+os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+
+
+def test_cache_and_cooldown() -> None:
+    engine = AudioEngine()
+    path = "assets/weapons/katana/touch.ogg"
+    assert engine.play_variation(path) is True
+    first_time = engine._last_play[path]
+    assert len(engine._cache[path]) == 6
+    assert engine.play_variation(path) is False
+    assert engine._last_play[path] == first_time
+    time.sleep(engine.COOLDOWN_MS / 1000 + 0.02)
+    assert engine.play_variation(path) is True
+    engine.shutdown()

--- a/tests/test_audio_weapons.py
+++ b/tests/test_audio_weapons.py
@@ -1,0 +1,40 @@
+import time
+from typing import List, cast
+
+from app.audio.engine import AudioEngine
+from app.audio.weapons import WeaponAudio
+
+
+class StubAudioEngine:
+    def __init__(self) -> None:
+        self.played: List[str] = []
+
+    def play_variation(self, path: str, volume: float | None = None) -> bool:  # noqa: D401
+        self.played.append(path)
+        return True
+
+    def get_length(self, path: str) -> float:  # noqa: D401
+        return 0.0
+
+    def stop_all(self) -> None:  # noqa: D401
+        pass
+
+
+def test_melee_idle_and_touch() -> None:
+    engine = StubAudioEngine()
+    audio = WeaponAudio("melee", "katana", engine=cast(AudioEngine, engine), idle_gap=0.01)
+    audio.start_idle()
+    time.sleep(0.05)
+    audio.on_touch()
+    audio.stop_idle()
+    assert any(path.endswith("idle.ogg") for path in engine.played)
+    assert any(path.endswith("touch.ogg") for path in engine.played)
+
+
+def test_throw_events() -> None:
+    engine = StubAudioEngine()
+    audio = WeaponAudio("throw", "shuriken", engine=cast(AudioEngine, engine))
+    audio.on_throw()
+    audio.on_touch()
+    assert any(path.endswith("throw.ogg") for path in engine.played)
+    assert any(path.endswith("touch.ogg") for path in engine.played)


### PR DESCRIPTION
## Summary
- implement AudioEngine with cached pitch variations and cooldown
- add WeaponAudio helper for melee idle loops, throws, and hits
- expose numpy dependency

## Testing
- `mypy app/audio/engine.py app/audio/weapons.py tests/test_audio_engine.py tests/test_audio_weapons.py`
- `pytest tests/test_audio_engine.py tests/test_audio_weapons.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*
- `pre-commit run --files app/audio/__init__.py app/audio/engine.py app/audio/weapons.py tests/test_audio_engine.py tests/test_audio_weapons.py pyproject.toml` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aec2dd4c00832aa09ca49a87c67e63