### PR TITLE
feat: scale HUD health bars with surface size

### DIFF
--- a/app/render/hud.py
+++ b/app/render/hud.py
@@ -8,6 +8,9 @@ from app.render.theme import Theme, draw_horizontal_gradient
 class Hud:
     """Draw heads-up display elements."""
 
+    BAR_WIDTH_RATIO: float = 0.3
+    BAR_HEIGHT_RATIO: float = 0.03
+
     def __init__(self, theme: Theme) -> None:
         pygame.font.init()
         self.theme = theme
@@ -24,10 +27,14 @@ class Hud:
     def draw_hp_bars(
         self, surface: pygame.Surface, hp_a: float, hp_b: float, labels: tuple[str, str]
     ) -> None:
-        """Draw two symmetrical health bars with labels."""
+        """Draw two symmetrical health bars with labels.
 
-        bar_width = 300
-        bar_height = 25
+        The bar dimensions scale with the given surface so that the HUD adapts
+        to different resolutions.
+        """
+
+        bar_width = max(1, int(surface.get_width() * self.BAR_WIDTH_RATIO))
+        bar_height = max(1, int(surface.get_height() * self.BAR_HEIGHT_RATIO))
         margin = 40
 
         # Left bar (team A)


### PR DESCRIPTION
## Summary
- scale HUD health bar dimensions based on surface size
- test HUD health bar scaling and dynamic background color

## Testing
- `uv run ruff check .`
- `uv run ruff format --check app/render/hud.py tests/test_hud.py`
- `uv run mypy .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install pydantic imageio-ffmpeg pymunk` *(fails: Could not find a version that satisfies the requirement pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_68b374fcb430832a8906a57356de5aac