### PR TITLE
feat: timestamp ball damage

### DIFF
--- a/app/game/match.py
+++ b/app/game/match.py
@@ -80,14 +80,15 @@ class _MatchView(WorldView):
                 return p.ball.health / p.ball.stats.max_health
         raise KeyError(eid)
 
-    def deal_damage(self, eid: EntityId, damage: Damage) -> None:
+    def deal_damage(self, eid: EntityId, damage: Damage, timestamp: float) -> None:
+        """Apply ``damage`` to ``eid`` at the given ``timestamp``."""
         for p in self.players:
             if p.eid == eid and p.alive:
                 p.alive = not p.ball.take_damage(damage)
                 self.renderer.add_impact(self.get_position(eid))
                 self.renderer.trigger_blink(p.color, int(damage.amount))
                 if not p.alive:
-                    self.engine.play_variation(BALL_DEATH_SOUND)
+                    self.engine.play_variation(BALL_DEATH_SOUND, timestamp=timestamp)
                 return
 
     def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:
@@ -252,7 +253,7 @@ def run_match(  # noqa: C901
                         continue
                     pos = (float(p.ball.body.position.x), float(p.ball.body.position.y))
                     if eff.collides(view, pos, p.ball.shape.radius):
-                        keep = eff.on_hit(view, p.eid)
+                        keep = eff.on_hit(view, p.eid, elapsed)
                         if not keep:
                             eff.destroy()
                             effects.remove(eff)

--- a/app/weapons/base.py
+++ b/app/weapons/base.py
@@ -25,8 +25,8 @@ class WorldView(Protocol):
     def get_health_ratio(self, eid: EntityId) -> float:
         """Return the current health ratio ``health / max_health`` of an entity."""
 
-    def deal_damage(self, eid: EntityId, damage: Damage) -> None:
-        """Apply *damage* to the entity."""
+    def deal_damage(self, eid: EntityId, damage: Damage, timestamp: float) -> None:
+        """Apply ``damage`` to ``eid`` at the given ``timestamp``."""
 
     def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:
         """Apply an impulse to the entity's body."""
@@ -63,8 +63,8 @@ class WeaponEffect(Protocol):
     def collides(self, view: WorldView, position: Vec2, radius: float) -> bool:
         """Return ``True`` if the effect intersects a circle at *position*."""
 
-    def on_hit(self, view: WorldView, target: EntityId) -> bool:
-        """Handle a collision with *target* and return ``True`` to keep the effect."""
+    def on_hit(self, view: WorldView, target: EntityId, timestamp: float) -> bool:
+        """Handle a collision with ``target`` at ``timestamp`` and return ``True`` to keep the effect."""
 
     def draw(self, renderer: Renderer, view: WorldView) -> None:
         """Render the effect on *renderer*."""

--- a/app/weapons/effects.py
+++ b/app/weapons/effects.py
@@ -44,10 +44,11 @@ class OrbitingSprite(WeaponEffect):
         hit_rad = max(self.sprite.get_width(), self.sprite.get_height()) / 2
         return bool(dx * dx + dy * dy <= (hit_rad + radius) ** 2)
 
-    def on_hit(self, view: WorldView, target: EntityId) -> bool:  # noqa: D401
-        view.deal_damage(target, self.damage)
+    def on_hit(self, view: WorldView, target: EntityId, timestamp: float) -> bool:  # noqa: D401
+        """Apply damage to ``target`` at ``timestamp``."""
+        view.deal_damage(target, self.damage, timestamp)
         if self.audio is not None:
-            self.audio.on_touch()
+            self.audio.on_touch(timestamp)
         return True
 
     def draw(self, renderer: Renderer, view: WorldView) -> None:  # noqa: D401

--- a/app/world/projectiles.py
+++ b/app/world/projectiles.py
@@ -79,10 +79,11 @@ class Projectile(WeaponEffect):
         rad = cast(float, self.shape.radius) + radius
         return dx * dx + dy * dy <= rad * rad
 
-    def on_hit(self, view: WorldView, target: EntityId) -> bool:
-        view.deal_damage(target, self.damage)
+    def on_hit(self, view: WorldView, target: EntityId, timestamp: float) -> bool:
+        """Apply damage to ``target`` at ``timestamp`` and transfer momentum."""
+        view.deal_damage(target, self.damage, timestamp)
         if self.audio is not None:
-            self.audio.on_touch()
+            self.audio.on_touch(timestamp)
         target_pos = view.get_position(target)
         pos = self.body.position
         dx = pos.x - target_pos[0]

--- a/prompts/04-weapons.md
+++ b/prompts/04-weapons.md
@@ -5,7 +5,7 @@ But : gameplay minimal 1v1.
 
 - `app/weapons/base.py` :
   - classe Weapon(name, cooldown, dmg: Damage) avec timer
-  - WorldView Protocol : get_enemy(owner_id), get_position(eid), deal_damage(eid, Damage), apply_impulse(eid, vx, vy), spawn_projectile(...)
+  - WorldView Protocol : get_enemy(owner_id), get_position(eid), deal_damage(eid, Damage, timestamp), apply_impulse(eid, vx, vy), spawn_projectile(...)
 - `app/weapons/katana.py` :
   - arc 70°, portée ~140, cooldown 0.6s, dmg 18, knockback 220, enregistre `katana`
 - `app/weapons/shuriken.py` :

--- a/tests/test_ball_death_sound.py
+++ b/tests/test_ball_death_sound.py
@@ -39,11 +39,13 @@ class DummyRenderer:
 class DummyEngine:
     def __init__(self) -> None:
         self.paths: list[str] = []
+        self.timestamps: list[float | None] = []
 
     def play_variation(
         self, path: str, volume: float | None = None, timestamp: float | None = None
     ) -> bool:
         self.paths.append(path)
+        self.timestamps.append(timestamp)
         return True
 
 
@@ -58,6 +60,8 @@ def test_deal_damage_triggers_explosion_sound_on_death() -> None:
     renderer = cast("Renderer", DummyRenderer())
     view = _MatchView([player], [], world, renderer, engine)
 
-    view.deal_damage(player.eid, Damage(amount=200.0))
+    view.deal_damage(player.eid, Damage(amount=200.0), timestamp=1.23)
 
-    assert Path("assets/balls/explose.ogg").as_posix() in dummy_engine.paths
+    path = Path("assets/balls/explose.ogg").as_posix()
+    assert path in dummy_engine.paths
+    assert dummy_engine.timestamps[dummy_engine.paths.index(path)] == 1.23

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -35,7 +35,7 @@ class DummyView(WorldView):
     def get_health_ratio(self, eid: EntityId) -> float:  # noqa: D401
         return self.health_me if eid == self.me else self.health_enemy
 
-    def deal_damage(self, eid: EntityId, damage: Damage) -> None:  # noqa: D401
+    def deal_damage(self, eid: EntityId, damage: Damage, timestamp: float) -> None:  # noqa: D401
         return
 
     def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:  # noqa: D401
@@ -67,7 +67,7 @@ class DummyView(WorldView):
             def collides(self, view: WorldView, position: Vec2, radius: float) -> bool:
                 return False
 
-            def on_hit(self, view: WorldView, target: EntityId) -> bool:
+            def on_hit(self, view: WorldView, target: EntityId, timestamp: float) -> bool:
                 return False
 
             def draw(self, renderer: object, view: WorldView) -> None:

--- a/tests/test_weapon_audio_integration.py
+++ b/tests/test_weapon_audio_integration.py
@@ -42,7 +42,7 @@ def test_katana_audio_events() -> None:
         def get_position(self, eid: EntityId) -> Vec2:  # noqa: D401
             return (0.0, 0.0)
 
-        def deal_damage(self, eid: EntityId, damage: Damage) -> None:  # noqa: D401
+        def deal_damage(self, eid: EntityId, damage: Damage, timestamp: float) -> None:  # noqa: D401
             pass
 
     view_obj = View()
@@ -50,7 +50,7 @@ def test_katana_audio_events() -> None:
     katana.update(EntityId(1), view, 0.0)
     assert stub_audio.idle_started
     effect = view_obj.effects[0]
-    effect.on_hit(view, EntityId(2))
+    effect.on_hit(view, EntityId(2), timestamp=0.0)
     assert stub_audio.touched
 
 
@@ -95,7 +95,7 @@ def test_shuriken_audio_events() -> None:
             self.projectile = proj
             return proj
 
-        def deal_damage(self, eid: EntityId, damage: Damage) -> None:  # noqa: D401
+        def deal_damage(self, eid: EntityId, damage: Damage, timestamp: float) -> None:  # noqa: D401
             pass
 
         def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:  # noqa: D401
@@ -107,5 +107,5 @@ def test_shuriken_audio_events() -> None:
     assert stub_audio.thrown
     projectile = view_obj.projectile
     assert projectile is not None
-    projectile.on_hit(view, EntityId(2))
+    projectile.on_hit(view, EntityId(2), timestamp=0.0)
     assert stub_audio.touched

--- a/tests/unit/test_policy_angles.py
+++ b/tests/unit/test_policy_angles.py
@@ -30,7 +30,7 @@ class DummyView(WorldView):
     def get_health_ratio(self, eid: EntityId) -> float:  # noqa: D401
         return 1.0
 
-    def deal_damage(self, eid: EntityId, damage: Damage) -> None:  # noqa: D401
+    def deal_damage(self, eid: EntityId, damage: Damage, timestamp: float) -> None:  # noqa: D401
         return
 
     def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:  # noqa: D401
@@ -62,7 +62,7 @@ class DummyView(WorldView):
             def collides(self, view: WorldView, position: Vec2, radius: float) -> bool:
                 return False
 
-            def on_hit(self, view: WorldView, target: EntityId) -> bool:
+            def on_hit(self, view: WorldView, target: EntityId, timestamp: float) -> bool:
                 return False
 
             def draw(self, renderer: object, view: WorldView) -> None:

--- a/tests/unit/test_weapons.py
+++ b/tests/unit/test_weapons.py
@@ -34,7 +34,7 @@ class DummyView(WorldView):
     def get_health_ratio(self, eid: EntityId) -> float:  # noqa: D401
         return 1.0
 
-    def deal_damage(self, eid: EntityId, damage: Damage) -> None:  # noqa: D401
+    def deal_damage(self, eid: EntityId, damage: Damage, timestamp: float) -> None:  # noqa: D401
         self.damage_values.append(damage.amount)
 
     def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:  # noqa: D401
@@ -53,7 +53,7 @@ class DummyView(WorldView):
             def collides(self, view: WorldView, position: Vec2, radius: float) -> bool:
                 return False
 
-            def on_hit(self, view: WorldView, target: EntityId) -> bool:
+            def on_hit(self, view: WorldView, target: EntityId, timestamp: float) -> bool:
                 return False
 
             def draw(self, renderer: object, view: WorldView) -> None:


### PR DESCRIPTION
## Summary
- carry simulation time through WorldView.deal_damage and WeaponEffect.on_hit
- include timestamp when MatchView plays BALL_DEATH_SOUND
- adjust projectiles, effects, and tests to forward timestamps

## Testing
- `uv run ruff check app/weapons/base.py app/game/match.py app/world/projectiles.py app/weapons/effects.py tests/test_ball_death_sound.py tests/test_policy.py tests/unit/test_policy_angles.py tests/unit/test_weapons.py tests/test_weapon_audio_integration.py`
- `uv run ruff format app/weapons/base.py app/game/match.py app/world/projectiles.py app/weapons/effects.py tests/test_ball_death_sound.py tests/test_policy.py tests/unit/test_policy_angles.py tests/unit/test_weapons.py tests/test_weapon_audio_integration.py`
- `uv run mypy app tests`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68b016c4f7ac832ab5ae2c0cc9b0347f