### PR TITLE
feat: use static diagonal gradient for hp bars

### DIFF
--- a/app/render/hud.py
+++ b/app/render/hud.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import pygame
 
-from app.core.utils import ping_pong
 from app.render.sprites import ASSET_DIR, load_sprite
-from app.render.theme import Theme, draw_horizontal_gradient
+from app.render.theme import Theme, draw_diagonal_gradient
 
 
 class Hud:
@@ -18,22 +17,17 @@ class Hud:
     VS_WIDTH_RATIO: float = 0.2
     VS_MARGIN: int = -100
 
-    def __init__(self, theme: Theme, gradient_speed: float = 0.01) -> None:
+    def __init__(self, theme: Theme) -> None:
         """Initialize the HUD renderer.
 
         Parameters
         ----------
         theme:
             Color palette used for rendering.
-        gradient_speed:
-            Increment applied to the internal gradient phase at each call to
-            :meth:`draw_hp_bars`. ``0`` disables animation.
         """
 
         pygame.font.init()
         self.theme = theme
-        self.gradient_speed = gradient_speed
-        self.gradient_phase = 0.0
         self.title_font = pygame.font.Font(None, 72)
         weapon_font_path = (ASSET_DIR / "fonts" / "FightKickDemoRegular.ttf").as_posix()
         self.bar_font = pygame.font.Font(weapon_font_path, 48)
@@ -97,10 +91,8 @@ class Hud:
         """Draw two symmetrical health bars with labels.
 
         The bar dimensions scale with the given surface so that the HUD adapts
-        to different resolutions. A horizontal gradient fills the bars and
-        oscillates using a ping-pong cycle. The gradient offset increases until
-        it reaches ``1.0`` and then reverses back toward ``0.0`` to create a
-        back-and-forth animation.
+        to different resolutions. A static 45° gradient fills the bars from the
+        top-left to the bottom-right corner.
 
         Returns
         -------
@@ -112,8 +104,6 @@ class Hud:
         bar_height = max(1, int(surface.get_height() * self.BAR_HEIGHT_RATIO))
         margin = 40
 
-        self.gradient_phase = (self.gradient_phase + self.gradient_speed) % 2.0
-        phase = ping_pong(self.gradient_phase)
         self.update_hp(hp_a, hp_b)
 
         # Left bar (team A)
@@ -127,7 +117,7 @@ class Hud:
                 if self.current_hp_a < self.LOW_HP_THRESHOLD
                 else self.theme.team_a.hp_gradient
             )
-            draw_horizontal_gradient(surface, filled_rect, colors_a, phase=phase)
+            draw_diagonal_gradient(surface, filled_rect, colors_a)
         label_a = self.bar_font.render(labels[0], True, (255, 255, 255))
         label_a_rect = label_a.get_rect()
         label_a_rect.centery = left_rect.centery
@@ -152,7 +142,7 @@ class Hud:
                 if self.current_hp_b < self.LOW_HP_THRESHOLD
                 else tuple(reversed(self.theme.team_b.hp_gradient))
             )
-            draw_horizontal_gradient(surface, filled_rect, colors_b, phase=phase)
+            draw_diagonal_gradient(surface, filled_rect, colors_b)
         label_b = self.bar_font.render(labels[1], True, (255, 255, 255))
         label_b_rect = label_b.get_rect()
         label_b_rect.centery = right_rect.centery

--- a/app/render/theme.py
+++ b/app/render/theme.py
@@ -86,3 +86,43 @@ def draw_horizontal_gradient(
             (rect.x + x, rect.y),
             (rect.x + x, rect.y + rect.height),
         )
+
+
+def draw_diagonal_gradient(
+    surface: pygame.Surface,
+    rect: pygame.Rect,
+    colors: Sequence[Color],
+) -> None:
+    """Draw a 45° gradient from the top-left to the bottom-right corner.
+
+    Parameters
+    ----------
+    surface:
+        Target drawing surface.
+    rect:
+        Area where the gradient is rendered.
+    colors:
+        Sequence of colors defining the gradient stops. A single color fills
+        ``rect`` uniformly.
+    """
+
+    if not colors:
+        return
+    if len(colors) == 1:
+        pygame.draw.rect(surface, colors[0], rect)
+        return
+
+    segments = len(colors) - 1
+    max_dist = rect.width + rect.height
+    for y in range(rect.height):
+        for x in range(rect.width):
+            t = (x + y) / max_dist
+            pos = t * segments
+            index = min(int(pos), segments - 1)
+            ratio = pos - index
+            start = colors[index]
+            end = colors[index + 1]
+            r = int(start[0] + (end[0] - start[0]) * ratio)
+            g = int(start[1] + (end[1] - start[1]) * ratio)
+            b = int(start[2] + (end[2] - start[2]) * ratio)
+            surface.set_at((rect.x + x, rect.y + y), (r, g, b))

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -113,19 +113,9 @@ def test_hp_label_and_vs_positions() -> None:
     assert vs_rect.width == int(surface.get_width() * Hud.VS_WIDTH_RATIO)
 
 
-def test_gradient_phase_increments() -> None:
+def test_hp_gradient_static() -> None:
     surface = pygame.Surface((800, 300))
-    hud = Hud(settings.theme, gradient_speed=1.2)
-    hud.draw_hp_bars(surface, 1.0, 1.0, ("A", "B"))
-    assert hud.gradient_phase == pytest.approx(1.2, abs=1e-6)
-    hud.draw_hp_bars(surface, 1.0, 1.0, ("A", "B"))
-    # Phase cycles modulo 2.0
-    assert hud.gradient_phase == pytest.approx(0.4, abs=1e-6)
-
-
-def test_gradient_phase_shifts_colors() -> None:
-    surface = pygame.Surface((800, 300))
-    hud = Hud(settings.theme, gradient_speed=0.5)
+    hud = Hud(settings.theme)
     bar_width = int(surface.get_width() * Hud.BAR_WIDTH_RATIO)
     bar_height = int(surface.get_height() * Hud.BAR_HEIGHT_RATIO)
     x = 40 + bar_width // 4
@@ -138,9 +128,18 @@ def test_gradient_phase_shifts_colors() -> None:
     hud.draw_hp_bars(surface, 1.0, 1.0, ("A", "B"))
     color2 = surface.get_at((x, y))[:3]
 
-    surface.fill((0, 0, 0))
-    hud.draw_hp_bars(surface, 1.0, 1.0, ("A", "B"))
-    color3 = surface.get_at((x, y))[:3]
+    assert color1 == color2
 
-    assert color1 != color2
-    assert color1 == color3
+
+def test_hp_gradient_diagonal_orientation() -> None:
+    surface = pygame.Surface((400, 200))
+    hud = Hud(settings.theme)
+    hud.draw_hp_bars(surface, 1.0, 1.0, ("A", "B"))
+
+    bar_width = int(surface.get_width() * Hud.BAR_WIDTH_RATIO)
+    bar_height = int(surface.get_height() * Hud.BAR_HEIGHT_RATIO)
+    left_rect = pygame.Rect(40, 120, bar_width, bar_height)
+
+    c1 = surface.get_at((left_rect.x + 5, left_rect.y + 10))[:3]
+    c2 = surface.get_at((left_rect.x + 10, left_rect.y + 5))[:3]
+    assert c1 == c2


### PR DESCRIPTION
## Summary
- render HUD health bars with a static 45° gradient
- add diagonal gradient renderer utility
- test that health bar gradient is static and diagonal

## Testing
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `uv run pip-audit` *(fails: No such file or directory)*
- `uv run bandit -r app` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b3891beec0832ab26e2612b2322ee6