### PR TITLE
feat: record audio into exported videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Image de prévisualisation à venir.
 - 🖥️ **Mode affichage** sans enregistrement grâce à l'option `--display`.
 - 🔄 **Reproductibilité totale** grâce aux seeds (mêmes combats → mêmes résultats).
 - 🧩 **Architecture plug-in** : ajout d'armes, IA ou effets visuels sans toucher au moteur.
-- 🔊 **Effets sonores & particules** (prévu pour la v2).
+- 🔊 **Effets sonores** intégrés dans la piste audio.
 - 📦 **Batch mode** : génération de **N vidéos** en une seule commande.
 - 🚀 Prêt pour la scalabilité : 1v1, 2v2, FFA, replay slow-mo, highlights TikTok.
 

--- a/app/audio/__init__.py
+++ b/app/audio/__init__.py
@@ -1,6 +1,6 @@
 """Audio module providing sound playback for weapons."""
 
 from .engine import AudioEngine
-from .weapons import WeaponAudio
+from .weapons import WeaponAudio, get_default_engine
 
-__all__ = ["AudioEngine", "WeaponAudio"]
+__all__ = ["AudioEngine", "WeaponAudio", "get_default_engine"]

--- a/app/audio/weapons.py
+++ b/app/audio/weapons.py
@@ -1,19 +1,18 @@
-from __future__ import annotations
-
 """High level helpers to play weapon related sounds."""
+
+from __future__ import annotations
 
 import threading
 import time
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Literal
 
 from .engine import AudioEngine
-
 
 _DEFAULT_ENGINE: AudioEngine | None = None
 
 
-def _get_default_engine() -> AudioEngine:
+def get_default_engine() -> AudioEngine:
     """Return a shared :class:`AudioEngine` instance."""
     global _DEFAULT_ENGINE
     if _DEFAULT_ENGINE is None:
@@ -30,12 +29,12 @@ class WeaponAudio:
         name: str,
         *,
         base_dir: str = "assets/weapons",
-        engine: Optional[AudioEngine] = None,
+        engine: AudioEngine | None = None,
         idle_gap: float = 1.0,
     ) -> None:
         self._type = type
         self._name = name
-        self._engine = engine or _get_default_engine()
+        self._engine = engine or get_default_engine()
         self._idle_gap = idle_gap
         self._idle_thread: threading.Thread | None = None
         self._idle_running = threading.Event()

--- a/app/game/match.py
+++ b/app/game/match.py
@@ -8,6 +8,7 @@ import numpy as np
 import pygame
 
 from app.ai.policy import SimplePolicy
+from app.audio import get_default_engine
 from app.core.config import settings
 from app.core.types import Color, Damage, EntityId, ProjectileInfo, Vec2
 from app.render.hud import Hud
@@ -151,6 +152,8 @@ def run_match(  # noqa: C901
     MatchTimeout
         If the match exceeds ``max_seconds`` without a winner.
     """
+    engine = get_default_engine()
+    engine.start_capture()
     world = PhysicsWorld()
     renderer = renderer or Renderer(settings.width, settings.height)
     hud = Hud(settings.theme)
@@ -329,4 +332,5 @@ def run_match(  # noqa: C901
 
         return winner
     finally:
-        recorder.close()
+        audio = engine.end_capture()
+        recorder.close(audio)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
+
+# Ensure pygame uses a dummy audio driver during tests so that sound
+# initialization works in headless environments.
+os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:

--- a/tests/integration/test_headless_match.py
+++ b/tests/integration/test_headless_match.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
+import imageio_ffmpeg
 import pytest
 
 from app.core.config import settings
@@ -19,3 +21,6 @@ def test_headless_match_records_video() -> None:
     with pytest.raises(MatchTimeout):
         run_match("katana", "shuriken", recorder, renderer, max_seconds=2)
     assert out.exists() and out.stat().st_size > 0
+    ffmpeg = imageio_ffmpeg.get_ffmpeg_exe()
+    info = subprocess.run([ffmpeg, "-i", str(out)], capture_output=True, text=True)
+    assert "Audio:" in info.stderr

--- a/tests/test_audio_engine.py
+++ b/tests/test_audio_engine.py
@@ -3,7 +3,6 @@ import time
 
 from app.audio.engine import AudioEngine
 
-
 os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
 
 
@@ -17,4 +16,15 @@ def test_cache_and_cooldown() -> None:
     assert engine._last_play[path] == first_time
     time.sleep(engine.COOLDOWN_MS / 1000 + 0.02)
     assert engine.play_variation(path) is True
+    engine.shutdown()
+
+
+def test_capture_mixdown() -> None:
+    engine = AudioEngine()
+    engine.start_capture()
+    path = "assets/weapons/katana/touch.ogg"
+    engine.play_variation(path)
+    audio = engine.end_capture()
+    assert audio.ndim == 2
+    assert audio.shape[0] > 0
     engine.shutdown()

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
+import imageio_ffmpeg
 from pytest import MonkeyPatch
 from typer.testing import CliRunner
 
@@ -31,6 +33,9 @@ def test_run_creates_video(tmp_path: Path) -> None:
     assert result.exit_code == 0
     video_path = out if out.exists() else out.with_suffix(".gif")
     assert video_path.exists()
+    ffmpeg = imageio_ffmpeg.get_ffmpeg_exe()
+    info = subprocess.run([ffmpeg, "-i", str(video_path)], capture_output=True, text=True)
+    assert "Audio:" in info.stderr
 
 
 def test_run_timeout(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- capture and mix audio events for matches
- mux audio track into recorded videos
- cover audio recording with tests and documentation

## Testing
- `ruff check app/audio/engine.py app/audio/weapons.py app/game/match.py app/video/recorder.py tests/conftest.py tests/integration/test_headless_match.py tests/test_audio_engine.py tests/test_cli_run.py`
- `mypy app/audio/engine.py app/audio/weapons.py app/game/match.py app/video/recorder.py tests/test_audio_engine.py tests/test_cli_run.py tests/integration/test_headless_match.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'imageio_ffmpeg')*


------
https://chatgpt.com/codex/tasks/task_e_68aececd59b4832ab2a55362ba63e050