### PR TITLE
fix: keep weapons intro fully opaque

### DIFF
--- a/app/render/intro_renderer.py
+++ b/app/render/intro_renderer.py
@@ -65,16 +65,18 @@ class IntroRenderer:
     def compute_alpha(self, progress: float, state: IntroState) -> int:
         """Return opacity for ``progress`` given the intro ``state``.
 
-        ``LOGO_IN`` and ``WEAPONS_IN`` fade from transparent to fully opaque.
-        ``FADE_OUT`` transitions from opaque to transparent. Other states
-        remain fully opaque. The easing function from :class:`IntroConfig` is
-        applied for the fade-in transitions.
+        ``LOGO_IN`` fades from transparent to fully opaque using the easing
+        function from :class:`IntroConfig`. ``WEAPONS_IN`` remains fully opaque
+        regardless of progress. ``FADE_OUT`` transitions from opaque to
+        transparent. Other states remain fully opaque.
         """
         from app.intro.intro_manager import IntroState as _IntroState
 
         p = clamp(progress, 0.0, 1.0)
-        if state in (_IntroState.LOGO_IN, _IntroState.WEAPONS_IN):
+        if state is _IntroState.LOGO_IN:
             return int(self.config.fade(p) * 255)
+        if state is _IntroState.WEAPONS_IN:
+            return 255
         if state is _IntroState.FADE_OUT:
             return int(p * 255)
         return 255

--- a/tests/unit/test_intro_renderer.py
+++ b/tests/unit/test_intro_renderer.py
@@ -39,14 +39,19 @@ def test_compute_positions_custom_config() -> None:
     assert center == (50.0, 100.0)
 
 
-def test_compute_alpha_in_states_monotonic() -> None:
+def test_compute_alpha_logo_in_fades_in() -> None:
     renderer = IntroRenderer(200, 100)
     progresses = [0.0, 0.3, 0.6, 1.0]
-    for state in (IntroState.LOGO_IN, IntroState.WEAPONS_IN):
-        alphas = [renderer.compute_alpha(p, state) for p in progresses]
-        assert alphas[0] == 0
-        assert alphas[-1] == 255
-        assert all(a0 <= a1 for a0, a1 in zip(alphas, alphas[1:], strict=False))
+    alphas = [renderer.compute_alpha(p, IntroState.LOGO_IN) for p in progresses]
+    assert alphas[0] == 0
+    assert alphas[-1] == 255
+    assert all(a0 <= a1 for a0, a1 in zip(alphas, alphas[1:], strict=False))
+
+
+def test_compute_alpha_weapons_in_stays_opaque() -> None:
+    renderer = IntroRenderer(200, 100)
+    for p in (0.0, 0.25, 0.5, 0.75, 1.0):
+        assert renderer.compute_alpha(p, IntroState.WEAPONS_IN) == 255
 
 
 def test_compute_alpha_fade_out() -> None:


### PR DESCRIPTION
## Summary
- limit fade easing to logo intro to avoid unintended opacity changes
- keep weapons intro fully opaque and add regression test

## Testing
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68b4444ad1e8832aa06a9610049417e1