### PR TITLE
feat: align HP bar labels and show VS marker

### DIFF
--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -91,3 +91,22 @@ def test_hp_interpolation_converges() -> None:
         hud.update_hp(0.0, 0.5)
     assert hud.current_hp_a == pytest.approx(0.0, abs=1e-2)
     assert hud.current_hp_b == pytest.approx(0.5, abs=1e-2)
+
+
+def test_hp_label_and_vs_positions() -> None:
+    hud = Hud(settings.theme)
+    surface = pygame.Surface((800, 600))
+    label_a_rect, label_b_rect, vs_rect = hud.draw_hp_bars(surface, 1.0, 1.0, ("Alpha", "Beta"))
+
+    bar_width = int(surface.get_width() * Hud.BAR_WIDTH_RATIO)
+    bar_height = int(surface.get_height() * Hud.BAR_HEIGHT_RATIO)
+    left_rect = pygame.Rect(40, 120, bar_width, bar_height)
+    right_rect = pygame.Rect(surface.get_width() - 40 - bar_width, 120, bar_width, bar_height)
+
+    assert label_a_rect.left == left_rect.left + Hud.LABEL_PADDING
+    assert label_a_rect.right <= left_rect.right - Hud.LABEL_PADDING
+    assert label_b_rect.right == right_rect.right - Hud.LABEL_PADDING
+    assert label_b_rect.left >= right_rect.left + Hud.LABEL_PADDING
+
+    assert vs_rect.centerx == surface.get_width() // 2
+    assert vs_rect.centery == left_rect.centery


### PR DESCRIPTION
## Summary
- align health-bar labels inside bars and clamp for readability
- add centered "VS" marker between bars
- test label and marker positions

## Testing
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68b37917c268832aaa9ec8fff5322cd6