### PR TITLE
refactor: adopt new intro manager API

### DIFF
--- a/app/game/controller.py
+++ b/app/game/controller.py
@@ -12,6 +12,7 @@ from app.ai.policy import SimplePolicy
 from app.audio import AudioEngine, BallAudio
 from app.core.config import settings
 from app.core.types import Color, Damage, EntityId, ProjectileInfo, Vec2
+from app.intro import IntroManager
 from app.render.hud import Hud
 from app.render.renderer import Renderer
 from app.video.recorder import RecorderProtocol
@@ -20,8 +21,6 @@ from app.weapons.base import Weapon, WeaponEffect, WorldView
 from app.world.entities import Ball
 from app.world.physics import PhysicsWorld
 from app.world.projectiles import Projectile
-
-from .intro import IntroManager
 
 
 @dataclass(slots=True)
@@ -194,10 +193,14 @@ class GameController:
             if not self.display:
                 self.engine.start_capture()
             intro_elapsed = 0.0
+            labels = (self.weapon_a.capitalize(), self.weapon_b.capitalize())
+            self.intro_manager.start()
             while not self.intro_manager.is_finished():
                 self.intro_manager.update(settings.dt)
                 self.renderer.clear()
-                self.intro_manager.draw(self.renderer, self.hud)
+                self.intro_manager.draw(self.renderer.surface, labels)
+                self.hud.draw_title(self.renderer.surface, settings.hud.title)
+                self.hud.draw_watermark(self.renderer.surface, settings.hud.watermark)
                 self.renderer.present()
                 if not self.display:
                     frame_surface = self.renderer.surface.copy()

--- a/app/game/match.py
+++ b/app/game/match.py
@@ -9,10 +9,8 @@ from app.game.controller import (
     Player,
     _MatchView,  # noqa: F401 - re-exported for tests
 )
-from app.game.intro import IntroManager
-from app.intro.config import IntroConfig
+from app.intro import IntroConfig, IntroManager
 from app.render.hud import Hud
-from app.render.intro_renderer import IntroRenderer
 from app.render.renderer import Renderer
 from app.video.recorder import RecorderProtocol
 from app.weapons import weapon_registry
@@ -68,11 +66,8 @@ def create_controller(
         ),
     ]
 
