### PR TITLE
fix: scale display window

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -34,13 +34,10 @@ def run(
     """Run a single match and export a video to ``./generated``."""
     random.seed(seed)
 
-    display_width = settings.width // 2
-    display_height = settings.height // 2
-
     recorder: Recorder | NullRecorder
     temp_path: Path | None = None
     if display:
-        renderer = Renderer(display_width, display_height, display=True)
+        renderer = Renderer(settings.width, settings.height, display=True)
         recorder = NullRecorder()
     else:
         out_dir = Path("generated")

--- a/app/display.py
+++ b/app/display.py
@@ -76,7 +76,14 @@ class Display:
             msg = "pygame is required for Display"
             raise RuntimeError(msg)
         self._flags = pygame.RESIZABLE
-        self._window = pygame.display.set_mode(self.target_size, self._flags)
+        info = pygame.display.Info()
+        screen_w, screen_h = info.current_w, info.current_h
+        scale = calculate_scale((screen_w, screen_h), self.target_size)
+        window_size = (
+            int(self.target_width * scale),
+            int(self.target_height * scale),
+        )
+        self._window = pygame.display.set_mode(window_size, self._flags)
 
     @property
     def target_size(self) -> Size:

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -108,8 +108,8 @@ def test_run_display_mode_no_file(monkeypatch: MonkeyPatch) -> None:
     )
 
     assert result.exit_code == 0
-    assert captured["width"] == settings.width // 2
-    assert captured["height"] == settings.height // 2
+    assert captured["width"] == settings.width
+    assert captured["height"] == settings.height
     assert captured["display"] is True
     # En mode display, aucun fichier ne doit être créé
     assert not Path("generated").exists()

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+import os
+from types import SimpleNamespace
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import pygame
 import pytest
 
-from app.display import calculate_scale
+from app.display import Display, calculate_scale
 
 
 @pytest.mark.parametrize(
@@ -21,3 +27,67 @@ def test_calculate_scale(window: tuple[int, int], expected: float) -> None:
 def test_calculate_scale_invalid() -> None:
     with pytest.raises(ValueError):
         calculate_scale((0, 100), (1080, 1920))
+
+
+def test_display_initial_window_scaled(monkeypatch: pytest.MonkeyPatch) -> None:
+    info = SimpleNamespace(current_w=1920, current_h=1080)
+    monkeypatch.setattr(pygame.display, "Info", lambda: info)
+
+    captured: dict[str, tuple[int, int]] = {}
+
+    class FakeSurface:
+        def __init__(self, size: tuple[int, int]):
+            self._size = size
+
+        def get_size(self) -> tuple[int, int]:
+            return self._size
+
+    def fake_set_mode(size: tuple[int, int], flags: int) -> FakeSurface:
+        captured["size"] = size
+        return FakeSurface(size)
+
+    monkeypatch.setattr(pygame.display, "set_mode", fake_set_mode)
+
+    Display(1080, 1920)
+
+    assert captured["size"] == (607, 1080)
+
+
+def test_present_letterboxing(monkeypatch: pytest.MonkeyPatch) -> None:
+    info = SimpleNamespace(current_w=1920, current_h=1080)
+    monkeypatch.setattr(pygame.display, "Info", lambda: info)
+
+    class FakeSurface:
+        def __init__(self, size: tuple[int, int]):
+            self._size = size
+            self.blit_calls: list[tuple[object, tuple[int, int]]] = []
+
+        def get_size(self) -> tuple[int, int]:
+            return self._size
+
+        def fill(self, color: tuple[int, int, int]) -> None:  # pragma: no cover - trivial
+            pass
+
+        def blit(self, surf: object, offset: tuple[int, int]) -> None:
+            self.blit_calls.append((surf, offset))
+
+    window = FakeSurface((1920, 1080))
+    monkeypatch.setattr(pygame.display, "set_mode", lambda size, flags: window)
+    monkeypatch.setattr(pygame.display, "get_surface", lambda: window)
+    monkeypatch.setattr(pygame.display, "flip", lambda: None)
+
+    scaled: dict[str, object] = {}
+
+    def fake_smoothscale(surface: FakeSurface, size: tuple[int, int]) -> FakeSurface:
+        scaled_surface = FakeSurface(size)
+        scaled["size"] = size
+        return scaled_surface
+
+    monkeypatch.setattr(pygame.transform, "smoothscale", fake_smoothscale)
+
+    display = Display(1080, 1920)
+    source = FakeSurface((1080, 1920))
+    display.present(source)
+
+    assert scaled["size"] == (607, 1080)
+    assert window.blit_calls[0][1] == (656, 0)


### PR DESCRIPTION
## Summary
- render display mode at full video resolution
- initialize display window based on monitor size
- test display scaling and full-res display mode

## Testing
- `uv run ruff check app/cli.py app/display.py tests/test_cli_run.py tests/test_display.py`
- `uv run ruff format app/cli.py app/display.py tests/test_cli_run.py tests/test_display.py`
- `uv run mypy app/cli.py app/display.py`
- `uv run pytest tests/test_cli_run.py tests/test_display.py` *(fails: ModuleNotFoundError: No module named 'pygame')*


------
https://chatgpt.com/codex/tasks/task_e_68aff752f694832a9fd719f2b1324513