### PR TITLE
feat: load intro weapon assets

### DIFF
--- a/app/game/match.py
+++ b/app/game/match.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from app.ai.policy import SimplePolicy
 from app.audio import BallAudio, get_default_engine
 from app.core.config import settings
@@ -9,7 +11,7 @@ from app.game.controller import (
     Player,
     _MatchView,  # noqa: F401 - re-exported for tests
 )
-from app.intro import IntroConfig, IntroManager
+from app.intro import IntroConfig, IntroManager, set_intro_weapons
 from app.render.hud import Hud
 from app.render.renderer import Renderer
 from app.video.recorder import RecorderProtocol
@@ -67,6 +69,10 @@ def create_controller(
     ]
 
     intro_config = intro_config or IntroConfig(hold=1.0, fade_out=0.25)
+    weapons_dir = Path(__file__).resolve().parents[2] / "assets" / "weapons"
+    weapon_a_path = weapons_dir / weapon_a / "weapon.png"
+    weapon_b_path = weapons_dir / weapon_b / "weapon.png"
+    intro_config = set_intro_weapons(weapon_a_path, weapon_b_path, config=intro_config)
     intro = IntroManager(config=intro_config)
     return GameController(
         weapon_a,

--- a/tests/integration/test_intro_assets_loading.py
+++ b/tests/integration/test_intro_assets_loading.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pygame
+
+from app.game.match import create_controller
+from app.intro import IntroAssets
+from tests.integration.helpers import SpyRecorder
+
+
+def test_intro_assets_load_weapon_images() -> None:
+    controller = create_controller("katana", "shuriken", SpyRecorder(), max_seconds=0)
+    config = controller.intro_manager.config
+
+    assets = IntroAssets.load(config)
+
+    expected_a = pygame.image.load(str(Path("assets/weapons/katana/weapon.png"))).convert_alpha()
+    expected_b = pygame.image.load(str(Path("assets/weapons/shuriken/weapon.png"))).convert_alpha()
+
+    assert pygame.image.tostring(assets.weapon_a, "RGBA") == pygame.image.tostring(
+        expected_a, "RGBA"
+    )
+    assert pygame.image.tostring(assets.weapon_b, "RGBA") == pygame.image.tostring(
+        expected_b, "RGBA"
+    )
+    pygame.quit()


### PR DESCRIPTION
## Summary
- set intro weapon image paths in match controller
- exercise IntroAssets with real weapon assets

## Testing
- `uv run ruff format app/game/match.py tests/integration/test_intro_assets_loading.py`
- `uv run ruff check app/game/match.py tests/integration/test_intro_assets_loading.py`
- `uv run mypy app/game/match.py tests/integration/test_intro_assets_loading.py`
- `python -m pytest tests/integration/test_intro_assets_loading.py` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_68b43a8daaac832abea802d46d29c28c