### PR TITLE
fix: preserve full audio for slowmo replay

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import numpy as np
+
+from app.core.types import Damage, EntityId, Vec2
+from app.video.recorder import Recorder
+from app.weapons.base import Weapon, WorldView
+
+EVENT_TIME = 0.1
+
+
+class InstantKillWeapon(Weapon):
+    """Weapon that immediately destroys the opponent."""
+
+    def __init__(self) -> None:
+        super().__init__(name="instakill", cooldown=0.0, damage=Damage(200))
+        self._done = False
+
+    def _fire(
+        self, owner: EntityId, view: WorldView, direction: Vec2
+    ) -> None:  # pragma: no cover - stub
+        return None
+
+    def update(self, owner: EntityId, view: WorldView, dt: float) -> None:
+        if not self._done:
+            enemy = view.get_enemy(owner)
+            if enemy is not None:
+                view.deal_damage(enemy, self.damage, timestamp=EVENT_TIME)
+                self._done = True
+        super().update(owner, view, dt)
+
+
+class SpyRecorder(Recorder):
+    """Recorder that retains the provided audio buffer."""
+
+    def __init__(self) -> None:
+        self.audio: np.ndarray | None = None
+
+    def add_frame(self, _frame: np.ndarray) -> None:  # pragma: no cover - stub
+        return
+
+    def close(
+        self, audio: np.ndarray | None = None, rate: int = 48_000
+    ) -> None:  # pragma: no cover - stub
+        self.audio = audio

--- a/tests/test_match_audio.py
+++ b/tests/test_match_audio.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import cast
 
 import numpy as np
+import pytest
 
 from app.audio.engine import AudioEngine
 from app.core.config import settings
@@ -32,3 +33,10 @@ def test_replay_audio_matches_video_and_preserves_kill_sound() -> None:
 
     assert abs(final_audio.shape[0] - expected) <= tolerance
     assert final_audio[-1, 0] == kill_amp
+
+
+def test_append_slowmo_segment_raises_on_empty_window() -> None:
+    audio = np.zeros((1, 1), dtype=np.int16)
+    engine = cast(AudioEngine, DummyEngine())
+    with pytest.raises(ValueError):
+        _append_slowmo_segment(audio, engine, death_ts=10.0)


### PR DESCRIPTION
## Summary
- end audio capture before stopping engine to keep full buffer
- validate slow-motion window and raise on empty capture
- test slow-mo replay audio length and content

## Testing
- `uv run ruff check app/game/match.py tests/test_match_audio.py tests/integration/helpers.py tests/integration/test_end_screen_audio.py tests/integration/test_slowmo_replay.py`
- `uv run mypy app/game/match.py tests/test_match_audio.py tests/integration/helpers.py tests/integration/test_end_screen_audio.py tests/integration/test_slowmo_replay.py`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `uv sync --all-extras --dev` *(fails: client error (Connect))*

------
https://chatgpt.com/codex/tasks/task_e_68b16430e784832abf63bff1d2f75458