### PR TITLE
feat: render intro images from preloaded assets

### DIFF
--- a/app/intro/intro_manager.py
+++ b/app/intro/intro_manager.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import replace
 from enum import Enum, auto
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from app.core.config import settings
 from app.core.utils import clamp
 from app.render.intro_renderer import IntroRenderer
 
+from .assets import IntroAssets
 from .config import IntroConfig
 
 if TYPE_CHECKING:  # pragma: no cover - hints only
@@ -40,8 +43,12 @@ class IntroManager:
         engine: AudioEngine | None = None,
     ) -> None:
         self.config = config or IntroConfig()
+        if self.config.logo_path is None:
+            assets_dir = Path(__file__).resolve().parents[2] / "assets"
+            self.config = replace(self.config, logo_path=assets_dir / "vs.png")
+        self.assets = IntroAssets.load(self.config)
         self._renderer = intro_renderer or IntroRenderer(
-            settings.width, settings.height, self.config
+            settings.width, settings.height, self.config, assets=self.assets
         )
         self._engine = engine
         self._state = IntroState.IDLE

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -4,6 +4,7 @@ Ce document décrit l'architecture de l'animation d'introduction avant chaque ma
 
 ## IntroManager
 
+- Précharge les assets nécessaires via `IntroAssets.load` : police, logo VS (`assets/vs.png`) et images des armes.
 - Machine à états gérant les phases : `LOGO_IN`, `WEAPONS_IN`, `HOLD`, `FADE_OUT`, `DONE`.
 - Méthodes `start`, `update(dt, events)`, `draw(surface, labels)` et `is_finished` orchestrent la séquence.
 - Permet de passer l'intro via la touche de saut (Échap par défaut) quand `allow_skip=True`.
@@ -12,7 +13,8 @@ Ce document décrit l'architecture de l'animation d'introduction avant chaque ma
 
 - Calcule les positions et l'opacité des éléments selon le `progress` fourni par le gestionnaire.
 - Utilise les paramètres d'`IntroConfig` pour les dimensions, les positions et les fonctions d'interpolation.
-- Rend les labels des armes et le marqueur central sur une surface `pygame`.
+- Affiche le logo VS et les images des armes avec un slide-in et un glow avant un fade final.
+- Les éléments restent visibles pendant `hold=1s` puis disparaissent via `fade_out=0.25s`.
 
 ## Tween / Easing
 

--- a/tests/integration/test_intro_assets_loading.py
+++ b/tests/integration/test_intro_assets_loading.py
@@ -1,27 +1,58 @@
 from __future__ import annotations
 
-from pathlib import Path
+from collections import defaultdict
 
 import pygame
 
+from app.core.config import settings
 from app.game.match import create_controller
-from app.intro import IntroAssets
 from tests.integration.helpers import SpyRecorder
 
 
-def test_intro_assets_load_weapon_images() -> None:
+def test_intro_assets_loaded_and_drawn_once() -> None:
+    load_counts: dict[str, int] = defaultdict(int)
+    original_load = pygame.image.load
+
+    def counting_load(path: str) -> pygame.Surface:
+        for key in ("vs.png", "katana/weapon.png", "shuriken/weapon.png"):
+            if path.endswith(key):
+                load_counts[key] += 1
+        return original_load(path)
+
+    pygame.image.load = counting_load
     controller = create_controller("katana", "shuriken", SpyRecorder(), max_seconds=0)
-    config = controller.intro_manager.config
+    intro = controller.intro_manager
 
-    assets = IntroAssets.load(config)
+    try:
+        assert load_counts["vs.png"] == 1
+        assert load_counts["katana/weapon.png"] == 1
+        assert load_counts["shuriken/weapon.png"] == 1
 
-    expected_a = pygame.image.load(str(Path("assets/weapons/katana/weapon.png"))).convert_alpha()
-    expected_b = pygame.image.load(str(Path("assets/weapons/shuriken/weapon.png"))).convert_alpha()
+        assets = intro._renderer.assets
+        assert assets is not None
+        counts = {id(assets.logo): 0, id(assets.weapon_a): 0, id(assets.weapon_b): 0}
+        original_rotozoom = pygame.transform.rotozoom
 
-    assert pygame.image.tostring(assets.weapon_a, "RGBA") == pygame.image.tostring(
-        expected_a, "RGBA"
-    )
-    assert pygame.image.tostring(assets.weapon_b, "RGBA") == pygame.image.tostring(
-        expected_b, "RGBA"
-    )
-    pygame.quit()
+        def counting_rotozoom(
+            surface: pygame.Surface, angle: float, scale: float
+        ) -> pygame.Surface:
+            key = id(surface)
+            if key in counts:
+                counts[key] += 1
+            return original_rotozoom(surface, angle, scale)
+
+        pygame.transform.rotozoom = counting_rotozoom
+        surface = pygame.Surface((settings.width, settings.height))
+
+        intro.start()
+        while not intro.is_finished():
+            for k in counts:
+                counts[k] = 0
+            intro.draw(surface, ("", ""))
+            for v in counts.values():
+                assert v == 1
+            intro.update(1.0)
+    finally:
+        pygame.transform.rotozoom = original_rotozoom
+        pygame.image.load = original_load
+        pygame.quit()


### PR DESCRIPTION
## Summary
- preload font, VS logo, and weapon images for the intro sequence
- render VS and weapons as images with slide transitions
- document asset-based intro timing and add coverage test

## Testing
- `uv run ruff check .`
- `uv run mypy app/intro/intro_manager.py app/render/intro_renderer.py tests/integration/test_intro_assets_loading.py`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pygame')*


------
https://chatgpt.com/codex/tasks/task_e_68b43ee48388832a98d77285af410a8d