### PR TITLE
fix: disable video padding in recorder

### DIFF
--- a/app/video/recorder.py
+++ b/app/video/recorder.py
@@ -20,7 +20,12 @@ class Recorder:
         self._format = "mp4"
         self._video_path = self.path.with_suffix(".video.mp4")
         try:
-            self.writer = imageio.get_writer(self._video_path, fps=fps, codec="libx264")
+            self.writer = imageio.get_writer(
+                self._video_path,
+                fps=fps,
+                codec="libx264",
+                macro_block_size=1,
+            )
         except Exception:
             self._format = "gif"
             self._video_path = self.path.with_suffix(".gif")

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import imageio
+import numpy as np
+from pytest import CaptureFixture
+
+from app.video.recorder import Recorder
+
+
+def test_recorder_preserves_dimensions(tmp_path: Path, capfd: CaptureFixture[str]) -> None:
+    width, height = 100, 58
+    recorder = Recorder(width, height, 30, tmp_path / "out.mp4")
+    frame = np.zeros((height, width, 3), dtype=np.uint8)
+    recorder.add_frame(frame)
+    recorder.close()
+    err = capfd.readouterr().err
+    assert "WARNING" not in err
+    with imageio.get_reader(tmp_path / "out.mp4") as reader:
+        out_frame = reader.get_data(0)
+    assert out_frame.shape == (height, width, 3)


### PR DESCRIPTION
## Summary
- ensure video recorder disables macro block padding
- add test verifying recorded video dimensions remain unchanged

## Testing
- `uv run ruff check app/video/recorder.py tests/test_recorder.py`
- `uv run ruff format app/video/recorder.py tests/test_recorder.py`
- `uv run mypy app/video/recorder.py tests/test_recorder.py`
- `uv run pytest tests/test_recorder.py` *(fails: No module named 'imageio')*
- `uv run --with pre-commit pre-commit run --files app/video/recorder.py tests/test_recorder.py` *(fails: Failed to fetch pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68aff0739158832a852670ad04e91f02