### PR TITLE
feat: add weapon audio hooks

### DIFF
--- a/app/weapons/effects.py
+++ b/app/weapons/effects.py
@@ -6,6 +6,7 @@ from math import tau
 import numpy as np
 import pygame
 
+from app.audio.weapons import WeaponAudio
 from app.core.types import Color, Damage, EntityId, Vec2
 from app.render.renderer import Renderer
 
@@ -25,6 +26,7 @@ class OrbitingSprite(WeaponEffect):
     trail_color: Color = (255, 255, 255)
     trail: list[Vec2] = field(default_factory=list)
     trail_len: int = 8
+    audio: WeaponAudio | None = None
 
     def step(self, dt: float) -> bool:  # noqa: D401
         self.angle = float(np.float32(self.angle + self.speed * dt) % np.float32(tau))
@@ -44,6 +46,8 @@ class OrbitingSprite(WeaponEffect):
 
     def on_hit(self, view: WorldView, target: EntityId) -> bool:  # noqa: D401
         view.deal_damage(target, self.damage)
+        if self.audio is not None:
+            self.audio.on_touch()
         return True
 
     def draw(self, renderer: Renderer, view: WorldView) -> None:  # noqa: D401

--- a/app/weapons/katana.py
+++ b/app/weapons/katana.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pygame
 
+from app.audio.weapons import WeaponAudio
 from app.core.types import Damage, EntityId, Vec2
 from app.world.entities import DEFAULT_BALL_RADIUS
 
@@ -16,6 +17,7 @@ class Katana(Weapon):
 
     def __init__(self) -> None:
         super().__init__(name="katana", cooldown=0.0, damage=Damage(18), speed=4.0)
+        self.audio = WeaponAudio("melee", "katana")
         self._initialized = False
         blade_height = DEFAULT_BALL_RADIUS * 3.0
         self._sprite = pygame.transform.rotate(
@@ -35,8 +37,10 @@ class Katana(Weapon):
                 radius=60.0,
                 angle=0.0,
                 speed=self.speed,
+                audio=self.audio,
             )
             view.spawn_effect(effect)
+            self.audio.start_idle()
             self._initialized = True
         super().update(owner, view, dt)
 

--- a/app/weapons/shuriken.py
+++ b/app/weapons/shuriken.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from app.audio.weapons import WeaponAudio
 from app.core.types import Damage, EntityId, Vec2
 from app.world.entities import DEFAULT_BALL_RADIUS
+from app.world.projectiles import Projectile
 
 from . import weapon_registry
 from .assets import load_weapon_sprite
@@ -13,14 +15,16 @@ class Shuriken(Weapon):
 
     def __init__(self) -> None:
         super().__init__(name="shuriken", cooldown=0.4, damage=Damage(10), speed=600.0)
+        self.audio = WeaponAudio("throw", "shuriken")
         self._radius = DEFAULT_BALL_RADIUS / 3.0
         sprite_size = self._radius * 2.0
         self._sprite = load_weapon_sprite("shuriken", max_dim=sprite_size)
 
     def _fire(self, owner: EntityId, view: WorldView, direction: Vec2) -> None:
+        self.audio.on_throw()
         velocity = (direction[0] * self.speed, direction[1] * self.speed)
         position = view.get_position(owner)
