### PR TITLE
feat: darken health bar background

### DIFF
--- a/app/config.json
+++ b/app/config.json
@@ -1,28 +1,17 @@
 {
-  "canvas": { "width": 1080, "height": 1920, "fps": 60 },
-  "theme": {
-    "team_a": {
-      "primary": [0, 102, 204],
-      "hp_gradient": [
-        [102, 178, 255],
-        [0, 51, 102]
-      ]
+    "canvas": {"width": 1080, "height": 1920, "fps": 60},
+    "theme": {
+        "team_a": {"primary": [0, 102, 204], "hp_gradient": [[102, 178, 255], [0, 51, 102]]},
+        "team_b": {"primary": [255, 102, 0], "hp_gradient": [[255, 178, 102], [102, 51, 0]]},
+        "hp_empty": [51, 51, 51],
     },
-    "team_b": {
-      "primary": [255, 102, 0],
-      "hp_gradient": [
-        [255, 178, 102],
-        [102, 51, 0]
-      ]
-    }
-  },
-  "hud": { "title": "", "watermark": "" },
-  "end_screen": {
-    "victory_text": "Victory : {weapon}",
-    "subtitle_text": "{weapon} wins!",
-    "slowmo": 0.35,
-    "slowmo_duration": 0.6,
-    "freeze_ms": 120,
-    "fade_ms": 400
-  }
+    "hud": {"title": "", "watermark": ""},
+    "end_screen": {
+        "victory_text": "Victory : {weapon}",
+        "subtitle_text": "{weapon} wins!",
+        "slowmo": 0.35,
+        "slowmo_duration": 0.6,
+        "freeze_ms": 120,
+        "fade_ms": 400,
+    },
 }

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -49,6 +49,7 @@ class Settings(BaseModel):  # type: ignore[misc]
     theme: Theme = Theme(
         team_a=TeamColors(primary=(0, 102, 204), hp_gradient=((102, 178, 255), (0, 51, 102))),
         team_b=TeamColors(primary=(255, 102, 0), hp_gradient=((255, 178, 102), (102, 51, 0))),
+        hp_empty=(51, 51, 51),
     )
     hud: HudConfig = HudConfig()
     end_screen: EndScreenConfig = EndScreenConfig()

--- a/app/render/hud.py
+++ b/app/render/hud.py
@@ -24,21 +24,19 @@ class Hud:
     def draw_hp_bars(
         self, surface: pygame.Surface, hp_a: float, hp_b: float, labels: tuple[str, str]
     ) -> None:
-        """Draw two symmetrical health bars with labels using theme gradients."""
+        """Draw two symmetrical health bars with labels."""
+
         bar_width = 300
         bar_height = 25
         margin = 40
 
         # Left bar (team A)
         left_rect = pygame.Rect(margin, 120, bar_width, bar_height)
-        draw_horizontal_gradient(
-            surface, left_rect, *self.theme.team_a.hp_gradient
-        )
-        pygame.draw.rect(
-            surface,
-            self.theme.team_a.primary,
-            (left_rect.x, left_rect.y, int(bar_width * hp_a), bar_height),
-        )
+        pygame.draw.rect(surface, self.theme.hp_empty, left_rect)
+        width_a = int(bar_width * hp_a)
+        if width_a > 0:
+            filled_rect = pygame.Rect(left_rect.x, left_rect.y, width_a, bar_height)
+            draw_horizontal_gradient(surface, filled_rect, *self.theme.team_a.hp_gradient)
         label_a = self.bar_font.render(labels[0], True, (255, 255, 255))
         surface.blit(label_a, (left_rect.x, left_rect.y - 30))
 
@@ -46,19 +44,14 @@ class Hud:
         right_rect = pygame.Rect(
             surface.get_width() - margin - bar_width, 120, bar_width, bar_height
         )
-        # Gradient drawn right-to-left
-        grad_start, grad_end = self.theme.team_b.hp_gradient
-        draw_horizontal_gradient(surface, right_rect, grad_end, grad_start)
-        pygame.draw.rect(
-            surface,
-            self.theme.team_b.primary,
-            (
-                right_rect.x + bar_width - int(bar_width * hp_b),
-                right_rect.y,
-                int(bar_width * hp_b),
-                bar_height,
-            ),
-        )
+        pygame.draw.rect(surface, self.theme.hp_empty, right_rect)
+        width_b = int(bar_width * hp_b)
+        if width_b > 0:
+            filled_rect = pygame.Rect(
+                right_rect.x + bar_width - width_b, right_rect.y, width_b, bar_height
+            )
+            grad_start, grad_end = self.theme.team_b.hp_gradient
+            draw_horizontal_gradient(surface, filled_rect, grad_end, grad_start)
         label_b = self.bar_font.render(labels[1], True, (255, 255, 255))
         surface.blit(
             label_b,
@@ -72,9 +65,7 @@ class Hud:
         rect.bottomleft = (10, surface.get_height() - 10)
         surface.blit(mark, rect)
 
-    def draw_victory_banner(
-        self, surface: pygame.Surface, title: str, subtitle: str
-    ) -> None:
+    def draw_victory_banner(self, surface: pygame.Surface, title: str, subtitle: str) -> None:
         """Draw the final victory banner at the center of the screen."""
         title_surf = self.title_font.render(title, True, (255, 255, 255))
         sub_surf = self.bar_font.render(subtitle, True, (255, 255, 255))

--- a/app/render/theme.py
+++ b/app/render/theme.py
@@ -17,10 +17,21 @@ class TeamColors:
 
 @dataclass(frozen=True)
 class Theme:
-    """Complete color palette for the renderer and HUD."""
+    """Complete color palette for the renderer and HUD.
+
+    Attributes
+    ----------
+    team_a:
+        Colors for team A.
+    team_b:
+        Colors for team B.
+    hp_empty:
+        Color displayed for lost health.
+    """
 
     team_a: TeamColors
     team_b: TeamColors
+    hp_empty: Color
 
 
 def draw_horizontal_gradient(

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -15,3 +15,16 @@ def test_hud_draws_without_errors() -> None:
     renderer.present()
     frame = renderer.capture_frame()
     assert frame.shape == (200, 100, 3)
+
+
+def test_hp_bar_background_color() -> None:
+    renderer = Renderer(800, 300)
+    hud = Hud(settings.theme)
+    renderer.clear()
+    hud.draw_hp_bars(renderer.surface, 0.5, 0.25, ("A", "B"))
+    empty = settings.theme.hp_empty
+    y = 120 + 25 // 2
+    left_empty_x = 40 + int(300 * 0.5) + 1
+    assert renderer.surface.get_at((left_empty_x, y))[:3] == empty
+    right_rect_start = renderer.surface.get_width() - 40 - 300
+    assert renderer.surface.get_at((right_rect_start + 1, y))[:3] == empty


### PR DESCRIPTION
## Summary
- add configurable dark background for depleted health
- document new theme color and update default configuration
- cover health bar background with dedicated test

## Testing
- `uv run ruff check app/render/hud.py app/render/theme.py app/core/config.py tests/test_hud.py`
- `uv run mypy app/render/hud.py app/render/theme.py app/core/config.py tests/test_hud.py`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68aff4a59ef0832aba9e5c0ef95f2f6b