### PR TITLE
feat: interpolate intro text toward HUD

### DIFF
--- a/app/game/controller.py
+++ b/app/game/controller.py
@@ -200,7 +200,7 @@ class GameController:
             while not self.intro_manager.is_finished():
                 self.intro_manager.update(settings.dt)
                 self.renderer.clear()
-                self.intro_manager.draw(self.renderer.surface, labels)
+                self.intro_manager.draw(self.renderer.surface, labels, self.hud)
                 self.hud.draw_title(self.renderer.surface, settings.hud.title)
                 self.hud.draw_watermark(self.renderer.surface, settings.hud.watermark)
                 self.renderer.present()

--- a/app/intro/intro_manager.py
+++ b/app/intro/intro_manager.py
@@ -6,8 +6,11 @@ from enum import Enum, auto
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import pygame
+
 from app.core.config import settings
 from app.core.utils import clamp
+from app.render.hud import Hud
 from app.render.intro_renderer import IntroRenderer
 
 from .assets import IntroAssets
@@ -58,6 +61,7 @@ class IntroManager:
         self._engine = engine
         self._state = IntroState.IDLE
         self._elapsed = 0.0
+        self._targets: tuple[pygame.Rect, pygame.Rect, pygame.Rect] | None = None
 
     @property
     def state(self) -> IntroState:
@@ -101,12 +105,14 @@ class IntroManager:
             self._advance_state()
 
     def draw(
-        self, surface: pygame.Surface, labels: tuple[str, str]
+        self, surface: pygame.Surface, labels: tuple[str, str], hud: Hud
     ) -> None:  # pragma: no cover - visual
         """Render the intro on ``surface`` using the configured renderer."""
 
         progress = self._progress()
-        self._renderer.draw(surface, labels, progress, self._state)
+        if self._state is IntroState.FADE_OUT and self._targets is None:
+            self._targets = hud.compute_layout(surface, labels)
+        self._renderer.draw(surface, labels, progress, self._state, self._targets)
 
     def is_finished(self) -> bool:
         """Return ``True`` if the intro has completed."""

--- a/tests/integration/test_intro_loop.py
+++ b/tests/integration/test_intro_loop.py
@@ -11,6 +11,7 @@ from app.core.config import settings
 from app.game.controller import GameController
 from app.game.match import create_controller
 from app.intro import IntroConfig, IntroManager, IntroState
+from app.render.hud import Hud
 from app.render.renderer import Renderer
 from tests.integration.helpers import SpyRecorder
 
@@ -45,7 +46,7 @@ class StubIntroManager(IntroManager):
             self._skipped = True
 
     def draw(
-        self, surface: pygame.Surface, labels: tuple[str, str]
+        self, surface: pygame.Surface, labels: tuple[str, str], hud: Hud
     ) -> None:  # pragma: no cover - simple counter
         self.draws += 1
 


### PR DESCRIPTION
## Summary
- add Hud.compute_layout to expose target positions
- interpolate intro elements toward HUD layout during fade out
- test intro-to-HUD interpolation

## Testing
- `uv run ruff check app/render/hud.py app/render/intro_renderer.py app/intro/intro_manager.py app/game/controller.py tests/unit/test_intro_renderer.py tests/integration/test_intro_loop.py`
- `uv run mypy app/render/hud.py app/render/intro_renderer.py app/intro/intro_manager.py app/game/controller.py tests/unit/test_intro_renderer.py tests/integration/test_intro_loop.py`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `uv sync --all-extras --dev` *(fails: tunnel error: unsuccessful)*

------
https://chatgpt.com/codex/tasks/task_e_68b45afebf30832a941268c1e03da582