### PR TITLE
test: expand intro renderer and tween coverage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,10 @@ import os
 import sys
 from pathlib import Path
 
-# Ensure pygame uses a dummy audio driver during tests so that sound
+# Ensure pygame uses dummy drivers during tests so that audio and video
 # initialization works in headless environments.
 os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:

--- a/tests/unit/test_intro_manager.py
+++ b/tests/unit/test_intro_manager.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-import pygame
+import pytest
 
-from app.intro import IntroConfig, IntroManager, IntroState
+pygame = pytest.importorskip("pygame")
+
+from app.intro import IntroConfig, IntroManager, IntroState  # noqa: E402
 
 
 def test_intro_manager_start_state() -> None:
@@ -43,3 +45,21 @@ def test_intro_manager_skip() -> None:
 
     assert manager.state == IntroState.DONE
     assert manager.is_finished()
+
+
+def test_intro_manager_skip_disallowed() -> None:
+    config = IntroConfig(
+        logo_in=10.0,
+        weapons_in=10.0,
+        hold=10.0,
+        fade_out=10.0,
+        allow_skip=False,
+        skip_key=pygame.K_s,
+    )
+    manager = IntroManager(config=config)
+    manager.start()
+
+    event = pygame.event.Event(pygame.KEYDOWN, {"key": pygame.K_s})
+    manager.update(0.0, [event])
+
+    assert manager.state == IntroState.LOGO_IN

--- a/tests/unit/test_intro_renderer.py
+++ b/tests/unit/test_intro_renderer.py
@@ -1,7 +1,16 @@
 from __future__ import annotations
 
-from app.intro import IntroConfig
-from app.render.intro_renderer import IntroRenderer
+from typing import TYPE_CHECKING
+
+import pytest
+
+pygame = pytest.importorskip("pygame")
+
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    import pygame as _pygame
+
+from app.intro import IntroConfig  # noqa: E402
+from app.render.intro_renderer import IntroRenderer  # noqa: E402
 
 
 def test_compute_positions_slide_and_center() -> None:
@@ -41,3 +50,45 @@ def test_compute_alpha_custom_fade() -> None:
     config = IntroConfig(fade=lambda t: t)
     renderer = IntroRenderer(200, 100, config=config)
     assert renderer.compute_alpha(0.25) == int(0.5 * 255)
+
+
+def test_draw_glow_passes(monkeypatch: pytest.MonkeyPatch) -> None:
+    pygame.init()
+    renderer = IntroRenderer(200, 100)
+    surface = pygame.Surface((200, 100), flags=pygame.SRCALPHA)
+    blits: list[tuple[int, int]] = []
+
+    original_blit = pygame.Surface.blit
+
+    def counting_blit(
+        self: _pygame.Surface,
+        source: _pygame.Surface,
+        dest: _pygame.Rect | tuple[int, int],
+        *args: object,
+        **kwargs: object,
+    ) -> _pygame.Rect:
+        center = dest.center if hasattr(dest, "center") else dest
+        blits.append(center)
+        return original_blit(self, source, dest, *args, **kwargs)
+
+    monkeypatch.setattr(pygame.Surface, "blit", counting_blit)
+
+    renderer.draw(surface, ("A", "B"), 1.0)
+
+    left, right, center = renderer.compute_positions(1.0)
+    expected_centers: list[tuple[int, int]] = []
+    for base in (left, right, center):
+        bx, by = int(base[0]), int(base[1])
+        expected_centers.extend(
+            [
+                (bx + 4, by + 4),
+                (bx - 2, by),
+                (bx + 2, by),
+                (bx, by - 2),
+                (bx, by + 2),
+                (bx, by),
+            ]
+        )
+
+    assert len(blits) == len(expected_centers)
+    assert set(expected_centers).issubset(set(blits))

--- a/tests/unit/test_tween.py
+++ b/tests/unit/test_tween.py
@@ -36,3 +36,12 @@ def test_continuity(func: Callable[[float], float]) -> None:
     center = func(0.5)
     assert func(0.5 - eps) == pytest.approx(center, abs=1e-4)
     assert func(0.5 + eps) == pytest.approx(center, abs=1e-4)
+
+
+@pytest.mark.parametrize(
+    "func",
+    [linear, ease_in_out_cubic, ease_out_back, ease_out_elastic],
+)
+def test_clamping_out_of_range(func: Callable[[float], float]) -> None:
+    assert func(-1.0) == pytest.approx(0.0)
+    assert func(2.0) == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- ensure tests run headless by forcing dummy SDL drivers
- add clamping checks for all easing functions
- verify intro manager skip handling and intro renderer glow passes

## Testing
- `uv run ruff check tests/unit/test_intro_renderer.py tests/unit/test_intro_manager.py tests/unit/test_tween.py tests/conftest.py`
- `uv run mypy tests/conftest.py tests/unit/test_tween.py tests/unit/test_intro_manager.py tests/unit/test_intro_renderer.py`
- `uv run pytest tests/unit/test_tween.py tests/unit/test_intro_manager.py tests/unit/test_intro_renderer.py`


------
https://chatgpt.com/codex/tasks/task_e_68b40fa4eae4832ab4a60ae37446b79d