### PR TITLE
docs: add intro animation documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,3 +96,4 @@ Générer automatiquement des **vidéos satisfaction** (format TikTok 1080×1920
 ## Définition du “Done”
 
 - Lint OK, format OK, mypy OK, tests OK, couverture OK, doc mise à jour, ADR si changement d’archi.
+- L'intro testée sur plusieurs résolutions (ex. 720p et 1080p).

--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ uv run python -m app.cli batch \
 - **Configuration externe** : `app/config.json` regroupe canvas, palette (bleu/orange), HUD (titre, watermark) et paramètres d'**end screen** (textes, slow-mo, fade...).
 - **FPS / résolution** : ajuster `canvas` dans `app/config.json`.
 
+## 🎬 Intro animation
+
+Avant chaque match, une courte séquence présente les armes en jeu.
+
+- **Configuration** : `IntroConfig` permet d'ajuster les durées, les fonctions d'interpolation et la touche de saut. Utilisez `allow_skip=False` pour imposer l'animation.
+- **Assets** : le logo et les images d'armes sont chargés depuis `assets/`. L'option CLI `--intro-weapons` permet de remplacer les visuels par défaut.
+- **Skip** : appuyez sur `Échap` pour passer l'animation.
+
 ### Développer une nouvelle arme
 
 1. **Skin** : placer l'image dans `assets/` puis la charger via `load_sprite`.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,0 +1,20 @@
+# Intro animation
+
+Ce document décrit l'architecture de l'animation d'introduction avant chaque match.
+
+## IntroManager
+
+- Machine à états gérant les phases : `LOGO_IN`, `WEAPONS_IN`, `HOLD`, `FADE_OUT`, `DONE`.
+- Méthodes `start`, `update(dt, events)`, `draw(surface, labels)` et `is_finished` orchestrent la séquence.
+- Permet de passer l'intro via la touche de saut (Échap par défaut) quand `allow_skip=True`.
+
+## IntroRenderer
+
+- Calcule les positions et l'opacité des éléments selon le `progress` fourni par le gestionnaire.
+- Utilise les paramètres d'`IntroConfig` pour les dimensions, les positions et les fonctions d'interpolation.
+- Rend les labels des armes et le marqueur central sur une surface `pygame`.
+
+## Tween / Easing
+
+- Les transitions reposent sur des fonctions d'interpolation (`ease_out_back`, `pulse_ease`, `fade`) définies dans `IntroConfig`.
+- Le module utilitaire `app/core/tween.py` expose des easings génériques (`linear`, `ease_in_out_cubic`, ...`) réutilisables dans le moteur.


### PR DESCRIPTION
## Summary
- document intro animation setup and skipping in README
- describe intro architecture (IntroManager, IntroRenderer, tween) in docs/intro.md
- require testing intro on multiple resolutions in AGENTS guidelines

## Testing
- `uv run pre-commit run --files README.md docs/intro.md AGENTS.md` *(failed: pre-commit missing)*
- `uv sync --all-extras --dev` *(failed: unable to download certifi)*
- `uv run pytest` *(failed: ModuleNotFoundError: pydantic, imageio_ffmpeg)*

------
https://chatgpt.com/codex/tasks/task_e_68b412d55c38832aa91ae0d58524afde