### PR TITLE
feat: warn when sprite asset missing

### DIFF
--- a/app/render/sprites.py
+++ b/app/render/sprites.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 from functools import cache
 from pathlib import Path
@@ -7,6 +8,7 @@ from pathlib import Path
 import pygame
 
 ASSET_DIR = Path(__file__).resolve().parents[2] / "assets"
+logger = logging.getLogger(__name__)
 
 
 @cache
@@ -23,14 +25,24 @@ def load_sprite(name: str, scale: float = 1.0, max_dim: float | None = None) -> 
         If provided, resize the image so that its longest side equals ``max_dim``
         while preserving aspect ratio. ``scale`` is ignored when ``max_dim`` is
         given.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the requested sprite does not exist in the assets directory.
     """
+    path = ASSET_DIR / name
+    if not path.exists():
+        logger.warning("Sprite not found at %s", path)
+        raise FileNotFoundError(path)
+
     if not pygame.get_init():
         os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
         pygame.init()
     if pygame.display.get_surface() is None:
         pygame.display.set_mode((1, 1))
 
-    image = pygame.image.load((ASSET_DIR / name).as_posix()).convert_alpha()
+    image = pygame.image.load(path.as_posix()).convert_alpha()
     if max_dim is not None:
         width, height = image.get_size()
         factor = max_dim / float(max(width, height))

--- a/tests/unit/test_sprite_missing.py
+++ b/tests/unit/test_sprite_missing.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from app.render.sprites import load_sprite
+
+
+def test_load_sprite_missing_asset_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    missing_name = "does_not_exist.png"
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(FileNotFoundError):
+            load_sprite(missing_name)
+    assert missing_name in caplog.text


### PR DESCRIPTION
## Summary
- log missing sprite assets using the module logger
- add unit test covering warning on absent asset

## Testing
- ⚠️ `make lint` (mypy attr-defined errors in unrelated modules)
- ⚠️ `make test` (pytest plugin `pytest-cov` missing)
- ✅ `uv run ruff check app/render/sprites.py tests/unit/test_sprite_missing.py`
- ✅ `uv run mypy app/render/sprites.py tests/unit/test_sprite_missing.py`


------
https://chatgpt.com/codex/tasks/task_e_68b40282779c832a8740a00878c2c522