### PR TITLE
Remove HUD title and apply FightKick weapon font

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -27,7 +27,7 @@ class Canvas(BaseModel):  # type: ignore[misc]
 class HudConfig(BaseModel):  # type: ignore[misc]
     """Texts displayed in the HUD."""
 
-    title: str = "NostradaBalls"
+    title: str = ""
     watermark: str = "@nostradaballs"
 
 

--- a/app/render/hud.py
+++ b/app/render/hud.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pygame
 
-from app.render.sprites import load_sprite
+from app.render.sprites import ASSET_DIR, load_sprite
 from app.render.theme import Theme, draw_horizontal_gradient
 
 
@@ -21,7 +21,8 @@ class Hud:
         pygame.font.init()
         self.theme = theme
         self.title_font = pygame.font.Font(None, 72)
-        self.bar_font = pygame.font.Font(None, 48)
+        weapon_font_path = (ASSET_DIR / "fonts" / "FightKickDemoRegular.ttf").as_posix()
+        self.bar_font = pygame.font.Font(weapon_font_path, 48)
         self.watermark_font = pygame.font.Font(None, 36)
         self.current_hp_a = 1.0
         self.current_hp_b = 1.0
@@ -45,6 +46,8 @@ class Hud:
 
     def draw_title(self, surface: pygame.Surface, text: str) -> None:
         """Render the main title centered at the top of the screen."""
+        if not text:
+            return
         title = self.title_font.render(text, True, (255, 255, 255))
         rect = title.get_rect(center=(surface.get_width() // 2, 60))
         surface.blit(title, rect)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,11 @@ def test_load_settings_from_file(tmp_path: Path) -> None:
     assert settings.hud.watermark == "Y"
 
 
+def test_default_hud_title() -> None:
+    default_settings = config.Settings()
+    assert default_settings.hud.title == ""
+
+
 def test_default_victory_text() -> None:
     default_settings = config.Settings()
     assert default_settings.end_screen.victory_text == "Victory : {weapon}"


### PR DESCRIPTION
## Summary
- clear HUD title text to remove on-screen label
- style weapon labels using FightKickDemoRegular font
- skip title rendering when no text is provided
- verify blank HUD title default via unit test

## Testing
- `uv run pre-commit run --files app/core/config.py app/render/hud.py tests/test_config.py` *(fails: pre-commit missing and installation attempt could not fetch dependency)*
- `uv run mypy app/core/config.py app/render/hud.py tests/test_config.py`
- `uv run pytest` *(fails: missing modules pydantic, imageio_ffmpeg, pymunk, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b37fa65340832a8ec54f5e0f128a6a