### PR TITLE
test: defer renderer init to dummy audio context

### DIFF
--- a/tests/integration/test_end_screen_audio.py
+++ b/tests/integration/test_end_screen_audio.py
@@ -23,7 +23,6 @@ def test_end_screen_audio_contains_explosion_and_slow_segment(
         weapon_registry.register("instakill", InstantKillWeapon)
 
     recorder = SpyRecorder()
-    renderer = Renderer(settings.width, settings.height)
 
     captured: dict[str, np.ndarray] = {}
     original = _append_slowmo_segment
@@ -35,6 +34,7 @@ def test_end_screen_audio_contains_explosion_and_slow_segment(
     monkeypatch.setattr("app.game.match._append_slowmo_segment", capture)
 
     with temporary_sdl_audio_driver("dummy"):
+        renderer = Renderer(settings.width, settings.height)
         run_match("instakill", "instakill", recorder, renderer, max_seconds=1)
 
     raw = captured["real"]

--- a/tests/integration/test_slowmo_replay.py
+++ b/tests/integration/test_slowmo_replay.py
@@ -19,7 +19,6 @@ def test_slowmo_segment_has_expected_length_and_content(monkeypatch: pytest.Monk
         weapon_registry.register("instakill", InstantKillWeapon)
 
     recorder = SpyRecorder()
-    renderer = Renderer(settings.width, settings.height)
 
     captured: dict[str, np.ndarray] = {}
     original = _append_slowmo_segment
@@ -31,6 +30,7 @@ def test_slowmo_segment_has_expected_length_and_content(monkeypatch: pytest.Monk
     monkeypatch.setattr("app.game.match._append_slowmo_segment", capture)
 
     with temporary_sdl_audio_driver("dummy"):
+        renderer = Renderer(settings.width, settings.height)
         run_match("instakill", "instakill", recorder, renderer, max_seconds=1)
 
     raw = captured["raw"]


### PR DESCRIPTION
## Summary
- ensure renderer initialization happens within temporary SDL audio driver for end screen and slowmo replay tests

## Testing
- `uv run ruff check tests/integration/test_end_screen_audio.py tests/integration/test_slowmo_replay.py`
- `uv run mypy tests/integration/test_end_screen_audio.py tests/integration/test_slowmo_replay.py`
- `uv run pytest tests/integration/test_end_screen_audio.py tests/integration/test_slowmo_replay.py` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68b1b1cfcd04832a8ed7451635918ffc