### PR TITLE
refactor: abstract recorder interface

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -13,7 +13,7 @@ from app.audio.env import temporary_sdl_audio_driver
 from app.core.config import settings
 from app.game.match import MatchTimeout, run_match
 from app.render.renderer import Renderer
-from app.video.recorder import NullRecorder, Recorder
+from app.video.recorder import NullRecorder, Recorder, RecorderProtocol
 from app.weapons import weapon_registry
 
 app = typer.Typer(help="Génération de vidéos satisfaction (TikTok).")
@@ -38,7 +38,7 @@ def run(
 
     driver = None if display else "dummy"
 
-    recorder: Recorder
+    recorder: RecorderProtocol
     renderer: Renderer
     temp_path: Path | None = None
     winner: str | None = None
@@ -66,12 +66,12 @@ def run(
                 display=display,
             )
         except MatchTimeout as exc:
-            if not display and recorder.path.exists():
+            if not display and recorder.path is not None and recorder.path.exists():
                 recorder.path.unlink()
             typer.echo(f"Error: {exc}", err=True)
             raise typer.Exit(code=1) from None
 
-    if not display and isinstance(recorder, Recorder) and temp_path is not None:
+    if not display and recorder.path is not None and temp_path is not None:
         winner_name = _sanitize(winner) if winner is not None else "draw"
         final_path = temp_path.with_name(f"{temp_path.stem}-{winner_name}_win{temp_path.suffix}")
         temp_path.rename(final_path)

--- a/app/game/match.py
+++ b/app/game/match.py
@@ -13,7 +13,7 @@ from app.core.config import settings
 from app.core.types import Color, Damage, EntityId, ProjectileInfo, Vec2
 from app.render.hud import Hud
 from app.render.renderer import Renderer
-from app.video.recorder import Recorder
+from app.video.recorder import RecorderProtocol
 from app.video.slowmo import append_slowmo_ending
 from app.weapons import weapon_registry
 from app.weapons.base import Weapon, WeaponEffect, WorldView
@@ -145,7 +145,7 @@ class _MatchView(WorldView):
 def run_match(  # noqa: C901
     weapon_a: str,
     weapon_b: str,
-    recorder: Recorder,
+    recorder: RecorderProtocol,
     renderer: Renderer | None = None,
     max_seconds: int = 120,
     display: bool = False,
@@ -158,7 +158,7 @@ def run_match(  # noqa: C901
         Weapon used by team A.
     weapon_b : str
         Weapon used by team B.
-    recorder : Recorder
+    recorder : RecorderProtocol
         Recorder instance responsible for writing video frames.
     renderer : Renderer | None, optional
         Optional renderer instance. If ``None``, an off-screen renderer is created.
@@ -360,7 +360,7 @@ def run_match(  # noqa: C901
         audio = engine.end_capture() if not display else None
         engine.stop_all()
         recorder.close(audio)
-        if not display and death_ts is not None:
+        if not display and death_ts is not None and recorder.path is not None:
             append_slowmo_ending(
                 recorder.path,
                 death_ts,

--- a/app/video/recorder.py
+++ b/app/video/recorder.py
@@ -3,13 +3,31 @@ from __future__ import annotations
 import subprocess
 import wave
 from pathlib import Path
+from typing import Protocol
 
 import imageio
 import imageio_ffmpeg
 import numpy as np
 
 
-class Recorder:
+class RecorderProtocol(Protocol):
+    """Minimal interface required from a video recorder.
+
+    Any concrete implementation must provide a writable ``path`` attribute and
+    implement :meth:`add_frame` and :meth:`close`. The ``path`` attribute may be
+    ``None`` when the recorder does not persist any output (e.g. ``NullRecorder``).
+    """
+
+    path: Path | None
+
+    def add_frame(self, frame: np.ndarray) -> None:
+        """Append a pre-rendered frame to the output video."""
+
+    def close(self, audio: np.ndarray | None = None, rate: int = 48_000) -> None:
+        """Finalize the recording, optionally muxing an audio track."""
+
+
+class Recorder(RecorderProtocol):
     """Write frames to a video file and optionally mux audio."""
 
     def __init__(self, width: int, height: int, fps: int, path: Path) -> None:

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -16,7 +16,7 @@ from app.audio.engine import AudioEngine
 from app.cli import app
 from app.core.config import settings
 from app.render.renderer import Renderer
-from app.video.recorder import NullRecorder, Recorder
+from app.video.recorder import NullRecorder, Recorder, RecorderProtocol
 
 
 def test_run_creates_video(tmp_path: Path) -> None:
@@ -53,7 +53,7 @@ def test_run_timeout(monkeypatch: MonkeyPatch) -> None:
     def run_match_short(
         weapon_a: str,
         weapon_b: str,
-        recorder: Recorder,
+        recorder: RecorderProtocol,
         renderer: Renderer | None = None,
     ) -> None:
         # max_seconds=0 provoque systématiquement un MatchTimeout


### PR DESCRIPTION
## Summary
- introduce `RecorderProtocol` for flexible video recorder implementations
- use `RecorderProtocol` in match loop and CLI
- gate slow-motion post-processing on recorder path presence

## Testing
- `python -m mypy app tests`
- `python -m ruff check app/video/recorder.py app/game/match.py app/cli.py tests/test_cli_run.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'imageio_ffmpeg')*


------
https://chatgpt.com/codex/tasks/task_e_68b387669c44832a8b147f6326d1d894