### PR TITLE
feat: enforce intro bound for slowmo replays

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ uv run python -m app.cli batch \
 - **IA** : agressive, kite, support, teamplay.
 - **Équipes** : passer de 1v1 → 2v2 → FFA → Battle Royale.
 - **Rendu** : couleurs, arènes, effets visuels.
-- **Boucle & fin de match** : animation de victoire puis segment ralenti configurable.
+- **Boucle & fin de match** : animation de victoire puis segment ralenti configurable, démarrant au plus tôt après l'intro.
 - **Configuration externe** : `app/config.json` regroupe canvas, palette (bleu/orange), HUD (titre, watermark) et paramètres d'**end screen** (textes, slow-mo, fade...).
 - **FPS / résolution** : ajuster `canvas` dans `app/config.json`.
 

--- a/app/game/controller.py
+++ b/app/game/controller.py
@@ -39,7 +39,7 @@ class MatchTimeout(Exception):
     """Raised when a match exceeds the maximum duration."""
 
 
-class _MatchView(WorldView):
+class _MatchView(WorldView):  # type: ignore[misc]
     def __init__(
         self,
         players: list[Player],
@@ -77,7 +77,8 @@ class _MatchView(WorldView):
     def get_health_ratio(self, eid: EntityId) -> float:
         for p in self.players:
             if p.eid == eid:
-                return p.ball.health / p.ball.stats.max_health
+                ratio = p.ball.health / p.ball.stats.max_health
+                return float(ratio)
         raise KeyError(eid)
 
     def deal_damage(self, eid: EntityId, damage: Damage, timestamp: float) -> None:
@@ -189,10 +190,10 @@ class GameController:
 
     def run(self) -> str | None:  # noqa: C901
         """Execute the match and return the winning weapon, if any."""
+        intro_elapsed = 0.0
         try:
             if not self.display:
                 self.engine.start_capture()
-            intro_elapsed = 0.0
             labels = (self.weapon_a.capitalize(), self.weapon_b.capitalize())
             self.intro_manager.start()
             while not self.intro_manager.is_finished():
@@ -388,5 +389,6 @@ class GameController:
                     settings.end_screen.pre_s,
                     settings.end_screen.post_s,
                     settings.end_screen.slow_factor,
+                    intro_elapsed,
                 )
             self.engine.shutdown()


### PR DESCRIPTION
## Summary
- prevent slow-mo extraction from starting before a configurable timestamp
- propagate intro duration to slow-mo post-processing
- test early knockouts start slow-mo replay after intro

## Testing
- `uv run ruff check app/video/slowmo.py app/game/controller.py tests/test_match_slowmo_timestamp.py`
- `uv run mypy --follow-imports=skip app/video/slowmo.py app/game/controller.py tests/test_match_slowmo_timestamp.py`
- `uv run pytest tests/test_match_slowmo_timestamp.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68b44e7e2340832a9c6bf1c96a132593