### PR TITLE
feat: add CLI support for intro weapon images

### DIFF
--- a/app/game/match.py
+++ b/app/game/match.py
@@ -10,7 +10,9 @@ from app.game.controller import (
     _MatchView,  # noqa: F401 - re-exported for tests
 )
 from app.game.intro import IntroManager
+from app.intro.config import IntroConfig
 from app.render.hud import Hud
+from app.render.intro_renderer import IntroRenderer
 from app.render.renderer import Renderer
 from app.video.recorder import RecorderProtocol
 from app.weapons import weapon_registry
@@ -35,6 +37,7 @@ def create_controller(
     *,
     max_seconds: int = 120,
     display: bool = False,
+    intro_config: IntroConfig | None = None,
 ) -> GameController:
     """Construct a :class:`GameController` with default components."""
     engine = get_default_engine()
@@ -65,7 +68,11 @@ def create_controller(
         ),
     ]
 
-    intro = IntroManager(labels=(weapon_a.capitalize(), weapon_b.capitalize()))
+    intro_renderer = IntroRenderer(settings.width, settings.height, intro_config)
+    intro = IntroManager(
+        labels=(weapon_a.capitalize(), weapon_b.capitalize()),
+        intro_renderer=intro_renderer,
+    )
     return GameController(
         weapon_a,
         weapon_b,

--- a/app/intro/__init__.py
+++ b/app/intro/__init__.py
@@ -1,7 +1,13 @@
 """Intro package providing the introduction manager and helpers."""
 
 from .assets import IntroAssets
-from .config import IntroConfig
+from .config import IntroConfig, set_intro_weapons
 from .intro_manager import IntroManager, IntroState
 
-__all__ = ["IntroAssets", "IntroConfig", "IntroManager", "IntroState"]
+__all__ = [
+    "IntroAssets",
+    "IntroConfig",
+    "IntroManager",
+    "IntroState",
+    "set_intro_weapons",
+]

--- a/app/intro/assets.py
+++ b/app/intro/assets.py
@@ -38,9 +38,13 @@ class IntroAssets:
 
         font = _load_font(config.font_path)
 
-        def _load_image(path: Path | None, label: str) -> pygame.Surface:
-            if path and Path(path).exists():
-                return pygame.image.load(str(path)).convert_alpha()
+        def _load_image(path: Path | None, fallback_label: str) -> pygame.Surface:
+            label = fallback_label
+            if path:
+                path_obj = Path(path)
+                if path_obj.exists():
+                    return pygame.image.load(str(path_obj)).convert_alpha()
+                label = path_obj.stem
             logging.warning("Missing image at %s; using fallback", path)
             surface = pygame.Surface(FALLBACK_SIZE)
             surface.fill(FALLBACK_COLOR)
@@ -50,8 +54,8 @@ class IntroAssets:
             return surface
 
         logo = _load_image(config.logo_path, "logo")
-        weapon_a = _load_image(config.weapon_a_path, "A")
-        weapon_b = _load_image(config.weapon_b_path, "B")
+        weapon_a = _load_image(config.weapon_a_path, "L")
+        weapon_b = _load_image(config.weapon_b_path, "R")
         return cls(font=font, logo=logo, weapon_a=weapon_a, weapon_b=weapon_b)
 
 

--- a/app/intro/config.py
+++ b/app/intro/config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 from app.core.types import Vec2
@@ -70,3 +70,30 @@ class IntroConfig:
     weapon_b_path: Path | None = None
     allow_skip: bool = True
     skip_key: int = 27
+
+
+def set_intro_weapons(
+    left: Path | None, right: Path | None, *, config: IntroConfig | None = None
+) -> IntroConfig:
+    """Return a copy of ``config`` with weapon image paths updated.
+
+    Parameters
+    ----------
+    left, right:
+        Paths to the images representing the left and right weapons.
+    config:
+        Optional base configuration to update. When ``None`` a default
+        :class:`IntroConfig` is created.
+
+    Returns
+    -------
+    IntroConfig
+        A new configuration with ``weapon_a_path`` and ``weapon_b_path`` set
+        to the provided values.
+    """
+
+    base = config or IntroConfig()
+    return replace(base, weapon_a_path=left, weapon_b_path=right)
+
+
+__all__ = ["IntroConfig", "set_intro_weapons"]


### PR DESCRIPTION
## Summary
- allow passing intro weapon images via `--intro-weapons` on CLI
- expose `set_intro_weapons` helper and propagate config to match controller
- add fallback surface with label when intro images are missing
- test CLI option for intro weapons

## Testing
- `uv run ruff check app/intro/config.py app/intro/assets.py app/intro/__init__.py app/game/match.py app/cli.py tests/test_cli_run.py`
- `uv run ruff format app/intro/config.py app/intro/assets.py app/intro/__init__.py app/game/match.py app/cli.py tests/test_cli_run.py`
- `uv run ruff check app/intro/config.py app/intro/assets.py app/intro/__init__.py app/game/match.py app/cli.py tests/test_cli_run.py`
- `uv run mypy app/intro/config.py app/intro/assets.py app/intro/__init__.py app/game/match.py app/cli.py`
- `uv run pre-commit run --files app/intro/config.py app/intro/assets.py app/intro/__init__.py app/game/match.py app/cli.py tests/test_cli_run.py` *(fails: Failed to spawn: `pre-commit`)*
- `uv run pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `uv run pytest tests/test_cli_run.py -k test_intro_weapons_option` *(fails: ModuleNotFoundError: No module named 'imageio_ffmpeg')*
- `uv run pip install imageio-ffmpeg` *(fails: Could not find a version that satisfies the requirement imageio-ffmpeg)*

------
https://chatgpt.com/codex/tasks/task_e_68b40e0e8444832aa3a3d0954f2a9545