### PR TITLE
feat: add slow-motion replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Image de prévisualisation à venir.
 - 🔊 **Effets sonores** intégrés dans la piste audio.
 - 📦 **Batch mode** : génération de **N vidéos** en une seule commande.
 - 🚀 Prêt pour la scalabilité : 1v1, 2v2, FFA, replay slow-mo, highlights TikTok.
+- 🎞️ **Ralentit automatique** du coup fatal ajouté à la fin de la vidéo.
 
 ---
 
@@ -117,7 +118,8 @@ Si aucun vainqueur n’est déterminé après **2 minutes**, le moteur interromp
 automatiquement la simulation et renvoie un **message d’erreur**.
 
 Pour afficher la simulation sans enregistrer de vidéo, ajoutez `--display`.
-La fenêtre s'ouvre alors à la moitié de la résolution configurée afin de tenir sur l'écran :
+La fenêtre s'ouvre alors à la moitié de la résolution configurée et s'arrête
+après l'animation de fin **sans** rejouer le ralenti :
 
 ```bash
 uv run python -m app.cli run --display
@@ -147,7 +149,7 @@ uv run python -m app.cli batch \
 - **IA** : agressive, kite, support, teamplay.
 - **Équipes** : passer de 1v1 → 2v2 → FFA → Battle Royale.
 - **Rendu** : couleurs, arènes, effets visuels.
-- **Boucle & fin de match** : freeze 120 ms, ralenti ×0.35, bannière « VICTOIRE » puis fondu vers le début (400 ms).
+- **Boucle & fin de match** : animation de victoire puis segment ralenti configurable.
 - **Configuration externe** : `app/config.json` regroupe canvas, palette (bleu/orange), HUD (titre, watermark) et paramètres d'**end screen** (textes, slow-mo, fade...).
 - **FPS / résolution** : ajuster `canvas` dans `app/config.json`.
 

--- a/app/config.json
+++ b/app/config.json
@@ -9,6 +9,9 @@
     "end_screen": {
         "victory_text": "Victory : {weapon}",
         "subtitle_text": "{weapon} wins!",
-        "explosion_duration": 2.0
+        "explosion_duration": 2.0,
+        "pre_s": 1.0,
+        "post_s": 1.0,
+        "slow_factor": 0.5
     }
 }

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -37,6 +37,9 @@ class EndScreenConfig(BaseModel):  # type: ignore[misc]
     victory_text: str = "Victory : {weapon}"
     subtitle_text: str = "{weapon} remporte le duel !"
     explosion_duration: float = 2.0
+    pre_s: float = 1.0
+    post_s: float = 1.0
+    slow_factor: float = 0.5
 
 
 class Settings(BaseModel):  # type: ignore[misc]

--- a/app/game/match.py
+++ b/app/game/match.py
@@ -14,6 +14,7 @@ from app.core.types import Color, Damage, EntityId, ProjectileInfo, Vec2
 from app.render.hud import Hud
 from app.render.renderer import Renderer
 from app.video.recorder import Recorder
+from app.video.slowmo import append_slowmo_ending
 from app.weapons import weapon_registry
 from app.weapons.base import Weapon, WeaponEffect, WorldView
 from app.world.entities import Ball
@@ -358,4 +359,12 @@ def run_match(  # noqa: C901
         audio = engine.end_capture() if not display else None
         engine.stop_all()
         recorder.close(audio)
+        if not display and death_ts is not None:
+            append_slowmo_ending(
+                recorder.path,
+                death_ts,
+                settings.end_screen.pre_s,
+                settings.end_screen.post_s,
+                settings.end_screen.slow_factor,
+            )
         engine.shutdown()

--- a/app/video/slowmo.py
+++ b/app/video/slowmo.py
@@ -1,0 +1,88 @@
+"""Utilities to append a slow-motion replay at the end of a video."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import imageio_ffmpeg
+
+
+def append_slowmo_ending(
+    path: Path,
+    death_ts: float,
+    pre_s: float,
+    post_s: float,
+    slow_factor: float,
+) -> None:
+    """Append a slow-motion segment around ``death_ts`` to ``path``.
+
+    The original video remains intact and a replay covering ``pre_s`` seconds before
+    ``death_ts`` and ``post_s`` seconds after is extracted, slowed down by
+    ``slow_factor`` (``0 < slow_factor <= 1``) and appended to the end of the
+    video. Video and audio are processed so that their durations stay aligned.
+
+    Parameters
+    ----------
+    path:
+        Path to the video to post-process. The file must be an ``.mp4`` with an
+        audio track.
+    death_ts:
+        Timestamp of the fatal hit in seconds.
+    pre_s:
+        Number of seconds to include before ``death_ts``.
+    post_s:
+        Number of seconds to include after ``death_ts``.
+    slow_factor:
+        Playback speed for the slow-motion segment. ``0.5`` means half speed.
+    """
+    if slow_factor <= 0:
+        msg = "slow_factor must be positive"
+        raise ValueError(msg)
+
+    ffmpeg = imageio_ffmpeg.get_ffmpeg_exe()
+    start = max(0.0, death_ts - pre_s)
+    end = death_ts + post_s
+
+    slow_segment = path.with_suffix(".slow.mp4")
+    original = path.with_suffix(".orig.mp4")
+    path.rename(original)
+
+    vf = f"trim=start={start}:end={end},setpts=PTS/{slow_factor}"
+    af = (
+        f"atrim=start={start}:end={end},asetpts=PTS/{slow_factor},atempo={slow_factor}"
+    )
+    cmd_segment = [
+        ffmpeg,
+        "-y",
+        "-i",
+        str(original),
+        "-filter_complex",
+        f"[0:v]{vf}[v];[0:a]{af}[a]",
+        "-map",
+        "[v]",
+        "-map",
+        "[a]",
+        str(slow_segment),
+    ]
+    subprocess.run(cmd_segment, check=True, capture_output=True)
+
+    cmd_concat = [
+        ffmpeg,
+        "-y",
+        "-i",
+        str(original),
+        "-i",
+        str(slow_segment),
+        "-filter_complex",
+        "[0:v][0:a][1:v][1:a]concat=n=2:v=1:a=1[v][a]",
+        "-map",
+        "[v]",
+        "-map",
+        "[a]",
+        str(path),
+    ]
+    subprocess.run(cmd_concat, check=True, capture_output=True)
+
+    slow_segment.unlink(missing_ok=True)
+    original.unlink(missing_ok=True)

--- a/tests/integration/test_postprocessed_slowmo.py
+++ b/tests/integration/test_postprocessed_slowmo.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from app.core.config import settings
+from app.core.types import Damage, EntityId, Vec2
+from app.game.match import run_match
+from app.render.renderer import Renderer
+from app.video.recorder import Recorder
+from app.weapons import weapon_registry
+from app.weapons.base import Weapon, WorldView
+
+EVENT_TIME = 2.0
+
+
+class DelayedKillWeapon(Weapon):
+    """Weapon that kills the opponent at a fixed timestamp."""
+
+    def __init__(self) -> None:
+        super().__init__(name="instakill", cooldown=0.0, damage=Damage(200))
+        self._done = False
+        self._elapsed = 0.0
+
+    def _fire(
+        self, owner: EntityId, view: WorldView, direction: Vec2
+    ) -> None:  # pragma: no cover - stub
+        return None
+
+    def update(self, owner: EntityId, view: WorldView, dt: float) -> None:
+        if not self._done:
+            self._elapsed += dt
+            if self._elapsed >= EVENT_TIME:
+                enemy = view.get_enemy(owner)
+                if enemy is not None:
+                    view.deal_damage(enemy, self.damage, timestamp=EVENT_TIME)
+                    self._done = True
+        super().update(owner, view, dt)
+
+
+def _stream_duration(path: Path, stream: str) -> float:
+    ffprobe = "ffprobe"
+    result = subprocess.run(
+        [
+            ffprobe,
+            "-v",
+            "error",
+            "-select_streams",
+            f"{stream}:0",
+            "-show_entries",
+            "stream=duration",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+            str(path),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return float(result.stdout.strip())
+
+
+def test_postprocessed_slowmo(tmp_path: Path) -> None:
+    if "instakill" not in weapon_registry.names():
+        weapon_registry.register("instakill", DelayedKillWeapon)
+    out = tmp_path / "slowmo.mp4"
+    recorder = Recorder(settings.width, settings.height, settings.fps, out)
+    renderer = Renderer(settings.width, settings.height)
+    run_match("instakill", "instakill", recorder, renderer, max_seconds=5)
+    assert out.exists()
+    video_dur = _stream_duration(out, "v")
+    audio_dur = _stream_duration(out, "a")
+    assert abs(video_dur - audio_dur) < 0.1
+    assert 7.9 < video_dur < 8.1


### PR DESCRIPTION
## Summary
- append configurable slow-motion replay to generated videos
- expose slow-mo settings in configuration and apply after matches
- document and test slow-motion pipeline

## Testing
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `uv run bandit -r .` *(fails: bandit: command not found)*
- `uv run pip-audit` *(fails: pip-audit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cb04ae1c832a8bac4d7e7b568b44