-    intro_renderer = IntroRenderer(settings.width, settings.height, intro_config)
-    intro = IntroManager(
-        labels=(weapon_a.capitalize(), weapon_b.capitalize()),
-        intro_renderer=intro_renderer,
-    )
+    intro_config = intro_config or IntroConfig(hold=1.0, fade_out=0.25)
+    intro = IntroManager(config=intro_config)
     return GameController(
         weapon_a,
         weapon_b,

--- a/tests/integration/test_intro_audio_delay.py
+++ b/tests/integration/test_intro_audio_delay.py
@@ -7,8 +7,8 @@ from app.audio import AudioEngine, reset_default_engine
 from app.audio.env import temporary_sdl_audio_driver
 from app.core.config import settings
 from app.core.types import Damage, EntityId, Vec2
-from app.game.intro import IntroManager
 from app.game.match import create_controller
+from app.intro import IntroConfig, IntroManager
 from app.render.renderer import Renderer
 from app.weapons import weapon_registry
 from app.weapons.base import Weapon, WorldView
@@ -23,7 +23,9 @@ class InstantKillWeapon(Weapon):
         super().__init__(name="instakill", cooldown=0.0, damage=Damage(200))
         self._done = False
 
-    def _fire(self, owner: EntityId, view: WorldView, direction: Vec2) -> None:  # pragma: no cover - stub
+    def _fire(
+        self, owner: EntityId, view: WorldView, direction: Vec2
+    ) -> None:  # pragma: no cover - stub
         return None
 
     def update(self, owner: EntityId, view: WorldView, dt: float) -> None:
@@ -57,10 +59,17 @@ def test_audio_starts_after_intro() -> None:
     with temporary_sdl_audio_driver("dummy"):
         recorder = SpyRecorder()
         renderer = Renderer(settings.width, settings.height)
-        controller = create_controller(
-            "instakill", "instakill", recorder, renderer, max_seconds=1
+        controller = create_controller("instakill", "instakill", recorder, renderer, max_seconds=1)
+        controller.intro_manager = IntroManager(
+            config=IntroConfig(
+                logo_in=intro_duration,
+                weapons_in=0.0,
+                hold=0.0,
+                fade_out=0.0,
+                allow_skip=False,
+            )
         )
-        controller.intro_manager = IntroManager(duration=intro_duration)
+        controller.intro_manager.start()
         engine = controller.engine
         engine.start_capture()
 

--- a/tests/integration/test_intro_loop.py
+++ b/tests/integration/test_intro_loop.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
+import pygame
+
 from app.core.config import settings
 from app.game.controller import GameController
-from app.game.intro import IntroManager
 from app.game.match import create_controller
-from app.render.hud import Hud
+from app.intro import IntroConfig, IntroManager
 from app.render.renderer import Renderer
 from tests.integration.helpers import SpyRecorder
 
@@ -13,21 +16,29 @@ class StubIntroManager(IntroManager):
     """Intro manager stub used to control flow during tests."""
 
     def __init__(self, frames: int, skip_at: int | None = None) -> None:
-        super().__init__(labels=("", ""))
+        super().__init__(config=IntroConfig(logo_in=0.0, weapons_in=0.0, hold=0.0, fade_out=0.0))
         self.frames = frames
         self.skip_at = skip_at
         self.updates = 0
         self.draws = 0
+        self._skipped = False
+
+    def start(self) -> None:  # pragma: no cover - override
+        return
 
     def is_finished(self) -> bool:  # pragma: no cover - simple predicate
         return self._skipped or self.updates >= self.frames
 
-    def update(self, dt: float) -> None:  # pragma: no cover - simple counter
+    def update(
+        self, dt: float, events: Sequence[pygame.event.Event] | None = None
+    ) -> None:  # pragma: no cover - simple counter
         self.updates += 1
         if self.skip_at is not None and self.updates >= self.skip_at:
-            self.skip()
+            self._skipped = True
 
-    def draw(self, renderer: Renderer, hud: Hud) -> None:  # pragma: no cover - simple counter
+    def draw(
+        self, surface: pygame.Surface, labels: tuple[str, str]
+    ) -> None:  # pragma: no cover - simple counter
         self.draws += 1
 
 

--- a/tests/integration/test_postprocessed_slowmo.py
+++ b/tests/integration/test_postprocessed_slowmo.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 from app.core.config import settings
 from app.core.types import Damage, EntityId, Vec2
-from app.game.intro import IntroManager
 from app.game.match import run_match
+from app.intro import IntroConfig
 from app.render.renderer import Renderer
 from app.video.recorder import Recorder
 from app.weapons import weapon_registry
@@ -72,7 +72,10 @@ def test_postprocessed_slowmo(tmp_path: Path) -> None:
     video_dur = _stream_duration(out, "v")
     audio_dur = _stream_duration(out, "a")
     assert abs(video_dur - audio_dur) < 0.1
-    intro_duration = IntroManager()._duration
+    intro_config = IntroConfig(hold=1.0, fade_out=0.25)
+    intro_duration = (
+        intro_config.logo_in + intro_config.weapons_in + intro_config.hold + intro_config.fade_out
+    )
     expected = (
         intro_duration
         + EVENT_TIME

--- a/tests/test_headless_match_kill_audio.py
+++ b/tests/test_headless_match_kill_audio.py
@@ -5,8 +5,8 @@ import numpy as np
 from app.audio import AudioEngine, reset_default_engine
 from app.core.config import settings
 from app.core.types import Damage, EntityId, Vec2
-from app.game.intro import IntroManager
 from app.game.match import run_match
+from app.intro import IntroConfig
 from app.render.renderer import Renderer
 from app.video.recorder import Recorder
 from app.weapons import weapon_registry
@@ -60,7 +60,10 @@ def test_headless_match_records_kill_audio() -> None:
     run_match("instakill", "instakill", recorder, renderer, max_seconds=1)
     assert recorder.audio is not None
 
-    intro_duration = IntroManager()._duration
+    intro_config = IntroConfig(hold=1.0, fade_out=0.25)
+    intro_duration = (
+        intro_config.logo_in + intro_config.weapons_in + intro_config.hold + intro_config.fade_out
+    )
     kill_sample = int((intro_duration + EVENT_TIME) * AudioEngine.SAMPLE_RATE)
     window = recorder.audio[kill_sample : kill_sample + 200]
     assert np.any(window != 0)


### PR DESCRIPTION
## Summary
- use `app.intro.IntroManager` and configure hold and fade-out
- update game controller to new intro drawing API
- adjust tests for intro timing and configuration

## Testing
- `uv run ruff check app/game/match.py app/game/controller.py tests/integration/test_intro_audio_delay.py tests/integration/test_intro_loop.py tests/integration/test_postprocessed_slowmo.py tests/test_headless_match_kill_audio.py`
- `uv run mypy app/game/match.py app/game/controller.py tests/integration/test_intro_audio_delay.py tests/integration/test_intro_loop.py tests/integration/test_postprocessed_slowmo.py tests/test_headless_match_kill_audio.py`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `uv pip install numpy pydantic imageio-ffmpeg` *(missing dependencies, no packages installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b433e068c4832a8cae88cf3b396b82