### PR TITLE
feat: add tween easing functions

### DIFF
--- a/app/core/tween.py
+++ b/app/core/tween.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import math
+
+__all__ = [
+    "linear",
+    "ease_in_out_cubic",
+    "ease_out_back",
+    "ease_out_elastic",
+]
+
+
+def _clamp(value: float, minimum: float = 0.0, maximum: float = 1.0) -> float:
+    """Clamp ``value`` within the inclusive range ``[minimum, maximum]``."""
+    return max(minimum, min(value, maximum))
+
+
+def linear(t: float) -> float:
+    """Return ``t`` unchanged after clamping to ``[0.0, 1.0]``.
+
+    Parameters
+    ----------
+    t:
+        Progress ratio to interpolate.
+
+    Returns
+    -------
+    float
+        The clamped progress value in ``[0.0, 1.0]``.
+    """
+
+    return _clamp(t)
+
+
+def ease_in_out_cubic(t: float) -> float:
+    """Cubic easing accelerating then decelerating symmetrically.
+
+    Parameters
+    ----------
+    t:
+        Progress ratio to transform.
+
+    Returns
+    -------
+    float
+        Eased progress in ``[0.0, 1.0]``.
+    """
+
+    t = _clamp(t)
+    if t < 0.5:
+        return 4.0 * t**3
+    return 1.0 - (-2.0 * t + 2.0) ** 3 / 2.0
+
+
+def ease_out_back(t: float) -> float:
+    """Easing with an overshoot going slightly past the target.
+
+    Parameters
+    ----------
+    t:
+        Progress ratio to transform.
+
+    Returns
+    -------
+    float
+        Eased progress in ``[0.0, 1.0]`` including a back overshoot.
+    """
+
+    t = _clamp(t)
+    c1 = 1.70158
+    c3 = c1 + 1.0
+    return 1.0 + c3 * (t - 1.0) ** 3 + c1 * (t - 1.0) ** 2
+
+
+def ease_out_elastic(t: float) -> float:
+    """Elastic easing producing a spring-like overshoot.
+
+    Parameters
+    ----------
+    t:
+        Progress ratio to transform.
+
+    Returns
+    -------
+    float
+        Eased progress in ``[0.0, 1.0]`` with oscillation.
+    """
+
+    t = _clamp(t)
+    if t == 0.0 or t == 1.0:
+        return t
+    c4 = (2.0 * math.pi) / 3.0
+    return math.pow(2.0, -10.0 * t) * math.sin((t * 10.0 - 0.75) * c4) + 1.0

--- a/tests/unit/test_tween.py
+++ b/tests/unit/test_tween.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from app.core.tween import (
+    ease_in_out_cubic,
+    ease_out_back,
+    ease_out_elastic,
+    linear,
+)
+
+
+@pytest.mark.parametrize(
+    ("func", "expected_mid"),
+    [
+        (linear, 0.5),
+        (ease_in_out_cubic, 0.5),
+        (ease_out_back, 1.0876975),
+        (ease_out_elastic, 1.015625),
+    ],
+)
+def test_values(func: Callable[[float], float], expected_mid: float) -> None:
+    assert func(0.0) == pytest.approx(0.0)
+    assert func(0.5) == pytest.approx(expected_mid)
+    assert func(1.0) == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize(
+    "func",
+    [linear, ease_in_out_cubic, ease_out_back, ease_out_elastic],
+)
+def test_continuity(func: Callable[[float], float]) -> None:
+    eps = 1e-5
+    center = func(0.5)
+    assert func(0.5 - eps) == pytest.approx(center, abs=1e-4)
+    assert func(0.5 + eps) == pytest.approx(center, abs=1e-4)


### PR DESCRIPTION
## Summary
- add core tween functions for linear and elastic easing
- cover easing functions with unit tests

## Testing
- `uv run ruff check app/core/tween.py tests/unit/test_tween.py`
- `uv run ruff format app/core/tween.py tests/unit/test_tween.py`
- `uv run mypy app/core/tween.py tests/unit/test_tween.py`
- `uv run pytest tests/unit/test_tween.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4079ea678832aa7be4c1ba1cc67f1