### PR TITLE
feat: allow custom impact duration

### DIFF
--- a/app/game/match.py
+++ b/app/game/match.py
@@ -82,11 +82,14 @@ class _MatchView(WorldView):
         """Apply ``damage`` to ``eid`` at the given ``timestamp``."""
         for p in self.players:
             if p.eid == eid and p.alive:
+                pos = self.get_position(eid)
                 p.alive = not p.ball.take_damage(damage)
-                self.renderer.add_impact(self.get_position(eid))
-                self.renderer.trigger_blink(p.color, int(damage.amount))
-                if not p.alive:
+                if p.alive:
+                    self.renderer.add_impact(pos)
+                else:
+                    self.renderer.add_impact(pos, duration=2.0)
                     p.audio.on_explode(timestamp=timestamp)
+                self.renderer.trigger_blink(p.color, int(damage.amount))
                 return
 
     def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:
@@ -315,10 +318,10 @@ def run_match(  # noqa: C901
                 float(lose_p.ball.body.position.x),
                 float(lose_p.ball.body.position.y),
             )
-            renderer.add_impact(lose_pos)
+            renderer.add_impact(lose_pos, duration=2.0)
             for frame_index in range(max(1, shrink_frames)):
                 if frame_index > 0 and frame_index % 4 == 0:
-                    renderer.add_impact(lose_pos)
+                    renderer.add_impact(lose_pos, duration=2.0)
                 progress = (frame_index + 1) / max(1, shrink_frames)
                 renderer.clear()
                 lose_radius = int(lose_p.ball.shape.radius * (1.0 - progress))

--- a/tests/test_ball_death_sound.py
+++ b/tests/test_ball_death_sound.py
@@ -32,7 +32,9 @@ if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
 
 
 class DummyRenderer:
-    def add_impact(self, pos: tuple[float, float]) -> None:  # pragma: no cover - stub
+    def add_impact(
+        self, pos: tuple[float, float], duration: float = 0.08
+    ) -> None:  # pragma: no cover - stub
         return
 
     def trigger_blink(

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -31,3 +31,15 @@ def test_draw_eyes_team_color() -> None:
     renderer.present()
     frame = renderer.capture_frame()
     assert (frame == np.array(team_color)).all(axis=-1).any()
+
+
+def test_add_impact_custom_duration() -> None:
+    renderer = Renderer(100, 100)
+    duration = 0.5
+    renderer.add_impact((50.0, 50.0), duration=duration)
+    frames = int(duration / settings.dt)
+    for _ in range(frames - 1):
+        renderer.clear()
+    assert len(renderer._impacts) == 1
+    renderer.clear()
+    assert len(renderer._impacts) == 0


### PR DESCRIPTION
## Summary
- allow renderer impacts to specify custom lifetime
- keep ball-death impacts on screen longer
- add unit test for custom impact persistence

## Testing
- `ruff check .`
- `mypy .`
- `pytest -q` *(fails: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68b059de3fe8832a92290369443fa33e