### PR TITLE
feat: animate health bar gradients

### DIFF
--- a/app/render/hud.py
+++ b/app/render/hud.py
@@ -17,9 +17,22 @@ class Hud:
     VS_WIDTH_RATIO: float = 0.2
     VS_MARGIN: int = -100
 
-    def __init__(self, theme: Theme) -> None:
+    def __init__(self, theme: Theme, gradient_speed: float = 0.01) -> None:
+        """Initialize the HUD renderer.
+
+        Parameters
+        ----------
+        theme:
+            Color palette used for rendering.
+        gradient_speed:
+            Increment applied to the internal gradient phase at each call to
+            :meth:`draw_hp_bars`. ``0`` disables animation.
+        """
+
         pygame.font.init()
         self.theme = theme
+        self.gradient_speed = gradient_speed
+        self.gradient_phase = 0.0
         self.title_font = pygame.font.Font(None, 72)
         self.bar_font = pygame.font.Font(None, 48)
         self.watermark_font = pygame.font.Font(None, 36)
@@ -92,6 +105,7 @@ class Hud:
         bar_height = max(1, int(surface.get_height() * self.BAR_HEIGHT_RATIO))
         margin = 40
 
+        self.gradient_phase = (self.gradient_phase + self.gradient_speed) % 1.0
         self.update_hp(hp_a, hp_b)
 
         # Left bar (team A)
@@ -105,7 +119,9 @@ class Hud:
                 if self.current_hp_a < self.LOW_HP_THRESHOLD
                 else self.theme.team_a.hp_gradient
             )
-            draw_horizontal_gradient(surface, filled_rect, colors_a)
+            draw_horizontal_gradient(
+                surface, filled_rect, colors_a, phase=self.gradient_phase
+            )
         label_a = self.bar_font.render(labels[0], True, (255, 255, 255))
         label_a_rect = label_a.get_rect()
         label_a_rect.centery = left_rect.centery
@@ -130,7 +146,9 @@ class Hud:
                 if self.current_hp_b < self.LOW_HP_THRESHOLD
                 else tuple(reversed(self.theme.team_b.hp_gradient))
             )
-            draw_horizontal_gradient(surface, filled_rect, colors_b)
+            draw_horizontal_gradient(
+                surface, filled_rect, colors_b, phase=self.gradient_phase
+            )
         label_b = self.bar_font.render(labels[1], True, (255, 255, 255))
         label_b_rect = label_b.get_rect()
         label_b_rect.centery = right_rect.centery

--- a/app/render/theme.py
+++ b/app/render/theme.py
@@ -42,6 +42,7 @@ def draw_horizontal_gradient(
     surface: pygame.Surface,
     rect: pygame.Rect,
     colors: Sequence[Color],
+    phase: float = 0.0,
 ) -> None:
     """Draw a left-to-right linear gradient on the given surface.
 
@@ -54,6 +55,10 @@ def draw_horizontal_gradient(
     colors:
         Sequence of colors defining the gradient stops. A single color
         fills ``rect`` uniformly.
+    phase:
+        Normalized offset applied to the gradient. ``0`` renders the
+        gradient in its original position while values in ``[0, 1)`` shift
+        it horizontally and wrap around.
     """
 
     if not colors:
@@ -64,7 +69,8 @@ def draw_horizontal_gradient(
 
     segments = len(colors) - 1
     for x in range(rect.width):
-        pos = x / rect.width * segments
+        t = (x / rect.width + phase) % 1.0
+        pos = t * segments
         index = min(int(pos), segments - 1)
         ratio = pos - index
         start = colors[index]

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -111,3 +111,30 @@ def test_hp_label_and_vs_positions() -> None:
     assert vs_rect.centerx == surface.get_width() // 2
     assert vs_rect.bottom == left_rect.top - Hud.VS_MARGIN
     assert vs_rect.width == int(surface.get_width() * Hud.VS_WIDTH_RATIO)
+
+
+def test_gradient_phase_increments() -> None:
+    surface = pygame.Surface((800, 300))
+    hud = Hud(settings.theme, gradient_speed=0.2)
+    hud.draw_hp_bars(surface, 1.0, 1.0, ("A", "B"))
+    assert hud.gradient_phase == pytest.approx(0.2, abs=1e-6)
+    hud.draw_hp_bars(surface, 1.0, 1.0, ("A", "B"))
+    assert hud.gradient_phase == pytest.approx(0.4, abs=1e-6)
+
+
+def test_gradient_phase_shifts_colors() -> None:
+    surface = pygame.Surface((800, 300))
+    hud = Hud(settings.theme, gradient_speed=0.25)
+    bar_width = int(surface.get_width() * Hud.BAR_WIDTH_RATIO)
+    bar_height = int(surface.get_height() * Hud.BAR_HEIGHT_RATIO)
+    x = 40 + bar_width // 4
+    y = 120 + bar_height // 2
+
+    hud.draw_hp_bars(surface, 1.0, 1.0, ("A", "B"))
+    color1 = surface.get_at((x, y))[:3]
+
+    surface.fill((0, 0, 0))
+    hud.draw_hp_bars(surface, 1.0, 1.0, ("A", "B"))
+    color2 = surface.get_at((x, y))[:3]
+
+    assert color1 != color2


### PR DESCRIPTION
## Summary
- add phase offset to draw_horizontal_gradient
- animate HUD health bar gradients with configurable speed
- test gradient phase increment and color shift

## Testing
- `uv run ruff check app/render/theme.py app/render/hud.py tests/test_hud.py`
- `uv run mypy app/render/theme.py app/render/hud.py tests/test_hud.py`
- `uv run pytest tests/test_hud.py::test_gradient_phase_increments -q` *(fails: No module named 'pygame')*
- `uv pip install pytest` *(fails: tunnel error: unsuccessful)*
- `uv run python manual verification script`


------
https://chatgpt.com/codex/tasks/task_e_68b380ba82b0832a8c22483a43388490