### PR TITLE
feat: add multi-tone theme and low HP warning

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -47,9 +47,16 @@ class Settings(BaseModel):  # type: ignore[misc]
 
     canvas: Canvas = Canvas()
     theme: Theme = Theme(
-        team_a=TeamColors(primary=(0, 102, 204), hp_gradient=((102, 178, 255), (0, 51, 102))),
-        team_b=TeamColors(primary=(255, 102, 0), hp_gradient=((255, 178, 102), (102, 51, 0))),
+        team_a=TeamColors(
+            primary=(0, 128, 255),
+            hp_gradient=((0, 128, 255), (0, 64, 128), (0, 0, 64)),
+        ),
+        team_b=TeamColors(
+            primary=(255, 128, 0),
+            hp_gradient=((255, 128, 0), (128, 64, 0), (64, 32, 0)),
+        ),
         hp_empty=(51, 51, 51),
+        hp_warning=(255, 0, 0),
     )
     hud: HudConfig = HudConfig()
     end_screen: EndScreenConfig = EndScreenConfig()

--- a/app/render/hud.py
+++ b/app/render/hud.py
@@ -11,6 +11,7 @@ class Hud:
     BAR_WIDTH_RATIO: float = 0.45
     BAR_HEIGHT_RATIO: float = 0.03
     HP_INTERPOLATION_RATE: float = 0.2
+    LOW_HP_THRESHOLD: float = 0.3
 
     def __init__(self, theme: Theme) -> None:
         pygame.font.init()
@@ -64,7 +65,12 @@ class Hud:
         width_a = int(bar_width * self.current_hp_a)
         if width_a > 0:
             filled_rect = pygame.Rect(left_rect.x, left_rect.y, width_a, bar_height)
-            draw_horizontal_gradient(surface, filled_rect, *self.theme.team_a.hp_gradient)
+            colors_a = (
+                (self.theme.hp_warning,)
+                if self.current_hp_a < self.LOW_HP_THRESHOLD
+                else self.theme.team_a.hp_gradient
+            )
+            draw_horizontal_gradient(surface, filled_rect, colors_a)
         label_a = self.bar_font.render(labels[0], True, (255, 255, 255))
         surface.blit(label_a, (left_rect.x, left_rect.y - 30))
 
@@ -78,8 +84,12 @@ class Hud:
             filled_rect = pygame.Rect(
                 right_rect.x + bar_width - width_b, right_rect.y, width_b, bar_height
             )
-            grad_start, grad_end = self.theme.team_b.hp_gradient
-            draw_horizontal_gradient(surface, filled_rect, grad_end, grad_start)
+            colors_b = (
+                (self.theme.hp_warning,)
+                if self.current_hp_b < self.LOW_HP_THRESHOLD
+                else tuple(reversed(self.theme.team_b.hp_gradient))
+            )
+            draw_horizontal_gradient(surface, filled_rect, colors_b)
         label_b = self.bar_font.render(labels[1], True, (255, 255, 255))
         surface.blit(
             label_b,

--- a/app/render/theme.py
+++ b/app/render/theme.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 import pygame
@@ -12,7 +13,7 @@ class TeamColors:
     """Color definitions for a team."""
 
     primary: Color
-    hp_gradient: tuple[Color, Color]
+    hp_gradient: tuple[Color, ...]
 
 
 @dataclass(frozen=True)
@@ -27,23 +28,47 @@ class Theme:
         Colors for team B.
     hp_empty:
         Color displayed for lost health.
+    hp_warning:
+        Color used when a player is in the danger zone.
     """
 
     team_a: TeamColors
     team_b: TeamColors
     hp_empty: Color
+    hp_warning: Color
 
 
 def draw_horizontal_gradient(
     surface: pygame.Surface,
     rect: pygame.Rect,
-    start: Color,
-    end: Color,
+    colors: Sequence[Color],
 ) -> None:
-    """Draw a left-to-right linear gradient on the given surface."""
+    """Draw a left-to-right linear gradient on the given surface.
 
+    Parameters
+    ----------
+    surface:
+        Target drawing surface.
+    rect:
+        Area where the gradient is rendered.
+    colors:
+        Sequence of colors defining the gradient stops. A single color
+        fills ``rect`` uniformly.
+    """
+
+    if not colors:
+        return
+    if len(colors) == 1:
+        pygame.draw.rect(surface, colors[0], rect)
+        return
+
+    segments = len(colors) - 1
     for x in range(rect.width):
-        ratio = x / rect.width
+        pos = x / rect.width * segments
+        index = min(int(pos), segments - 1)
+        ratio = pos - index
+        start = colors[index]
+        end = colors[index + 1]
         r = int(start[0] + (end[0] - start[0]) * ratio)
         g = int(start[1] + (end[1] - start[1]) * ratio)
         b = int(start[2] + (end[2] - start[2]) * ratio)

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -37,6 +37,21 @@ def test_hp_bar_background_color() -> None:
     assert renderer.surface.get_at((right_rect_start + 1, y))[:3] == empty
 
 
+def test_hp_bar_low_hp_color() -> None:
+    renderer = Renderer(800, 300)
+    hud = Hud(settings.theme)
+    renderer.clear()
+    for _ in range(25):
+        hud.draw_hp_bars(renderer.surface, 0.2, 0.8, ("A", "B"))
+    bar_width = int(renderer.surface.get_width() * Hud.BAR_WIDTH_RATIO)
+    bar_height = int(renderer.surface.get_height() * Hud.BAR_HEIGHT_RATIO)
+    x = 40 + bar_width // 10
+    y = 120 + bar_height // 2
+    assert renderer.surface.get_at((x, y))[:3] == settings.theme.hp_warning
+    right_x = renderer.surface.get_width() - 40 - bar_width + bar_width // 2
+    assert renderer.surface.get_at((right_x, y))[:3] != settings.theme.hp_warning
+
+
 def test_hp_bars_scale_with_surface(monkeypatch: pytest.MonkeyPatch) -> None:
     hud = Hud(settings.theme)
 


### PR DESCRIPTION
## Summary
- add saturated multi-tone gradients and warning color to theme
- highlight low health with warning color in HUD
- cover low-health colour change with unit test

## Testing
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_68b3777ab2a0832a9a198dc24a3ba139