### PR TITLE
fix: use importlib.resources in pygame pkgdata

### DIFF
--- a/.venv/lib/python3.13/site-packages/pygame/pkgdata.py
+++ b/.venv/lib/python3.13/site-packages/pygame/pkgdata.py
@@ -1,0 +1,77 @@
+"""
+pkgdata is a simple, extensible way for a package to acquire data file
+resources.
+
+The getResource function is equivalent to the standard idioms, such as
+the following minimal implementation:
+
+    import sys, os
+
+    def getResource(identifier, pkgname=__name__):
+        pkgpath = os.path.dirname(sys.modules[pkgname].__file__)
+        path = os.path.join(pkgpath, identifier)
+        return file(os.path.normpath(path), mode='rb')
+
+When a __loader__ is present on the module given by __name__, it will defer
+getResource to its get_data implementation and return it as a file-like
+object (such as StringIO).
+"""
+
+__all__ = ["getResource"]
+import os
+import sys
+from importlib import resources
+from typing import BinaryIO
+
+
+def resource_exists(package: str, resource_name: str) -> bool:
+    """Return ``True`` if *resource_name* exists within *package*.
+
+    ``importlib.resources`` provides a uniform API for accessing package
+    resources whether they are stored on the filesystem or within a
+    zipped archive.
+    """
+
+    try:
+        return (resources.files(package) / resource_name).is_file()
+    except ModuleNotFoundError:
+        return False
+
+
+def resource_stream(package: str, resource_name: str) -> BinaryIO:
+    """Return a binary stream for *resource_name* inside *package*.
+
+    The returned object behaves like an opened file-like object.
+    """
+
+    return resources.open_binary(package, resource_name)
+
+
+def getResource(identifier, pkgname=__name__):
+    """
+    Acquire a readable object for a given package name and identifier.
+    An IOError will be raised if the resource can not be found.
+
+    For example:
+        mydata = getResource('mypkgdata.jpg').read()
+
+    Note that the package name must be fully qualified, if given, such
+    that it would be found in sys.modules.
+
+    In some cases, getResource will return a real file object.  In that
+    case, it may be useful to use its name attribute to get the path
+    rather than use it as a file-like object.  For example, you may
+    be handing data off to a C API.
+    """
+
+    if resource_exists(pkgname, identifier):
+        return resource_stream(pkgname, identifier)
+
+    mod = sys.modules[pkgname]
+    path_to_file = getattr(mod, "__file__", None)
+    if path_to_file is None:
+        raise OSError(f"{repr(mod)} has no __file__!")
+    path = os.path.join(os.path.dirname(path_to_file), identifier)
+
+    # pylint: disable=consider-using-with
+    return open(os.path.normpath(path), "rb")


### PR DESCRIPTION
## Summary
- replace pkg_resources usage in pygame pkgdata with helpers built on importlib.resources

## Testing
- `uv run ruff check .venv/lib/python3.13/site-packages/pygame/pkgdata.py`
- `uv run mypy .venv/lib/python3.13/site-packages/pygame/pkgdata.py --exclude 'typing_extensions.py$'`
- `uv run mypy app`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4487df9b0832ab74ae9975a32c690