### PR TITLE
feat: display weapon names in intro

### DIFF
--- a/app/intro/config.py
+++ b/app/intro/config.py
@@ -56,9 +56,9 @@ class IntroConfig:
     micro_bounce: Easing = ease_out_back
     pulse: Easing = monotone_pulse
     fade: Easing = ease_out_quad
-    left_pos_pct: Vec2 = (0.25, 0.5)
-    right_pos_pct: Vec2 = (0.75, 0.5)
-    center_pos_pct: Vec2 = (0.5, 0.5)
+    left_pos_pct: Vec2 = (0.25, 0.6)
+    right_pos_pct: Vec2 = (0.75, 0.6)
+    center_pos_pct: Vec2 = (0.5, 0.45)
     slide_offset_pct: float = 0.5
     logo_scale: float = 1.0
     weapon_scale: float = 1.0

--- a/app/intro/intro_manager.py
+++ b/app/intro/intro_manager.py
@@ -43,9 +43,14 @@ class IntroManager:
         engine: AudioEngine | None = None,
     ) -> None:
         self.config = config or IntroConfig()
-        if self.config.logo_path is None:
+        if self.config.logo_path is None or self.config.font_path is None:
             assets_dir = Path(__file__).resolve().parents[2] / "assets"
-            self.config = replace(self.config, logo_path=assets_dir / "vs.png")
+            updates: dict[str, object] = {}
+            if self.config.logo_path is None:
+                updates["logo_path"] = assets_dir / "vs.png"
+            if self.config.font_path is None:
+                updates["font_path"] = assets_dir / "fonts" / "FightKickDemoRegular.ttf"
+            self.config = replace(self.config, **updates)
         self.assets = IntroAssets.load(self.config)
         self._renderer = intro_renderer or IntroRenderer(
             settings.width, settings.height, self.config, assets=self.assets

--- a/app/render/intro_renderer.py
+++ b/app/render/intro_renderer.py
@@ -16,6 +16,9 @@ if TYPE_CHECKING:  # pragma: no cover - hints only
 class IntroRenderer:
     """Render the pre-match introduction with slide, glow and fade effects."""
 
+    WEAPON_WIDTH_RATIO: float = 0.4
+    IMAGE_TEXT_GAP: float = 10.0
+
     def __init__(
         self,
         width: int,
@@ -106,15 +109,28 @@ class IntroRenderer:
         alpha = self.compute_alpha(progress, state)
 
         if self.assets is not None:
-            surfaces = [
-                (self.assets.weapon_a, left_pos, self.config.weapon_scale),
-                (self.assets.weapon_b, right_pos, self.config.weapon_scale),
-                (self.assets.logo, center_pos, self.config.logo_scale),
+            if self.font is None:
+                self.font = self.assets.font
+            text_surfaces = [
+                (self.font.render(labels[0], True, (255, 255, 255)), left_pos),
+                (self.font.render(labels[1], True, (255, 255, 255)), right_pos),
             ]
-            elements = []
-            for source, pos, scale in surfaces:
-                img = pygame.transform.rotozoom(source, (progress - 0.5) * 10, scale)
-                elements.append((img, pos))
+            weapon_surfaces = []
+            for source, (text_surf, pos) in zip(
+                (self.assets.weapon_a, self.assets.weapon_b), text_surfaces, strict=False
+            ):
+                target_width = self.width * self.WEAPON_WIDTH_RATIO
+                scale = target_width / source.get_width()
+                img = pygame.transform.rotozoom(
+                    source, (progress - 0.5) * 10, scale
+                )
+                text_height = text_surf.get_height()
+                img_y = pos[1] - text_height / 2 - self.IMAGE_TEXT_GAP - img.get_height() / 2
+                weapon_surfaces.append((img, (pos[0], img_y)))
+            logo_img = pygame.transform.rotozoom(
+                self.assets.logo, (progress - 0.5) * 10, self.config.logo_scale
+            )
+            elements = weapon_surfaces + [(logo_img, center_pos)] + text_surfaces
         else:
             if self.font is None:
                 pygame.font.init()

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -13,7 +13,10 @@ Ce document décrit l'architecture de l'animation d'introduction avant chaque ma
 
 - Calcule les positions et l'opacité des éléments selon le `progress` fourni par le gestionnaire.
 - Utilise les paramètres d'`IntroConfig` pour les dimensions, les positions et les fonctions d'interpolation.
-- Affiche le logo VS et les images des armes avec un slide-in et un glow avant un fade final.
+- Affiche le logo VS centré au-dessus des noms des armes.
+- Les images des armes (40 % de la largeur de l'écran) apparaissent juste au-dessus de leur nom,
+  tous deux alignés horizontalement légèrement sous le milieu de l'écran.
+- Les noms sont rendus avec la police `assets/fonts/FightKickDemoRegular.ttf`.
 - Les éléments restent visibles pendant `hold=1s` puis disparaissent via `fade_out=0.25s`.
 
 ## Tween / Easing

--- a/tests/unit/test_intro_renderer.py
+++ b/tests/unit/test_intro_renderer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -9,7 +10,7 @@ pygame = pytest.importorskip("pygame")
 if TYPE_CHECKING:  # pragma: no cover - type hints only
     import pygame as _pygame
 
-from app.intro import IntroConfig, IntroState  # noqa: E402
+from app.intro import IntroAssets, IntroConfig, IntroState  # noqa: E402
 from app.render.intro_renderer import IntroRenderer  # noqa: E402
 
 
@@ -18,11 +19,11 @@ def test_compute_positions_slide_and_center() -> None:
     left_start, right_start, center = renderer.compute_positions(0.0)
     assert left_start[0] < 0
     assert right_start[0] > renderer.width
-    assert center == (100.0, 50.0)
+    assert center == (100.0, 45.0)
 
     left_end, right_end, _ = renderer.compute_positions(1.0)
-    assert left_end == (50.0, 50.0)
-    assert right_end == (150.0, 50.0)
+    assert left_end == (50.0, 60.0)
+    assert right_end == (150.0, 60.0)
 
 
 def test_compute_positions_custom_config() -> None:
@@ -104,3 +105,67 @@ def test_draw_glow_passes(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert len(blits) == len(expected_centers)
     assert set(expected_centers).issubset(set(blits))
+
+
+def test_draw_with_assets(monkeypatch: pytest.MonkeyPatch) -> None:
+    pygame.init()
+    config = IntroConfig(
+        font_path=Path("assets/fonts/FightKickDemoRegular.ttf"),
+        logo_path=Path("assets/vs.png"),
+        weapon_a_path=Path("assets/ball-a.png"),
+        weapon_b_path=Path("assets/ball-b.png"),
+    )
+    assets = IntroAssets.load(config)
+    renderer = IntroRenderer(200, 100, config=config, assets=assets)
+    surface = pygame.Surface((200, 100), flags=pygame.SRCALPHA)
+    blits: list[tuple[int, int]] = []
+
+    original_blit = pygame.Surface.blit
+
+    def counting_blit(
+        self: _pygame.Surface,
+        source: _pygame.Surface,
+        dest: _pygame.Rect | tuple[int, int],
+        *args: object,
+        **kwargs: object,
+    ) -> _pygame.Rect:
+        center = dest.center if hasattr(dest, "center") else dest
+        blits.append(center)
+        return original_blit(self, source, dest, *args, **kwargs)
+
+    monkeypatch.setattr(pygame.Surface, "blit", counting_blit)
+
+    renderer.draw(surface, ("A", "B"), 1.0, IntroState.HOLD)
+
+    left_text, right_text, center = renderer.compute_positions(1.0)
+    label_a = renderer.font.render("A", True, (255, 255, 255))
+    label_b = renderer.font.render("B", True, (255, 255, 255))
+    scale = renderer.width * renderer.WEAPON_WIDTH_RATIO / assets.weapon_a.get_width()
+    weapon_a = pygame.transform.rotozoom(assets.weapon_a, (1.0 - 0.5) * 10, scale)
+    weapon_b = pygame.transform.rotozoom(assets.weapon_b, (1.0 - 0.5) * 10, scale)
+    gap = renderer.IMAGE_TEXT_GAP
+    weapon_a_pos = (
+        left_text[0],
+        left_text[1] - label_a.get_height() / 2 - gap - weapon_a.get_height() / 2,
+    )
+    weapon_b_pos = (
+        right_text[0],
+        right_text[1] - label_b.get_height() / 2 - gap - weapon_b.get_height() / 2,
+    )
+    expected_centers: list[tuple[int, int]] = []
+    for base in (weapon_a_pos, weapon_b_pos, center, left_text, right_text):
+        bx, by = int(base[0]), int(base[1])
+        expected_centers.extend(
+            [
+                (bx + 4, by + 4),
+                (bx - 2, by),
+                (bx + 2, by),
+                (bx, by - 2),
+                (bx, by + 2),
+                (bx, by),
+            ]
+        )
+
+    assert len(blits) == len(expected_centers)
+    assert set(expected_centers).issubset(set(blits))
+    pygame.quit()


### PR DESCRIPTION
## Summary
- show weapon images above their names with FightKick font in intro
- adjust intro layout and scaling to 40% weapon width
- document intro layout and extend renderer tests

## Testing
- `uv run ruff check --fix app/intro/config.py app/intro/intro_manager.py app/render/intro_renderer.py tests/unit/test_intro_renderer.py`
- `uv run pre-commit run --files app/intro/config.py app/intro/intro_manager.py app/render/intro_renderer.py docs/intro.md tests/unit/test_intro_renderer.py` *(fails: Failed to spawn pre-commit)*
- `uv pip install pre-commit` *(fails: Request failed)*
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'imageio_ffmpeg', 'pygame', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b44442ad84832aa48184394f25188e