### PR TITLE
feat: configurable intro renderer positions and alpha

### DIFF
--- a/tests/unit/test_intro_renderer.py
+++ b/tests/unit/test_intro_renderer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from app.intro import IntroConfig
 from app.render.intro_renderer import IntroRenderer
 
 
@@ -15,8 +16,28 @@ def test_compute_positions_slide_and_center() -> None:
     assert right_end == (150.0, 50.0)
 
 
+def test_compute_positions_custom_config() -> None:
+    config = IntroConfig(
+        left_pos_pct=(0.3, 0.4),
+        right_pos_pct=(0.7, 0.6),
+        center_pos_pct=(0.5, 0.5),
+        slide_offset_pct=0.4,
+    )
+    renderer = IntroRenderer(100, 200, config=config)
+    left_end, right_end, center = renderer.compute_positions(1.0)
+    assert left_end == (30.0, 80.0)
+    assert right_end == (70.0, 120.0)
+    assert center == (50.0, 100.0)
+
+
 def test_compute_alpha_fade_in_out() -> None:
     renderer = IntroRenderer(200, 100)
     assert renderer.compute_alpha(0.0) == 0
     assert renderer.compute_alpha(0.5) == 255
     assert renderer.compute_alpha(1.0) == 0
+
+
+def test_compute_alpha_custom_fade() -> None:
+    config = IntroConfig(fade=lambda t: t)
+    renderer = IntroRenderer(200, 100, config=config)
+    assert renderer.compute_alpha(0.25) == int(0.5 * 255)


### PR DESCRIPTION
## Summary
- extend `IntroConfig` with positional percentages, slide offsets and scale factors
- drive `IntroRenderer` layout and fade using `IntroConfig` and add glow/shadow effects
- test configuration-driven position and alpha computations

## Testing
- `uv run ruff check app/intro/intro_manager.py app/render/intro_renderer.py tests/unit/test_intro_renderer.py tests/unit/test_intro_manager.py`
- `uv run mypy app/intro/intro_manager.py app/render/intro_renderer.py tests/unit/test_intro_renderer.py tests/unit/test_intro_manager.py`
- `uv run pytest tests/unit/test_intro_renderer.py tests/unit/test_intro_manager.py` *(fails: ModuleNotFoundError: No module named 'pydantic', 'pygame')*
- `uv run pip install pydantic pygame` *(fails: Could not find a version that satisfies the requirement pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_68b408729e98832a95c5fad6fcd856e5