### PR TITLE
fix: shut down audio engine after matches

### DIFF
--- a/app/audio/engine.py
+++ b/app/audio/engine.py
@@ -54,7 +54,15 @@ class AudioEngine:
     # Public API
     # ------------------------------------------------------------------
     def shutdown(self) -> None:
-        """Stop all sounds and quit the mixer."""
+        """Stop all sounds and quit the mixer.
+
+        The shutdown operation is idempotent; calling it multiple times has
+        no effect once the mixer has been closed. This behaviour ensures that
+        cleanup routines can invoke :meth:`shutdown` safely even if another
+        part of the application already terminated the audio subsystem.
+        """
+        if pygame.mixer.get_init() is None:
+            return
         pygame.mixer.stop()
         pygame.mixer.quit()
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -8,6 +8,7 @@ from typing import Annotated, cast
 
 import typer
 
+from app.audio import reset_default_engine
 from app.audio.env import temporary_sdl_audio_driver
 from app.core.config import settings
 from app.game.match import MatchTimeout, run_match
@@ -60,6 +61,8 @@ def run(
                 path.unlink()
             typer.echo(f"Error: {exc}", err=True)
             raise typer.Exit(code=1) from None
+        finally:
+            reset_default_engine()
 
     if not display and isinstance(recorder, Recorder) and temp_path is not None:
         winner_name = _sanitize(winner) if winner is not None else "draw"
@@ -111,6 +114,8 @@ def batch(
                 )
                 temp_path.rename(final_path)
                 typer.echo(f"Saved video to {final_path}")
+            finally:
+                reset_default_engine()
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/app/game/match.py
+++ b/app/game/match.py
@@ -425,3 +425,4 @@ def run_match(  # noqa: C901
         if death_ts is not None:
             audio = _append_slowmo_segment(audio, engine, death_ts)
         recorder.close(audio)
+        engine.shutdown()

--- a/tests/test_match_shutdown_engine.py
+++ b/tests/test_match_shutdown_engine.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from app.audio import reset_default_engine
+from app.audio.engine import AudioEngine
+from app.core.config import settings
+from app.game.match import MatchTimeout, run_match
+from app.render.renderer import Renderer
+from app.video.recorder import Recorder
+
+
+class SpyRecorder(Recorder):
+    """Recorder that captures the provided audio buffer."""
+
+    def __init__(self) -> None:  # pragma: no cover - used in tests
+        self.audio: np.ndarray | None = None
+
+    def add_frame(self, _frame: np.ndarray) -> None:  # pragma: no cover - stub
+        return None
+
+    def close(self, audio: np.ndarray | None = None, rate: int = 48_000) -> None:  # pragma: no cover - stub
+        self.audio = audio
+
+
+def test_run_match_shuts_down_engine(monkeypatch: pytest.MonkeyPatch) -> None:
+    shutdown_called = {"flag": False}
+
+    def spy_shutdown(self: AudioEngine) -> None:  # pragma: no cover - spies
+        shutdown_called["flag"] = True
+
+    monkeypatch.setattr(AudioEngine, "shutdown", spy_shutdown)
+
+    recorder = SpyRecorder()
+    renderer = Renderer(settings.width, settings.height)
+    with pytest.raises(MatchTimeout):
+        run_match("katana", "katana", recorder, renderer, max_seconds=0)
+
+    assert shutdown_called["flag"]
+    reset_default_engine()


### PR DESCRIPTION
## Summary
- make `AudioEngine.shutdown` idempotent
- shut down audio engine when a match ends
- reset shared audio engine after each CLI match
- test engine shutdown after match execution

## Testing
- `uv run ruff check app/audio/engine.py app/game/match.py app/cli.py tests/test_match_shutdown_engine.py`
- `uv run mypy app/audio/engine.py app/game/match.py app/cli.py tests/test_match_shutdown_engine.py`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy pydantic imageio-ffmpeg pymunk` *(fails: Could not find a version that satisfies the requirement numpy)*


------
https://chatgpt.com/codex/tasks/task_e_68b0c92b0260832abd86aef9b7734b61