### PR TITLE
feat: add intro loop before match start

### DIFF
--- a/app/game/match.py
+++ b/app/game/match.py
@@ -17,6 +17,15 @@ from app.weapons import weapon_registry
 from app.world.entities import Ball
 from app.world.physics import PhysicsWorld
 
+__all__ = [
+    "create_controller",
+    "run_match",
+    "GameController",
+    "MatchTimeout",
+    "Player",
+    "_MatchView",
+]
+
 
 def create_controller(
     weapon_a: str,
@@ -56,7 +65,7 @@ def create_controller(
         ),
     ]
 
-    intro = IntroManager()
+    intro = IntroManager(labels=(weapon_a.capitalize(), weapon_b.capitalize()))
     return GameController(
         weapon_a,
         weapon_b,

--- a/tests/integration/test_intro_loop.py
+++ b/tests/integration/test_intro_loop.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from app.core.config import settings
+from app.game.controller import GameController
+from app.game.intro import IntroManager
+from app.game.match import create_controller
+from app.render.hud import Hud
+from app.render.renderer import Renderer
+from tests.integration.helpers import SpyRecorder
+
+
+class StubIntroManager(IntroManager):
+    """Intro manager stub used to control flow during tests."""
+
+    def __init__(self, frames: int, skip_at: int | None = None) -> None:
+        super().__init__(labels=("", ""))
+        self.frames = frames
+        self.skip_at = skip_at
+        self.updates = 0
+        self.draws = 0
+
+    def is_finished(self) -> bool:  # pragma: no cover - simple predicate
+        return self._skipped or self.updates >= self.frames
+
+    def update(self, dt: float) -> None:  # pragma: no cover - simple counter
+        self.updates += 1
+        if self.skip_at is not None and self.updates >= self.skip_at:
+            self.skip()
+
+    def draw(self, renderer: Renderer, hud: Hud) -> None:  # pragma: no cover - simple counter
+        self.draws += 1
+
+
+def _make_controller(intro: StubIntroManager) -> GameController:
+    recorder = SpyRecorder()
+    renderer = Renderer(settings.width, settings.height)
+    controller = create_controller("katana", "shuriken", recorder, renderer, max_seconds=0)
+    controller.intro_manager = intro
+    return controller
+
+
+def test_intro_runs_to_completion() -> None:
+    intro = StubIntroManager(frames=3)
+    controller = _make_controller(intro)
+    controller.run()
+    assert intro.updates == 3 and intro.draws == 3
+    assert controller.elapsed == 0.0
+
+
+def test_intro_can_be_skipped() -> None:
+    intro = StubIntroManager(frames=5, skip_at=1)
+    controller = _make_controller(intro)
+    controller.run()
+    assert intro.updates == 1 and intro.draws == 1
+    assert controller.elapsed == 0.0


### PR DESCRIPTION
## Summary
- run intro loop that updates and renders until finished before starting match
- extend `IntroManager` with state, skipping, and title/watermark rendering
- add integration tests for complete intro and skipped intro flows

## Testing
- `uv run ruff check app/game/match.py tests/integration/test_intro_loop.py app/game/intro.py app/game/controller.py`
- `uv run mypy .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic', 'pymunk', 'imageio_ffmpeg')*


------
https://chatgpt.com/codex/tasks/task_e_68b40a30c90c832a928df64f359a6644