### PR TITLE
fix: remove redundant audio engine reset in CLI

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -53,9 +53,7 @@ def run(
             safe_a = _sanitize(weapon_a)
             safe_b = _sanitize(weapon_b)
             temp_path = out_dir / f"{timestamp}-{safe_a}-VS-{safe_b}.mp4"
-            recorder = Recorder(
-                settings.width, settings.height, settings.fps, temp_path
-            )
+            recorder = Recorder(settings.width, settings.height, settings.fps, temp_path)
             renderer = Renderer(settings.width, settings.height)
 
         try:
@@ -66,14 +64,10 @@ def run(
                 path.unlink()
             typer.echo(f"Error: {exc}", err=True)
             raise typer.Exit(code=1) from None
-        finally:
-            reset_default_engine()
 
     if not display and isinstance(recorder, Recorder) and temp_path is not None:
         winner_name = _sanitize(winner) if winner is not None else "draw"
-        final_path = temp_path.with_name(
-            f"{temp_path.stem}-{winner_name}_win{temp_path.suffix}"
-        )
+        final_path = temp_path.with_name(f"{temp_path.stem}-{winner_name}_win{temp_path.suffix}")
         temp_path.rename(final_path)
         typer.echo(f"Saved video to {final_path}")
 

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -9,6 +9,8 @@ import imageio_ffmpeg
 from pytest import MonkeyPatch
 from typer.testing import CliRunner
 
+import app.audio.weapons as weapons
+from app.audio import reset_default_engine
 from app.audio.engine import AudioEngine
 from app.cli import app
 from app.core.config import settings
@@ -122,6 +124,7 @@ def test_run_uses_dummy_audio_driver(monkeypatch: MonkeyPatch) -> None:
     generated = Path("generated")
     if generated.exists():
         shutil.rmtree(generated)
+    reset_default_engine()
     monkeypatch.setenv("SDL_AUDIODRIVER", "original")
 
     recorded: dict[str, str | None] = {}
@@ -149,5 +152,6 @@ def test_run_uses_dummy_audio_driver(monkeypatch: MonkeyPatch) -> None:
     assert result.exit_code == 0
     assert recorded["driver"] == "dummy"
     assert os.environ["SDL_AUDIODRIVER"] == "original"
+    assert weapons._DEFAULT_ENGINE is None
     if generated.exists():
         shutil.rmtree(generated)


### PR DESCRIPTION
## Summary
- rely on `temporary_sdl_audio_driver` for audio engine cleanup in `cli.run`
- ensure CLI run resets audio engine via context manager

## Testing
- `uv run ruff format app/cli.py tests/test_cli_run.py`
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68b1b2bb06fc832ab9fccfe266791855