### PR TITLE
fix: update weapon asset paths

### DIFF
--- a/app/weapons/assets.py
+++ b/app/weapons/assets.py
@@ -11,7 +11,7 @@ def load_weapon_sprite(
     scale: float = 1.0,
     max_dim: float | None = None,
 ) -> pygame.Surface:
-    """Load the sprite for a weapon stored under ``assets/<name>/weapon.png``.
+    """Load the sprite for a weapon stored under ``assets/weapons/<name>/weapon.png``.
 
     Parameters
     ----------
@@ -24,5 +24,5 @@ def load_weapon_sprite(
         ``max_dim`` while preserving aspect ratio. ``scale`` is ignored when
         ``max_dim`` is given.
     """
-    path = f"{name}/weapon.png"
+    path = f"weapons/{name}/weapon.png"
     return load_sprite(path, scale=scale, max_dim=max_dim)


### PR DESCRIPTION
## Summary
- load weapon sprites from `assets/weapons/<name>/weapon.png`

## Testing
- `uv run ruff check app/weapons/assets.py`
- `uv run mypy app/weapons/assets.py`
- `uv run pytest tests/test_weapons.py -q` *(fails: ModuleNotFoundError: No module named 'pygame')*


------
https://chatgpt.com/codex/tasks/task_e_68aec37b9504832abf6b78ff2db30146