### PR TITLE
feat: add randomized ball hit sounds

### DIFF
--- a/app/audio/balls.py
+++ b/app/audio/balls.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import random
 from pathlib import Path
 
 from .engine import AudioEngine
@@ -20,11 +21,22 @@ class BallAudio:
         engine is used.
     """
 
-    def __init__(self, *, base_dir: str = "assets/balls", engine: AudioEngine | None = None) -> None:
+    def __init__(
+        self, *, base_dir: str = "assets/balls", engine: AudioEngine | None = None
+    ) -> None:
         self._engine = engine or get_default_engine()
         base = Path(base_dir)
         self._explode_path = str(base / "explose.ogg")
+        self._hit_paths: list[str] = [
+            str(base / "hit-a.ogg"),
+            str(base / "hit-b.ogg"),
+            str(base / "hit-c.ogg"),
+        ]
 
     def on_explode(self, timestamp: float | None = None) -> None:
         """Play the explosion sound when the ball is destroyed."""
         self._engine.play_variation(self._explode_path, timestamp=timestamp)
+
+    def on_hit(self, timestamp: float | None = None) -> None:
+        """Play a random hit sound when the ball takes damage."""
+        self._engine.play_variation(random.choice(self._hit_paths), timestamp=timestamp)

--- a/app/game/match.py
+++ b/app/game/match.py
@@ -87,6 +87,7 @@ class _MatchView(WorldView):
                 p.alive = not p.ball.take_damage(damage)
                 if p.alive:
                     self.renderer.add_impact(pos)
+                    p.audio.on_hit(timestamp=timestamp)
                 else:
                     self.renderer.add_impact(pos, duration=2.0)
                     p.audio.on_explode(timestamp=timestamp)
@@ -139,6 +140,8 @@ class _MatchView(WorldView):
                 pos = (float(eff.body.position.x), float(eff.body.position.y))
                 vel = (float(eff.body.velocity.x), float(eff.body.velocity.y))
                 yield ProjectileInfo(eff.owner, pos, vel)
+
+
 def run_match(  # noqa: C901
     weapon_a: str,
     weapon_b: str,
@@ -341,9 +344,7 @@ def run_match(  # noqa: C901
                 renderer.present()
                 if not display:
                     frame_surface = renderer.surface.copy()
-                    recorder.add_frame(
-                        np.swapaxes(pygame.surfarray.array3d(frame_surface), 0, 1)
-                    )
+                    recorder.add_frame(np.swapaxes(pygame.surfarray.array3d(frame_surface), 0, 1))
             return winner_weapon
 
         if len([p for p in players if p.alive]) >= 2 and elapsed >= max_seconds:

--- a/tests/test_audio_ball.py
+++ b/tests/test_audio_ball.py
@@ -35,3 +35,17 @@ def test_ball_explosion_event() -> None:
     audio.on_explode(timestamp=0.5)
     assert any(path.endswith("explose.ogg") for path in engine.played)
     assert engine.timestamps[0] == 0.5
+
+
+def test_ball_hit_event(monkeypatch: Any) -> None:
+    engine = StubAudioEngine()
+    audio = BallAudio(engine=cast(AudioEngine, engine))
+
+    def fake_choice(options: list[str]) -> str:
+        assert len(options) == 3
+        return options[1]
+
+    monkeypatch.setattr("app.audio.balls.random.choice", fake_choice)
+    audio.on_hit(timestamp=1.25)
+    assert engine.played[0].endswith("hit-b.ogg")
+    assert engine.timestamps[0] == 1.25

--- a/tests/test_ball_hit_sound.py
+++ b/tests/test_ball_hit_sound.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+pygame_stub = cast(Any, types.ModuleType("pygame"))
+pygame_stub.Surface = object
+pygame_stub.surfarray = types.ModuleType("surfarray")
+pygame_stub.surfarray.array3d = lambda *args, **kwargs: None
+pygame_stub.sndarray = types.ModuleType("sndarray")
+pygame_stub.mixer = types.ModuleType("mixer")
+sys.modules.setdefault("pygame", pygame_stub)
+sys.modules.setdefault("pygame.sndarray", pygame_stub.sndarray)
+sys.modules.setdefault("pygame.mixer", pygame_stub.mixer)
+
+np_stub = cast(Any, types.ModuleType("numpy"))
+sys.modules.setdefault("numpy", np_stub)
+
+from app.audio import BallAudio  # noqa: E402
+from app.core.types import Damage  # noqa: E402
+from app.game.match import Player, _MatchView  # noqa: E402
+from app.world.entities import Ball  # noqa: E402
+from app.world.physics import PhysicsWorld  # noqa: E402
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from app.ai.policy import SimplePolicy
+    from app.audio import AudioEngine
+    from app.render.renderer import Renderer
+    from app.weapons.base import Weapon
+
+
+class DummyRenderer:
+    def add_impact(
+        self, pos: tuple[float, float], duration: float = 0.08
+    ) -> None:  # pragma: no cover - stub
+        return
+
+    def trigger_blink(
+        self, color: tuple[int, int, int], intensity: int
+    ) -> None:  # pragma: no cover - stub
+        return
+
+
+class DummyEngine:
+    def __init__(self) -> None:
+        self.paths: list[str] = []
+        self.timestamps: list[float | None] = []
+
+    def play_variation(
+        self, path: str, volume: float | None = None, timestamp: float | None = None
+    ) -> object:
+        self.paths.append(path)
+        self.timestamps.append(timestamp)
+        return object()
+
+
+def test_deal_damage_triggers_hit_sound(monkeypatch: Any) -> None:
+    world = PhysicsWorld()
+    ball = Ball.spawn(world, (0.0, 0.0))
+    weapon = cast("Weapon", object())
+    policy = cast("SimplePolicy", object())
+    dummy_engine = DummyEngine()
+    engine = cast("AudioEngine", dummy_engine)
+    audio = BallAudio(engine=engine)
+    player = Player(ball.eid, ball, weapon, policy, (1.0, 0.0), (255, 255, 255), audio)
+    renderer = cast("Renderer", DummyRenderer())
+    view = _MatchView([player], [], world, renderer, engine)
+
+    def fake_choice(options: list[str]) -> str:
+        assert len(options) == 3
+        return options[2]
+
+    monkeypatch.setattr("app.audio.balls.random.choice", fake_choice)
+    view.deal_damage(player.eid, Damage(amount=10.0), timestamp=2.5)
+
+    path = Path("assets/balls/hit-c.ogg").as_posix()
+    assert path in dummy_engine.paths
+    idx = dummy_engine.paths.index(path)
+    assert dummy_engine.timestamps[idx] == 2.5


### PR DESCRIPTION
## Summary
- play one of three new hit sounds with pitch variation whenever a ball takes damage
- trigger hit sounds during match damage resolution
- add unit tests for ball hit audio behavior

## Testing
- `uv run ruff check app/audio/balls.py app/game/match.py tests/test_audio_ball.py tests/test_ball_hit_sound.py`
- `uv run mypy app/audio/balls.py app/game/match.py tests/test_audio_ball.py tests/test_ball_hit_sound.py`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68b37c731978832a868e4ed83bcee7e9