### PR TITLE
feat: animate HP bar gradient with ping-pong cycle

### DIFF
--- a/app/render/hud.py
+++ b/app/render/hud.py
@@ -96,7 +96,10 @@ class Hud:
         """Draw two symmetrical health bars with labels.
 
         The bar dimensions scale with the given surface so that the HUD adapts
-        to different resolutions.
+        to different resolutions. A horizontal gradient fills the bars and
+        oscillates using a ping-pong cycle. The gradient offset increases until
+        it reaches ``1.0`` and then reverses back toward ``0.0`` to create a
+        back-and-forth animation.
 
         Returns
         -------
@@ -108,7 +111,8 @@ class Hud:
         bar_height = max(1, int(surface.get_height() * self.BAR_HEIGHT_RATIO))
         margin = 40
 
-        self.gradient_phase = (self.gradient_phase + self.gradient_speed) % 1.0
+        self.gradient_phase = (self.gradient_phase + self.gradient_speed) % 2.0
+        phase = self.gradient_phase if self.gradient_phase <= 1.0 else 2.0 - self.gradient_phase
         self.update_hp(hp_a, hp_b)
 
         # Left bar (team A)
@@ -122,9 +126,7 @@ class Hud:
                 if self.current_hp_a < self.LOW_HP_THRESHOLD
                 else self.theme.team_a.hp_gradient
             )
-            draw_horizontal_gradient(
-                surface, filled_rect, colors_a, phase=self.gradient_phase
-            )
+            draw_horizontal_gradient(surface, filled_rect, colors_a, phase=phase)
         label_a = self.bar_font.render(labels[0], True, (255, 255, 255))
         label_a_rect = label_a.get_rect()
         label_a_rect.centery = left_rect.centery
@@ -149,9 +151,7 @@ class Hud:
                 if self.current_hp_b < self.LOW_HP_THRESHOLD
                 else tuple(reversed(self.theme.team_b.hp_gradient))
             )
-            draw_horizontal_gradient(
-                surface, filled_rect, colors_b, phase=self.gradient_phase
-            )
+            draw_horizontal_gradient(surface, filled_rect, colors_b, phase=phase)
         label_b = self.bar_font.render(labels[1], True, (255, 255, 255))
         label_b_rect = label_b.get_rect()
         label_b_rect.centery = right_rect.centery

--- a/app/render/theme.py
+++ b/app/render/theme.py
@@ -58,7 +58,9 @@ def draw_horizontal_gradient(
     phase:
         Normalized offset applied to the gradient. ``0`` renders the
         gradient in its original position while values in ``[0, 1)`` shift
-        it horizontally and wrap around.
+        it horizontally and wrap around. Animating ``phase`` with a
+        ping-pong pattern (``0 → 1 → 0``) produces a smooth back-and-forth
+        motion.
     """
 
     if not colors:

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -115,16 +115,17 @@ def test_hp_label_and_vs_positions() -> None:
 
 def test_gradient_phase_increments() -> None:
     surface = pygame.Surface((800, 300))
-    hud = Hud(settings.theme, gradient_speed=0.2)
+    hud = Hud(settings.theme, gradient_speed=1.2)
     hud.draw_hp_bars(surface, 1.0, 1.0, ("A", "B"))
-    assert hud.gradient_phase == pytest.approx(0.2, abs=1e-6)
+    assert hud.gradient_phase == pytest.approx(1.2, abs=1e-6)
     hud.draw_hp_bars(surface, 1.0, 1.0, ("A", "B"))
+    # Phase cycles modulo 2.0
     assert hud.gradient_phase == pytest.approx(0.4, abs=1e-6)
 
 
 def test_gradient_phase_shifts_colors() -> None:
     surface = pygame.Surface((800, 300))
-    hud = Hud(settings.theme, gradient_speed=0.25)
+    hud = Hud(settings.theme, gradient_speed=0.5)
     bar_width = int(surface.get_width() * Hud.BAR_WIDTH_RATIO)
     bar_height = int(surface.get_height() * Hud.BAR_HEIGHT_RATIO)
     x = 40 + bar_width // 4
@@ -137,4 +138,9 @@ def test_gradient_phase_shifts_colors() -> None:
     hud.draw_hp_bars(surface, 1.0, 1.0, ("A", "B"))
     color2 = surface.get_at((x, y))[:3]
 
+    surface.fill((0, 0, 0))
+    hud.draw_hp_bars(surface, 1.0, 1.0, ("A", "B"))
+    color3 = surface.get_at((x, y))[:3]
+
     assert color1 != color2
+    assert color1 == color3


### PR DESCRIPTION
## Summary
- animate HP bar gradient with ping-pong phase cycle
- document ping-pong usage in HUD and gradient helper
- adjust HUD gradient tests for new cycle

## Testing
- `uv run ruff format app/render/hud.py app/render/theme.py tests/test_hud.py`
- `uv run ruff check app/render/hud.py app/render/theme.py tests/test_hud.py`
- `uv run mypy app/render/hud.py app/render/theme.py tests/test_hud.py`
- `uv sync --all-extras --dev` *(failed: tunnel error)*
- `uv run pytest` *(failed: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68b383c25c34832a92a692786c971343