### PR TITLE
feat: interpolate HUD health bars

### DIFF
--- a/app/render/hud.py
+++ b/app/render/hud.py
@@ -10,6 +10,7 @@ class Hud:
 
     BAR_WIDTH_RATIO: float = 0.3
     BAR_HEIGHT_RATIO: float = 0.03
+    HP_INTERPOLATION_RATE: float = 0.2
 
     def __init__(self, theme: Theme) -> None:
         pygame.font.init()
@@ -17,6 +18,24 @@ class Hud:
         self.title_font = pygame.font.Font(None, 72)
         self.bar_font = pygame.font.Font(None, 48)
         self.watermark_font = pygame.font.Font(None, 36)
+        self.current_hp_a = 1.0
+        self.current_hp_b = 1.0
+
+    def update_hp(self, hp_a: float, hp_b: float) -> None:
+        """Interpolate the displayed health toward the target values.
+
+        Parameters
+        ----------
+        hp_a: float
+            Target health ratio for team A in ``[0, 1]``.
+        hp_b: float
+            Target health ratio for team B in ``[0, 1]``.
+        """
+
+        hp_a = max(0.0, min(1.0, hp_a))
+        hp_b = max(0.0, min(1.0, hp_b))
+        self.current_hp_a += (hp_a - self.current_hp_a) * self.HP_INTERPOLATION_RATE
+        self.current_hp_b += (hp_b - self.current_hp_b) * self.HP_INTERPOLATION_RATE
 
     def draw_title(self, surface: pygame.Surface, text: str) -> None:
         """Render the main title centered at the top of the screen."""
@@ -37,10 +56,12 @@ class Hud:
         bar_height = max(1, int(surface.get_height() * self.BAR_HEIGHT_RATIO))
         margin = 40
 
+        self.update_hp(hp_a, hp_b)
+
         # Left bar (team A)
         left_rect = pygame.Rect(margin, 120, bar_width, bar_height)
         pygame.draw.rect(surface, self.theme.hp_empty, left_rect)
-        width_a = int(bar_width * hp_a)
+        width_a = int(bar_width * self.current_hp_a)
         if width_a > 0:
             filled_rect = pygame.Rect(left_rect.x, left_rect.y, width_a, bar_height)
             draw_horizontal_gradient(surface, filled_rect, *self.theme.team_a.hp_gradient)
@@ -52,7 +73,7 @@ class Hud:
             surface.get_width() - margin - bar_width, 120, bar_width, bar_height
         )
         pygame.draw.rect(surface, self.theme.hp_empty, right_rect)
-        width_b = int(bar_width * hp_b)
+        width_b = int(bar_width * self.current_hp_b)
         if width_b > 0:
             filled_rect = pygame.Rect(
                 right_rect.x + bar_width - width_b, right_rect.y, width_b, bar_height

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -24,12 +24,14 @@ def test_hp_bar_background_color() -> None:
     renderer = Renderer(800, 300)
     hud = Hud(settings.theme)
     renderer.clear()
-    hud.draw_hp_bars(renderer.surface, 0.5, 0.25, ("A", "B"))
+    for _ in range(25):
+        hud.draw_hp_bars(renderer.surface, 0.5, 0.25, ("A", "B"))
     empty = settings.theme.hp_empty
     bar_width = int(renderer.surface.get_width() * Hud.BAR_WIDTH_RATIO)
     bar_height = int(renderer.surface.get_height() * Hud.BAR_HEIGHT_RATIO)
     y = 120 + bar_height // 2
-    left_empty_x = 40 + int(bar_width * 0.5) + 1
+    width_a = int(bar_width * hud.current_hp_a)
+    left_empty_x = 40 + width_a + 1
     assert renderer.surface.get_at((left_empty_x, y))[:3] == empty
     right_rect_start = renderer.surface.get_width() - 40 - bar_width
     assert renderer.surface.get_at((right_rect_start + 1, y))[:3] == empty
@@ -66,3 +68,11 @@ def test_hp_bars_scale_with_surface(monkeypatch: pytest.MonkeyPatch) -> None:
     assert captured_large[0].width == int(large_surface.get_width() * Hud.BAR_WIDTH_RATIO)
     assert captured_small[0].height == int(small_surface.get_height() * Hud.BAR_HEIGHT_RATIO)
     assert captured_large[0].height == int(large_surface.get_height() * Hud.BAR_HEIGHT_RATIO)
+
+
+def test_hp_interpolation_converges() -> None:
+    hud = Hud(settings.theme)
+    for _ in range(25):
+        hud.update_hp(0.0, 0.5)
+    assert hud.current_hp_a == pytest.approx(0.0, abs=1e-2)
+    assert hud.current_hp_b == pytest.approx(0.5, abs=1e-2)


### PR DESCRIPTION
## Summary
- smooth HUD health bars by interpolating displayed HP toward target values each frame
- add regression tests for HUD bar scaling and health interpolation

## Testing
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic', 'imageio_ffmpeg', 'pymunk')*

------
https://chatgpt.com/codex/tasks/task_e_68b376430f8c832a819c4df3fd320d14