### PR TITLE
feat: introduce intro assets loader with fallbacks

### DIFF
--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import math
 
-from app.core.config import settings
 from app.core.types import Vec2
 
 
@@ -52,5 +51,7 @@ def ping_pong(value: float, length: float = 1.0) -> float:
 
 def to_screen(position: Vec2) -> tuple[int, int]:
     """Convert world coordinates to screen coordinates."""
+    from app.core.config import settings
+
     x, y = position
     return int(x), int(settings.height - y)

--- a/app/intro/__init__.py
+++ b/app/intro/__init__.py
@@ -1,5 +1,7 @@
-"""Intro package providing the :class:`IntroManager`."""
+"""Intro package providing the introduction manager and helpers."""
 
-from .intro_manager import IntroConfig, IntroManager, IntroState
+from .assets import IntroAssets
+from .config import IntroConfig
+from .intro_manager import IntroManager, IntroState
 
-__all__ = ["IntroConfig", "IntroManager", "IntroState"]
+__all__ = ["IntroAssets", "IntroConfig", "IntroManager", "IntroState"]

--- a/app/intro/assets.py
+++ b/app/intro/assets.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .config import IntroConfig
+
+if TYPE_CHECKING:  # pragma: no cover - hints only
+    import pygame
+
+FALLBACK_COLOR: tuple[int, int, int] = (255, 0, 255)
+FALLBACK_SIZE: tuple[int, int] = (64, 64)
+
+
+@dataclass(frozen=True, slots=True)
+class IntroAssets:
+    """Assets required by the intro sequence."""
+
+    font: pygame.font.Font
+    logo: pygame.Surface
+    weapon_a: pygame.Surface
+    weapon_b: pygame.Surface
+
+    @classmethod
+    def load(cls, config: IntroConfig, *, font_size: int = 72) -> IntroAssets:
+        """Load assets defined in ``config`` using fallbacks when missing."""
+        import pygame
+
+        pygame.font.init()
+
+        def _load_font(path: Path | None) -> pygame.font.Font:
+            if path and Path(path).exists():
+                return pygame.font.Font(str(path), font_size)
+            logging.warning("Missing font at %s; using default font", path)
+            return pygame.font.Font(None, font_size)
+
+        font = _load_font(config.font_path)
+
+        def _load_image(path: Path | None, label: str) -> pygame.Surface:
+            if path and Path(path).exists():
+                return pygame.image.load(str(path)).convert_alpha()
+            logging.warning("Missing image at %s; using fallback", path)
+            surface = pygame.Surface(FALLBACK_SIZE)
+            surface.fill(FALLBACK_COLOR)
+            text = font.render(label, True, (0, 0, 0))
+            rect = text.get_rect(center=(FALLBACK_SIZE[0] // 2, FALLBACK_SIZE[1] // 2))
+            surface.blit(text, rect)
+            return surface
+
+        logo = _load_image(config.logo_path, "logo")
+        weapon_a = _load_image(config.weapon_a_path, "A")
+        weapon_b = _load_image(config.weapon_b_path, "B")
+        return cls(font=font, logo=logo, weapon_a=weapon_a, weapon_b=weapon_b)
+
+
+__all__ = ["IntroAssets", "FALLBACK_COLOR", "FALLBACK_SIZE"]

--- a/app/intro/config.py
+++ b/app/intro/config.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from app.core.types import Vec2
+from app.core.utils import ease_out_quad
+
+Easing = Callable[[float], float]
+
+
+def ease_out_back(t: float) -> float:
+    """Return an easing with a small overshoot for a bounce effect."""
+    c1 = 1.70158
+    c3 = c1 + 1.0
+    return 1 + c3 * (t - 1) ** 3 + c1 * (t - 1) ** 2
+
+
+def pulse_ease(t: float) -> float:
+    """Return a pulsating value between 0 and 1."""
+    import math
+
+    return 0.5 - 0.5 * math.cos(t * math.tau)
+
+
+@dataclass(frozen=True, slots=True)
+class IntroConfig:
+    """Configuration for intro timings, assets and behaviour.
+
+    Parameters
+    ----------
+    logo_in, weapons_in, hold, fade_out:
+        Durations in seconds for each phase of the intro animation.
+    micro_bounce, pulse, fade:
+        Easing functions used for the various phases.
+    left_pos_pct, right_pos_pct, center_pos_pct:
+        Final positions for the left label, right label and centre marker as
+        percentages of the screen size.
+    slide_offset_pct:
+        Horizontal offset in percent of the screen width from which the labels
+        start sliding.
+    logo_scale, weapon_scale:
+        Multiplicative factors applied to the logo and weapon images when
+        rendering.
+    font_path, logo_path, weapon_a_path, weapon_b_path:
+        Paths to the font and images used by the introduction. When ``None`` or
+        missing, fallbacks will be generated.
+    allow_skip, skip_key:
+        Options controlling whether the intro can be skipped and which key
+        triggers the skip. ``skip_key`` defaults to the Escape key.
+    """
+
+    logo_in: float = 1.0
+    weapons_in: float = 1.0
+    hold: float = 1.0
+    fade_out: float = 1.0
+    micro_bounce: Easing = ease_out_back
+    pulse: Easing = pulse_ease
+    fade: Easing = ease_out_quad
+    left_pos_pct: Vec2 = (0.25, 0.5)
+    right_pos_pct: Vec2 = (0.75, 0.5)
+    center_pos_pct: Vec2 = (0.5, 0.5)
+    slide_offset_pct: float = 0.5
+    logo_scale: float = 1.0
+    weapon_scale: float = 1.0
+    font_path: Path | None = None
+    logo_path: Path | None = None
+    weapon_a_path: Path | None = None
+    weapon_b_path: Path | None = None
+    allow_skip: bool = True
+    skip_key: int = 27

--- a/app/render/intro_renderer.py
+++ b/app/render/intro_renderer.py
@@ -8,7 +8,7 @@ from app.core.utils import clamp
 if TYPE_CHECKING:  # pragma: no cover - hints only
     import pygame
 
-    from app.intro.intro_manager import IntroConfig
+    from app.intro.config import IntroConfig
 
 
 class IntroRenderer:
@@ -21,7 +21,7 @@ class IntroRenderer:
         config: IntroConfig | None = None,
         font: pygame.font.Font | None = None,
     ) -> None:
-        from app.intro.intro_manager import IntroConfig as _IntroConfig
+        from app.intro.config import IntroConfig as _IntroConfig
 
         self.width = width
         self.height = height

--- a/tests/unit/test_intro_assets.py
+++ b/tests/unit/test_intro_assets.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+import pygame
+
+from app.intro import IntroAssets, IntroConfig
+from app.intro.assets import FALLBACK_COLOR
+
+
+def test_assets_load_existing() -> None:
+    pygame.init()
+    config = IntroConfig(
+        font_path=Path("assets/fonts/FightKickDemoRegular.ttf"),
+        logo_path=Path("assets/vs.png"),
+    )
+    assets = IntroAssets.load(config)
+    assert isinstance(assets.font, pygame.font.Font)
+    assert assets.logo.get_at((0, 0)) != FALLBACK_COLOR
+    pygame.quit()
+
+
+def test_assets_load_fallback(caplog: pytest.LogCaptureFixture) -> None:
+    pygame.init()
+    caplog.set_level(logging.WARNING)
+    config = IntroConfig(
+        font_path=Path("missing_font.ttf"),
+        logo_path=Path("missing_image.png"),
+    )
+    assets = IntroAssets.load(config)
+    assert "Missing font" in caplog.text
+    assert "Missing image" in caplog.text
+    assert assets.logo.get_at((0, 0)) == FALLBACK_COLOR
+    pygame.quit()

--- a/tests/unit/test_intro_manager.py
+++ b/tests/unit/test_intro_manager.py
@@ -12,8 +12,8 @@ def test_intro_manager_start_state() -> None:
 
 
 def test_intro_manager_transitions() -> None:
-    config = IntroConfig(logo_in=0.1, weapons_in=0.1, hold=0.1, fade_out=0.1)
-    manager = IntroManager(config=config, allow_skip=False)
+    config = IntroConfig(logo_in=0.1, weapons_in=0.1, hold=0.1, fade_out=0.1, allow_skip=False)
+    manager = IntroManager(config=config)
     manager.start()
     for expected in (
         IntroState.WEAPONS_IN,
@@ -27,8 +27,15 @@ def test_intro_manager_transitions() -> None:
 
 
 def test_intro_manager_skip() -> None:
-    config = IntroConfig(logo_in=10.0, weapons_in=10.0, hold=10.0, fade_out=10.0)
-    manager = IntroManager(config=config, allow_skip=True, skip_key=pygame.K_s)
+    config = IntroConfig(
+        logo_in=10.0,
+        weapons_in=10.0,
+        hold=10.0,
+        fade_out=10.0,
+        allow_skip=True,
+        skip_key=pygame.K_s,
+    )
+    manager = IntroManager(config=config)
     manager.start()
 
     event = pygame.event.Event(pygame.KEYDOWN, {"key": pygame.K_s})


### PR DESCRIPTION
## Summary
- centralize intro configuration with asset paths and skip options
- add asset loader providing font/image fallbacks with warnings
- refactor intro manager to use config and support missing assets

## Testing
- `ruff check app/intro/config.py app/intro/assets.py app/intro/intro_manager.py app/intro/__init__.py app/render/intro_renderer.py tests/unit/test_intro_manager.py tests/unit/test_intro_assets.py`
- `mypy app/intro app/render/intro_renderer.py app/core/utils.py`
- `pip install pygame==2.6.0 pydantic==2.8.2` *(failed: Could not find a version that satisfies the requirement pygame==2.6.0 (403 Forbidden))*
- `pytest tests/unit/test_intro_manager.py tests/unit/test_intro_assets.py` *(failed: ModuleNotFoundError: No module named 'pygame')*


------
https://chatgpt.com/codex/tasks/task_e_68b40bd24b30832abbbbbaa16ab6df81