### PR TITLE
fix: improve intro weapons option

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -35,8 +35,7 @@ def run(
         tuple[str, str] | None,
         typer.Option(
             "--intro-weapons",
-            nargs=2,
-            metavar="left=PATH right=PATH",
+            metavar=("left=PATH", "right=PATH"),
             help="Override intro weapon images",
         ),
     ] = None,


### PR DESCRIPTION
## Summary
- simplify intro weapons tuple option

## Testing
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `uv run pip-audit -q` *(fails: No such file or directory)*
- `uv run bandit -q -r .` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b425f10dc0832aae180b1a60ba689c