### PR TITLE
fix: align match timeline across phases

### DIFF
--- a/tests/integration/test_postprocessed_slowmo.py
+++ b/tests/integration/test_postprocessed_slowmo.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from app.core.config import settings
 from app.core.types import Damage, EntityId, Vec2
+from app.game.intro import IntroManager
 from app.game.match import run_match
 from app.render.renderer import Renderer
 from app.video.recorder import Recorder
@@ -71,4 +72,11 @@ def test_postprocessed_slowmo(tmp_path: Path) -> None:
     video_dur = _stream_duration(out, "v")
     audio_dur = _stream_duration(out, "a")
     assert abs(video_dur - audio_dur) < 0.1
-    assert 7.9 < video_dur < 8.1
+    intro_duration = IntroManager()._duration
+    expected = (
+        intro_duration
+        + EVENT_TIME
+        + settings.end_screen.explosion_duration
+        + (settings.end_screen.pre_s + settings.end_screen.post_s) / settings.end_screen.slow_factor
+    )
+    assert expected - 0.1 < video_dur < expected + 0.1

--- a/tests/test_headless_match_kill_audio.py
+++ b/tests/test_headless_match_kill_audio.py
@@ -5,6 +5,7 @@ import numpy as np
 from app.audio import AudioEngine, reset_default_engine
 from app.core.config import settings
 from app.core.types import Damage, EntityId, Vec2
+from app.game.intro import IntroManager
 from app.game.match import run_match
 from app.render.renderer import Renderer
 from app.video.recorder import Recorder
@@ -59,7 +60,8 @@ def test_headless_match_records_kill_audio() -> None:
     run_match("instakill", "instakill", recorder, renderer, max_seconds=1)
     assert recorder.audio is not None
 
-    kill_sample = int(EVENT_TIME * AudioEngine.SAMPLE_RATE)
+    intro_duration = IntroManager()._duration
+    kill_sample = int((intro_duration + EVENT_TIME) * AudioEngine.SAMPLE_RATE)
     window = recorder.audio[kill_sample : kill_sample + 200]
     assert np.any(window != 0)
 


### PR DESCRIPTION
## Summary
- track intro elapsed time and compute unified match clock
- use absolute timestamps for effects and weapon/ball audio
- fix tests expecting hardcoded durations

## Testing
- `uv run ruff check .`
- `uv run ruff format app/game/controller.py tests/test_headless_match_kill_audio.py tests/integration/test_postprocessed_slowmo.py`
- `uv run mypy .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `uv sync --all-extras --dev` *(fails: failed to download `pip==25.2`)*

------
https://chatgpt.com/codex/tasks/task_e_68b42808fadc832a998e8fd5bbc849bc