### PR TITLE
fix: support display mode without recorder path

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -4,7 +4,7 @@ import random
 import re
 from datetime import datetime
 from pathlib import Path
-from typing import Annotated, cast
+from typing import Annotated
 
 import typer
 
@@ -38,7 +38,8 @@ def run(
 
     driver = None if display else "dummy"
 
-    recorder: Recorder | NullRecorder | None = None
+    recorder: Recorder
+    renderer: Renderer
     temp_path: Path | None = None
     winner: str | None = None
 
@@ -57,11 +58,16 @@ def run(
             renderer = Renderer(settings.width, settings.height)
 
         try:
-            winner = run_match(weapon_a, weapon_b, cast(Recorder, recorder), renderer)
+            winner = run_match(
+                weapon_a,
+                weapon_b,
+                recorder,
+                renderer,
+                display=display,
+            )
         except MatchTimeout as exc:
-            path = getattr(recorder, "path", None)
-            if path is not None and path.exists():
-                path.unlink()
+            if not display and recorder.path.exists():
+                recorder.path.unlink()
             typer.echo(f"Error: {exc}", err=True)
             raise typer.Exit(code=1) from None
 

--- a/app/video/recorder.py
+++ b/app/video/recorder.py
@@ -72,11 +72,18 @@ class Recorder:
         audio_path.unlink(missing_ok=True)
 
 
-class NullRecorder:
+class NullRecorder(Recorder):
     """Recorder that discards frames and writes nothing."""
+
+    def __init__(self) -> None:
+        # ``path`` is required by :class:`Recorder` but is never used here.
+        # It defaults to the current directory to keep the attribute typed.
+        self.path = Path()
 
     def add_frame(self, _frame: np.ndarray) -> None:  # noqa: D401 - same interface
         """Ignore a pre-rendered frame."""
 
-    def close(self, _audio: np.ndarray | None = None) -> None:  # noqa: D401 - same interface
+    def close(
+        self, _audio: np.ndarray | None = None, rate: int = 48_000
+    ) -> None:  # noqa: D401 - same interface
         """No-op close method."""

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -10,12 +10,13 @@ from pytest import MonkeyPatch
 from typer.testing import CliRunner
 
 import app.audio.weapons as weapons
+import app.cli as cli_module
 from app.audio import reset_default_engine
 from app.audio.engine import AudioEngine
 from app.cli import app
 from app.core.config import settings
 from app.render.renderer import Renderer
-from app.video.recorder import Recorder
+from app.video.recorder import NullRecorder, Recorder
 
 
 def test_run_creates_video(tmp_path: Path) -> None:
@@ -97,27 +98,35 @@ def test_run_display_mode_no_file(monkeypatch: MonkeyPatch) -> None:
 
     monkeypatch.setattr(Renderer, "__init__", spy_init)
 
-    runner = CliRunner()
-    result = runner.invoke(
-        app,
-        [
-            "run",
-            "--seed",
-            "1",
-            "--weapon-a",
-            "katana",
-            "--weapon-b",
-            "shuriken",
-            "--display",
-        ],
-    )
+    class GuardedNullRecorder(NullRecorder):
+        @property
+        def path(self) -> Path:  # type: ignore[override]
+            raise AssertionError("NullRecorder.path accessed")
 
-    assert result.exit_code == 0
-    assert captured["width"] == settings.width
-    assert captured["height"] == settings.height
-    assert captured["display"] is True
-    # En mode display, aucun fichier ne doit être créé
-    assert not Path("generated").exists()
+    monkeypatch.setattr(cli_module, "NullRecorder", GuardedNullRecorder)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            app,
+            [
+                "run",
+                "--seed",
+                "1",
+                "--weapon-a",
+                "katana",
+                "--weapon-b",
+                "shuriken",
+                "--display",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert captured["width"] == settings.width
+        assert captured["height"] == settings.height
+        assert captured["display"] is True
+        # En mode display, aucun fichier ne doit être créé
+        assert not Path("generated").exists()
 
 
 def test_run_uses_dummy_audio_driver(monkeypatch: MonkeyPatch) -> None:

--- a/tests/unit/test_weapons.py
+++ b/tests/unit/test_weapons.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import cast
 
 import pytest
 
@@ -9,7 +8,7 @@ from app.core.config import settings
 from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
 from app.game.match import MatchTimeout, run_match
 from app.render.renderer import Renderer
-from app.video.recorder import NullRecorder, Recorder
+from app.video.recorder import NullRecorder
 from app.weapons import weapon_registry
 from app.weapons.base import Weapon, WeaponEffect, WorldView
 from app.weapons.katana import Katana
@@ -96,7 +95,7 @@ def test_weapon_update_called_each_frame() -> None:
     SpyWeapon.calls = []
     if "spy" not in weapon_registry.names():
         weapon_registry.register("spy", SpyWeapon)
-    recorder = cast(Recorder, NullRecorder())
+    recorder = NullRecorder()
     renderer = Renderer(settings.width, settings.height)
     with pytest.raises(MatchTimeout):
         run_match("spy", "spy", recorder, renderer, max_seconds=1)


### PR DESCRIPTION
## Summary
- ensure `run` passes `display` to `run_match` and drop unsafe recorder casting
- make `NullRecorder` a `Recorder` subclass so display runs avoid file system writes
- test that `--display` mode does not touch `recorder.path`

## Testing
- `uv run ruff check app tests`
- `uv run mypy app tests`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'imageio_ffmpeg' and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b3843f656c832a9ecab506d7fbb2b6