### PR TITLE
Allow AI to fire while retreating

### DIFF
--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -16,7 +16,7 @@ from app.audio.engine import AudioEngine
 from app.cli import app
 from app.core.config import settings
 from app.render.renderer import Renderer
-from app.video.recorder import NullRecorder, Recorder, RecorderProtocol
+from app.video.recorder import NullRecorder, RecorderProtocol
 
 
 def test_run_creates_video(tmp_path: Path) -> None:

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -118,6 +118,14 @@ def test_retreats_on_low_health(style: Literal["aggressive", "kiter"]) -> None:
     accel, face, fire = policy.decide(EntityId(1), view, 600.0)
     assert accel[0] < 0  # retreats from enemy
     assert face == (1.0, 0.0)  # still faces enemy
+    assert fire is True
+
+
+@pytest.mark.parametrize("style", ["aggressive", "kiter"])
+def test_low_health_fire_requires_range(style: Literal["aggressive", "kiter"]) -> None:
+    view = DummyView(EntityId(1), EntityId(2), (0.0, 0.0), (600.0, 0.0), health_me=0.1)
+    policy = SimplePolicy(style)
+    _, _, fire = policy.decide(EntityId(1), view, 600.0)
     assert fire is False
 
 


### PR DESCRIPTION
## Summary
- let fleeing AI keep shooting and only alter acceleration
- add tests for retreating fire logic
- remove unused test import

## Testing
- `make lint`
- `uv run pytest` *(fails: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68b389dd07c8832a833536de425faeb5