-        view.spawn_projectile(
+        proj = view.spawn_projectile(
             owner,
             position,
             velocity,
@@ -31,6 +35,8 @@ class Shuriken(Weapon):
             sprite=self._sprite,
             spin=12.0,
         )
+        if isinstance(proj, Projectile):
+            proj.audio = self.audio
 
 
 weapon_registry.register("shuriken", Shuriken)

--- a/app/world/projectiles.py
+++ b/app/world/projectiles.py
@@ -7,6 +7,7 @@ from typing import cast
 import pygame
 import pymunk
 
+from app.audio.weapons import WeaponAudio
 from app.core.types import Damage, EntityId, Vec2
 from app.render.renderer import Renderer
 from app.weapons.base import WeaponEffect, WorldView
@@ -27,6 +28,7 @@ class Projectile(WeaponEffect):
     sprite: pygame.Surface | None = None
     angle: float = 0.0
     spin: float = 0.0
+    audio: WeaponAudio | None = None
 
     @classmethod
     def spawn(
@@ -79,6 +81,8 @@ class Projectile(WeaponEffect):
 
     def on_hit(self, view: WorldView, target: EntityId) -> bool:
         view.deal_damage(target, self.damage)
+        if self.audio is not None:
+            self.audio.on_touch()
         target_pos = view.get_position(target)
         pos = self.body.position
         dx = pos.x - target_pos[0]

--- a/tests/test_audio_weapons.py
+++ b/tests/test_audio_weapons.py
@@ -1,5 +1,5 @@
 import time
-from typing import List, cast
+from typing import cast
 
 from app.audio.engine import AudioEngine
 from app.audio.weapons import WeaponAudio
@@ -7,7 +7,7 @@ from app.audio.weapons import WeaponAudio
 
 class StubAudioEngine:
     def __init__(self) -> None:
-        self.played: List[str] = []
+        self.played: list[str] = []
 
     def play_variation(self, path: str, volume: float | None = None) -> bool:  # noqa: D401
         self.played.append(path)

--- a/tests/test_weapon_audio_integration.py
+++ b/tests/test_weapon_audio_integration.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from typing import cast
+
+from app.audio.weapons import WeaponAudio
+from app.core.types import Damage, EntityId, Vec2
+from app.weapons.base import WeaponEffect, WorldView
+from app.weapons.katana import Katana
+from app.weapons.shuriken import Shuriken
+from app.world.physics import PhysicsWorld
+from app.world.projectiles import Projectile
+
+
+class StubAudio:
+    def __init__(self) -> None:
+        self.idle_started = False
+        self.thrown = False
+        self.touched = False
+
+    def start_idle(self) -> None:  # noqa: D401
+        self.idle_started = True
+
+    def on_throw(self) -> None:  # noqa: D401
+        self.thrown = True
+
+    def on_touch(self) -> None:  # noqa: D401
+        self.touched = True
+
+
+def test_katana_audio_events() -> None:
+    katana = Katana()
+    stub_audio = StubAudio()
+    katana.audio = cast(WeaponAudio, stub_audio)
+
+    class View:
+        def __init__(self) -> None:
+            self.effects: list[WeaponEffect] = []
+
+        def spawn_effect(self, effect: WeaponEffect) -> None:  # noqa: D401
+            self.effects.append(effect)
+
+        def get_position(self, eid: EntityId) -> Vec2:  # noqa: D401
+            return (0.0, 0.0)
+
+        def deal_damage(self, eid: EntityId, damage: Damage) -> None:  # noqa: D401
+            pass
+
+    view_obj = View()
+    view = cast(WorldView, view_obj)
+    katana.update(EntityId(1), view, 0.0)
+    assert stub_audio.idle_started
+    effect = view_obj.effects[0]
+    effect.on_hit(view, EntityId(2))
+    assert stub_audio.touched
+
+
+def test_shuriken_audio_events() -> None:
+    shuriken = Shuriken()
+    stub_audio = StubAudio()
+    shuriken.audio = cast(WeaponAudio, stub_audio)
+
+    class View:
+        def __init__(self) -> None:
+            self.world = PhysicsWorld()
+            self.projectile: Projectile | None = None
+
+        def get_position(self, eid: EntityId) -> Vec2:  # noqa: D401
+            return (0.0, 0.0)
+
+        def spawn_projectile(
+            self,
+            owner: EntityId,
+            position: Vec2,
+            velocity: Vec2,
+            *,
+            radius: float,
+            damage: Damage,
+            knockback: float,
+            ttl: float,
+            sprite: object | None = None,
+            spin: float = 0.0,
+        ) -> WeaponEffect:
+            proj = Projectile.spawn(
+                self.world,
+                owner,
+                position,
+                velocity,
+                radius,
+                damage,
+                knockback,
+                ttl,
+                sprite,
+                spin,
+            )
+            self.projectile = proj
+            return proj
+
+        def deal_damage(self, eid: EntityId, damage: Damage) -> None:  # noqa: D401
+            pass
+
+        def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:  # noqa: D401
+            pass
+
+    view_obj = View()
+    view = cast(WorldView, view_obj)
+    shuriken._fire(EntityId(1), view, (1.0, 0.0))
+    assert stub_audio.thrown
+    projectile = view_obj.projectile
+    assert projectile is not None
+    projectile.on_hit(view, EntityId(2))
+    assert stub_audio.touched


### PR DESCRIPTION
## Summary
- add WeaponAudio integration for katana and shuriken
- play weapon sounds on idle, throw and hit events
- cover audio hooks with new tests

## Testing
- `uv run ruff check tests/test_weapon_audio_integration.py tests/test_audio_weapons.py app/weapons/katana.py app/weapons/shuriken.py app/weapons/effects.py app/world/projectiles.py`
- `uv run mypy .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68aff17573c4832aa900084efbf3d39b