### PR TITLE
fix: use monotonic easing for weapon intro

### DIFF
--- a/app/intro/config.py
+++ b/app/intro/config.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 
 from app.core.types import Vec2
-from app.core.utils import ease_out_quad
+from app.core.utils import clamp, ease_out_quad
 
 Easing = Callable[[float], float]
 
@@ -17,11 +17,9 @@ def ease_out_back(t: float) -> float:
     return 1 + c3 * (t - 1) ** 3 + c1 * (t - 1) ** 2
 
 
-def pulse_ease(t: float) -> float:
-    """Return a pulsating value between 0 and 1."""
-    import math
-
-    return 0.5 - 0.5 * math.cos(t * math.tau)
+def monotone_pulse(t: float) -> float:
+    """Return a monotonic easing curve for the weapon intro."""
+    return ease_out_quad(clamp(t, 0.0, 1.0))
 
 
 @dataclass(frozen=True, slots=True)
@@ -56,7 +54,7 @@ class IntroConfig:
     hold: float = 1.0
     fade_out: float = 1.0
     micro_bounce: Easing = ease_out_back
-    pulse: Easing = pulse_ease
+    pulse: Easing = monotone_pulse
     fade: Easing = ease_out_quad
     left_pos_pct: Vec2 = (0.25, 0.5)
     right_pos_pct: Vec2 = (0.75, 0.5)

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -16,5 +16,5 @@ Ce document décrit l'architecture de l'animation d'introduction avant chaque ma
 
 ## Tween / Easing
 
-- Les transitions reposent sur des fonctions d'interpolation (`ease_out_back`, `pulse_ease`, `fade`) définies dans `IntroConfig`.
+- Les transitions reposent sur des fonctions d'interpolation (`ease_out_back`, `ease_out_quad`, `fade`) définies dans `IntroConfig`.
 - Le module utilitaire `app/core/tween.py` expose des easings génériques (`linear`, `ease_in_out_cubic`, ...`) réutilisables dans le moteur.

--- a/tests/test_match_slowmo_timestamp.py
+++ b/tests/test_match_slowmo_timestamp.py
@@ -78,7 +78,7 @@ def test_append_slowmo_receives_death_timestamp(
     assert captured_death is not None
     assert controller.death_ts is not None
     assert captured_death == pytest.approx(controller.death_ts)
-    assert captured_death >= controller.intro_manager._duration
+    assert captured_death >= controller.intro_manager._duration  # type: ignore[attr-defined]
 
     weapon_registry._factories.pop("instakill_test")
     reset_default_engine()

--- a/tests/test_match_stop_winner_idle.py
+++ b/tests/test_match_stop_winner_idle.py
@@ -81,15 +81,13 @@ def test_winner_idle_sound_stops_on_victory() -> None:
 
     recorder = DummyRecorder()
     renderer = Renderer(settings.width, settings.height)
-    controller = create_controller(
-        "killer_test", "passive_test", recorder, renderer, max_seconds=1
-    )
+    controller = create_controller("killer_test", "passive_test", recorder, renderer, max_seconds=1)
     controller.run()
 
     assert audio_a.stopped_at is not None
     assert controller.death_ts is not None
     assert audio_a.stopped_at == pytest.approx(controller.death_ts)
-    intro_duration = controller.intro_manager._duration
+    intro_duration = controller.intro_manager._duration  # type: ignore[attr-defined]
     assert audio_a.stopped_at >= intro_duration
     assert audio_b.stopped_at is not None
 

--- a/tests/unit/test_intro_manager.py
+++ b/tests/unit/test_intro_manager.py
@@ -63,3 +63,47 @@ def test_intro_manager_skip_disallowed() -> None:
     manager.update(0.0, [event])
 
     assert manager.state == IntroState.LOGO_IN
+
+
+def test_weapons_in_monotonic_then_hold_and_fade() -> None:
+    config = IntroConfig(
+        logo_in=0.0,
+        weapons_in=1.0,
+        hold=1.0,
+        fade_out=1.0,
+        allow_skip=False,
+    )
+    manager = IntroManager(config=config)
+    manager.start()
+    manager.update(0.0)
+
+    state = manager.state
+    assert state == IntroState.WEAPONS_IN
+
+    previous = manager._progress()
+    for _ in range(5):
+        manager.update(0.2)
+        progress = manager._progress()
+        assert previous <= progress <= 1.0
+        previous = progress
+
+    state = manager.state
+    assert state == IntroState.HOLD
+    assert manager._progress() == pytest.approx(1.0)
+
+    manager.update(0.5)
+    state = manager.state
+    assert state == IntroState.HOLD
+    assert manager._progress() == pytest.approx(1.0)
+
+    manager.update(0.5)
+    state = manager.state
+    assert state == IntroState.FADE_OUT
+    fade_start = manager._progress()
+    assert fade_start == pytest.approx(1.0)
+
+    manager.update(0.5)
+    fade_mid = manager._progress()
+    assert 0.0 <= fade_mid < fade_start
+    manager.update(0.25)
+    assert manager._progress() < fade_mid


### PR DESCRIPTION
## Summary
- replace pulsating weapon intro easing with monotonic curve based on `ease_out_quad`
- document new easing behaviour
- test that weapon intro runs once, holds for a second, then fades

## Testing
- `uv run ruff check .`
- `uv run mypy .`
- `uv run --with pytest-cov pytest --cov=.` *(fails: Failed to fetch `pytest-cov`)*
- `uv sync --all-extras --dev` *(fails: tunnel error while downloading `cachecontrol`)*
- `uv run pytest` *(fails: 28 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b43a87d1d4832a94b0e20d7d5f24ed