### PR TITLE
fix: refine intro fade logic

### DIFF
--- a/app/game/intro.py
+++ b/app/game/intro.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from app.core.config import settings
+from app.intro import IntroState
 from app.render.hud import Hud
 from app.render.intro_renderer import IntroRenderer
 from app.render.renderer import Renderer
@@ -42,6 +43,6 @@ class IntroManager:
         """Render the current frame of the intro sequence."""
 
         progress = 1.0 if self._duration == 0 else min(self._elapsed / self._duration, 1.0)
-        self._renderer.draw(renderer.surface, self._labels, progress)
+        self._renderer.draw(renderer.surface, self._labels, progress, IntroState.LOGO_IN)
         hud.draw_title(renderer.surface, settings.hud.title)
         hud.draw_watermark(renderer.surface, settings.hud.watermark)

--- a/app/intro/intro_manager.py
+++ b/app/intro/intro_manager.py
@@ -87,7 +87,7 @@ class IntroManager:
         """Render the intro on ``surface`` using the configured renderer."""
 
         progress = self._progress()
-        self._renderer.draw(surface, labels, progress)
+        self._renderer.draw(surface, labels, progress, self._state)
 
     def is_finished(self) -> bool:
         """Return ``True`` if the intro has completed."""


### PR DESCRIPTION
## Summary
- fade intro elements in during LOGO_IN and WEAPONS_IN and fade out during FADE_OUT
- wire intro state through renderer
- test monotonic alpha progression

## Testing
- `uv run ruff check app/render/intro_renderer.py app/intro/intro_manager.py app/game/intro.py tests/unit/test_intro_renderer.py`
- `uv run mypy app/render/intro_renderer.py app/intro/intro_manager.py app/game/intro.py`
- `uv run pytest tests/unit/test_intro_renderer.py tests/unit/test_intro_manager.py` *(fails: skipped - pygame not installed)*
- `uv run pip install pygame` *(fails: Could not find a version that satisfies the requirement pygame)*

------
https://chatgpt.com/codex/tasks/task_e_68b43d1c6c34832a9a1f1aa0a155f906