### PR TITLE
feat: flash balls red on hit

### DIFF
--- a/app/game/controller.py
+++ b/app/game/controller.py
@@ -96,6 +96,7 @@ class _MatchView(WorldView):
                     if weapon_audio is not None:
                         weapon_audio.stop_idle(timestamp)
                 self.renderer.trigger_blink(p.color, int(damage.amount))
+                self.renderer.trigger_hit_flash(p.color)
                 return
 
     def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:

--- a/app/intro/intro_manager.py
+++ b/app/intro/intro_manager.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from dataclasses import replace
 from enum import Enum, auto
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from app.core.config import settings
 from app.core.utils import clamp
@@ -45,7 +45,7 @@ class IntroManager:
         self.config = config or IntroConfig()
         if self.config.logo_path is None or self.config.font_path is None:
             assets_dir = Path(__file__).resolve().parents[2] / "assets"
-            updates: dict[str, object] = {}
+            updates: dict[str, Any] = {}
             if self.config.logo_path is None:
                 updates["logo_path"] = assets_dir / "vs.png"
             if self.config.font_path is None:

--- a/tests/unit/test_hit_flash.py
+++ b/tests/unit/test_hit_flash.py
@@ -1,0 +1,26 @@
+from app.core.config import settings
+from app.render.renderer import Renderer
+
+
+def test_hit_flash_colors_surface() -> None:
+    renderer = Renderer(width=100, height=100, display=False)
+    team_color = (1, 2, 3)
+    pos = (50.0, 50.0)
+    radius = 10
+    renderer.trigger_hit_flash(team_color, duration=0.1)
+    renderer.clear()
+    renderer.draw_ball(pos, radius, settings.ball_color, team_color)
+    color = renderer.surface.get_at((50, 50))
+    assert color.r > 200 and color.g < 100 and color.b < 100
+
+    for _ in range(int(0.2 / settings.dt)):
+        renderer.clear()
+        renderer.draw_ball(pos, radius, settings.ball_color, team_color)
+    renderer.clear()
+    renderer.draw_ball(pos, radius, settings.ball_color, team_color)
+    color_after = renderer.surface.get_at((50, 50))
+    assert (
+        abs(color_after.r - settings.ball_color[0]) < 5
+        and abs(color_after.g - settings.ball_color[1]) < 5
+        and abs(color_after.b - settings.ball_color[2]) < 5
+    )


### PR DESCRIPTION
## Summary
- flash damaged balls red for a brief duration
- cover hit flash rendering with a unit test
- tighten intro manager typing for mypy

## Testing
- `ruff check app tests/unit/test_hit_flash.py`
- `mypy app tests/unit/test_hit_flash.py`
- `pytest tests/unit/test_hit_flash.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68b4522f25f0832abcf716d4cfdfa627