### PR TITLE
feat: allow katana to deflect projectiles

### DIFF
--- a/app/game/match.py
+++ b/app/game/match.py
@@ -251,6 +251,23 @@ def run_match(  # noqa: C901
                     eff.destroy()
                     effects.remove(eff)
                     continue
+                if isinstance(eff, Projectile):
+                    proj_pos = (float(eff.body.position.x), float(eff.body.position.y))
+                    proj_rad = float(eff.shape.radius)
+                    deflected = False
+                    for other in effects:
+                        if other is eff:
+                            continue
+                        collide = getattr(other, "collides", None)
+                        if collide is None or not collide(view, proj_pos, proj_rad):
+                            continue
+                        reflector = getattr(other, "deflect_projectile", None)
+                        if reflector is not None:
+                            reflector(view, eff, elapsed)
+                            deflected = True
+                            break
+                    if deflected:
+                        continue
                 for p in players:
                     if p.eid == eff.owner or not p.alive:
                         continue

--- a/app/weapons/effects.py
+++ b/app/weapons/effects.py
@@ -9,6 +9,7 @@ import pygame
 from app.audio.weapons import WeaponAudio
 from app.core.types import Color, Damage, EntityId, Vec2
 from app.render.renderer import Renderer
+from app.world.projectiles import Projectile
 
 from .base import WeaponEffect, WorldView
 
@@ -50,6 +51,16 @@ class OrbitingSprite(WeaponEffect):
         if self.audio is not None:
             self.audio.on_touch(timestamp)
         return True
+
+    def deflect_projectile(
+        self, view: WorldView, projectile: Projectile, timestamp: float
+    ) -> None:
+        """Reflect ``projectile`` away from the owner."""
+        vx, vy = projectile.body.velocity
+        projectile.body.velocity = (-vx, -vy)
+        projectile.owner = self.owner
+        if projectile.audio is not None:
+            projectile.audio.on_touch(timestamp)
 
     def draw(self, renderer: Renderer, view: WorldView) -> None:  # noqa: D401
         pos = self._position(view)

--- a/tests/unit/test_katana_deflect.py
+++ b/tests/unit/test_katana_deflect.py
@@ -1,0 +1,91 @@
+import pygame
+from dataclasses import dataclass, field
+
+from app.core.types import Damage, EntityId, Vec2
+from app.weapons.effects import OrbitingSprite
+from app.world.physics import PhysicsWorld
+from app.world.projectiles import Projectile
+from app.weapons.base import WorldView, WeaponEffect
+
+
+@dataclass
+class DummyView(WorldView):
+    positions: dict[EntityId, Vec2]
+    damage: dict[EntityId, float] = field(default_factory=dict)
+
+    def get_enemy(self, owner: EntityId) -> EntityId | None:
+        return None
+
+    def get_position(self, eid: EntityId) -> Vec2:
+        return self.positions[eid]
+
+    def get_velocity(self, eid: EntityId) -> Vec2:
+        return (0.0, 0.0)
+
+    def get_health_ratio(self, eid: EntityId) -> float:
+        return 1.0
+
+    def deal_damage(self, eid: EntityId, damage: Damage, timestamp: float) -> None:
+        self.damage[eid] = self.damage.get(eid, 0.0) + damage.amount
+
+    def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:
+        return None
+
+    def spawn_effect(self, effect: WeaponEffect) -> None:
+        return None
+
+    def spawn_projectile(
+        self,
+        owner: EntityId,
+        position: Vec2,
+        velocity: Vec2,
+        radius: float,
+        damage: Damage,
+        knockback: float,
+        ttl: float,
+        sprite: pygame.Surface | None = None,
+        spin: float = 0.0,
+    ) -> WeaponEffect:
+        raise NotImplementedError
+
+    def iter_projectiles(self, excluding: EntityId | None = None):
+        return []
+
+
+def test_katana_deflects_projectile() -> None:
+    pygame.init()
+    world = PhysicsWorld()
+    owner = EntityId(1)
+    enemy = EntityId(2)
+    positions = {owner: (0.0, 0.0), enemy: (30.0, 0.0)}
+    view = DummyView(positions)
+    sprite = pygame.Surface((20, 20))
+    katana = OrbitingSprite(
+        owner=owner,
+        damage=Damage(0),
+        sprite=sprite,
+        radius=10.0,
+        angle=0.0,
+        speed=0.0,
+    )
+    projectile = Projectile.spawn(
+        world,
+        owner=enemy,
+        position=(10.0, 0.0),
+        velocity=(-100.0, 0.0),
+        radius=1.0,
+        damage=Damage(5),
+        knockback=0.0,
+        ttl=1.0,
+    )
+    pos = (float(projectile.body.position.x), float(projectile.body.position.y))
+    assert katana.collides(view, pos, float(projectile.shape.radius))
+
+    katana.deflect_projectile(view, projectile, timestamp=0.0)
+
+    assert projectile.owner == owner
+    assert projectile.body.velocity.x == 100.0
+    assert view.damage == {}
+
+    projectile.on_hit(view, enemy, timestamp=0.1)
+    assert view.damage[enemy] == 5


### PR DESCRIPTION
## Summary
- allow OrbitingSprite to reflect incoming projectiles and take ownership
- handle projectile/effect collisions in match loop
- cover katana projectile deflection with unit test

## Testing
- `uv run --with pre-commit pre-commit run --files app/game/match.py app/weapons/effects.py tests/unit/test_katana_deflect.py` *(fails: Failed to fetch: https://pypi.org/simple/pre-commit/)*
- `uv run --with pytest pytest tests/unit/test_katana_deflect.py` *(fails: Failed to fetch: https://pypi.org/simple/pytest/)*
- `uv run --with mypy mypy app/weapons/effects.py app/game/match.py tests/unit/test_katana_deflect.py` *(fails: Failed to fetch: https://pypi.org/simple/mypy/)*

------
https://chatgpt.com/codex/tasks/task_e_68b05ef5fb94832aa280889d5c1b8dba