### PR TITLE
feat: add ping-pong utility

### DIFF
--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 from app.core.config import settings
 from app.core.types import Vec2
 
@@ -12,6 +14,40 @@ def clamp(value: float, minimum: float, maximum: float) -> float:
 def ease_out_quad(t: float) -> float:
     """Simple quadratic easing returning values in [0, 1]."""
     return 1 - (1 - t) * (1 - t)
+
+
+def ping_pong(value: float, length: float = 1.0) -> float:
+    """Return a value oscillating between ``0`` and ``length``.
+
+    The function maps any input onto a triangular wave pattern. Values rise
+    linearly from ``0`` up to ``length`` and then descend back to ``0``,
+    repeating this cycle indefinitely.
+
+    Parameters
+    ----------
+    value:
+        Input value to transform.
+    length:
+        Maximum value of the wave. Must be positive.
+
+    Returns
+    -------
+    float
+        Oscillating value in ``[0, length]``.
+
+    Raises
+    ------
+    ValueError
+        If ``length`` is not positive.
+    """
+
+    if length <= 0.0:
+        raise ValueError("length must be positive")
+
+    cycle = math.fmod(value, length * 2.0)
+    if cycle < 0.0:
+        cycle += length * 2.0
+    return length - abs(cycle - length)
 
 
 def to_screen(position: Vec2) -> tuple[int, int]:

--- a/app/render/hud.py
+++ b/app/render/hud.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pygame
 
+from app.core.utils import ping_pong
 from app.render.sprites import ASSET_DIR, load_sprite
 from app.render.theme import Theme, draw_horizontal_gradient
 
@@ -112,7 +113,7 @@ class Hud:
         margin = 40
 
         self.gradient_phase = (self.gradient_phase + self.gradient_speed) % 2.0
-        phase = self.gradient_phase if self.gradient_phase <= 1.0 else 2.0 - self.gradient_phase
+        phase = ping_pong(self.gradient_phase)
         self.update_hp(hp_a, hp_b)
 
         # Left bar (team A)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import pytest
+
 from app.core.config import settings
-from app.core.utils import clamp, to_screen
+from app.core.utils import clamp, ping_pong, to_screen
 
 
 def test_clamp() -> None:
@@ -13,3 +15,12 @@ def test_clamp() -> None:
 def test_to_screen() -> None:
     assert to_screen((0.0, 0.0)) == (0, settings.height)
     assert to_screen((10.0, settings.height)) == (10, 0)
+
+
+def test_ping_pong() -> None:
+    assert ping_pong(0.0) == 0.0
+    assert ping_pong(0.25) == pytest.approx(0.25)
+    assert ping_pong(0.5) == pytest.approx(0.5)
+    assert ping_pong(1.0) == 1.0
+    assert ping_pong(1.5) == pytest.approx(0.5)
+    assert ping_pong(2.0) == 0.0


### PR DESCRIPTION
## Summary
- add `ping_pong` helper for triangular wave calculations
- apply `ping_pong` in HUD gradient animation
- cover `ping_pong` with unit tests

## Testing
- `uv run ruff check app/core/utils.py app/render/hud.py tests/unit/test_utils.py`
- `uv run mypy .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `uv run pip-audit` *(fails: No such file or directory)*
- `uv run bandit -r app` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b38510928c832aa259d723d8db4e20