### PR TITLE
feat: refine combat AI distance and dodging

### DIFF
--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -90,6 +90,14 @@ def test_kiter_moves_away() -> None:
     assert fire is True
 
 
+def test_kiter_closes_distance_when_out_of_range() -> None:
+    view = DummyView(EntityId(1), EntityId(2), (0.0, 0.0), (600.0, 0.0))
+    policy = SimplePolicy("kiter")
+    accel, _, fire = policy.decide(EntityId(1), view, 600.0)
+    assert accel[0] > 0  # moves right, toward enemy
+    assert fire is False
+
+
 def test_kiter_leads_moving_target() -> None:
     view = DummyView(
         EntityId(1),


### PR DESCRIPTION
## Summary
- adjust kiter AI to maintain distance based on projectile speed and only fire in range
- enhance aggressive AI projectile dodging logic
- test kiter behaviour when outside weapon range

## Testing
- `make lint`
- `make test` *(fails: pytest: error: unrecognized arguments: --cov=.)*
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68b050204e38832a96929e1746a4984c