### PR TITLE
feat: make eyes rendering configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ uv run python -m app.cli batch \
 - **IA** : agressive, kite, support, teamplay.
 - **Équipes** : passer de 1v1 → 2v2 → FFA → Battle Royale.
 - **Rendu** : couleurs, arènes, effets visuels.
+- **Yeux** : définir `"show_eyes": false` dans `app/config.json` pour les masquer.
 - **Boucle & fin de match** : animation de victoire puis segment ralenti configurable, démarrant au plus tôt après l'intro.
 - **Configuration externe** : `app/config.json` regroupe canvas, palette (bleu/orange), HUD (titre, watermark) et paramètres d'**end screen** (textes, slow-mo, fade...).
 - **FPS / résolution** : ajuster `canvas` dans `app/config.json`.

--- a/app/config.json
+++ b/app/config.json
@@ -13,5 +13,6 @@
         "pre_s": 1.0,
         "post_s": 1.0,
         "slow_factor": 0.5
-    }
+    },
+    "show_eyes": true
 }

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -63,6 +63,7 @@ class Settings(BaseModel):  # type: ignore[misc]
     wall_thickness: int = 10
     background_color: Color = (30, 30, 30)
     ball_color: Color = (220, 220, 220)
+    show_eyes: bool = True  # Render eyes on balls when ``True``.
 
     @property
     def width(self) -> int:

--- a/app/game/controller.py
+++ b/app/game/controller.py
@@ -283,7 +283,8 @@ class GameController:
                     vx, vy = p.ball.body.velocity
                     speed = sqrt(vx * vx + vy * vy)
                     gaze = (vx / speed, vy / speed) if speed else p.face
-                    self.renderer.draw_eyes(pos, gaze, radius, p.color)
+                    if settings.show_eyes:
+                        self.renderer.draw_eyes(pos, gaze, radius, p.color)
                 self.renderer.draw_impacts()
                 self.renderer.update_hp(
                     self.players[0].ball.health / self.players[0].ball.stats.max_health,
@@ -353,7 +354,8 @@ class GameController:
                         )
                     win_radius = int(win_p.ball.shape.radius)
                     self.renderer.draw_ball(win_pos, win_radius, settings.ball_color, win_p.color)
-                    self.renderer.draw_eyes(win_pos, win_p.face, win_radius, win_p.color)
+                    if settings.show_eyes:
+                        self.renderer.draw_eyes(win_pos, win_p.face, win_radius, win_p.color)
                     self.renderer.draw_impacts()
                     self.renderer.draw_hp(
                         self.renderer.surface,

--- a/app/render/renderer.py
+++ b/app/render/renderer.py
@@ -174,7 +174,9 @@ class Renderer:
             speed = random.uniform(80, 160)
             vel = (math.cos(ang) * speed, math.sin(ang) * speed)
             particles.append(_Particle(pos=pos, vel=vel))
-        self._impacts.append(_Impact(pos=pos, timer=duration, duration=duration, particles=particles))
+        self._impacts.append(
+            _Impact(pos=pos, timer=duration, duration=duration, particles=particles)
+        )
 
     def update_hp(self, hp_a: float, hp_b: float) -> None:
         target = [hp_a, hp_b]
@@ -232,6 +234,8 @@ class Renderer:
         pygame.draw.circle(self.surface, color, self._offset(pos), radius)
 
     def draw_eyes(self, pos: Vec2, gaze: Vec2, radius: int, team_color: Color) -> None:
+        if not settings.show_eyes:
+            return
         state = self._get_state(team_color)
         if state.blink_progress > 0:
             state.blink_progress -= 1

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -33,6 +33,22 @@ def test_draw_eyes_team_color() -> None:
     assert (frame == np.array(team_color)).all(axis=-1).any()
 
 
+def test_draw_eyes_disabled() -> None:
+    original = settings.show_eyes
+    try:
+        settings.show_eyes = False
+        renderer = Renderer(100, 100)
+        renderer.clear()
+        renderer.present()
+        baseline = renderer.capture_frame()
+        renderer.draw_eyes((50.0, 50.0), (1.0, 0.0), 10, (255, 0, 0))
+        renderer.present()
+        frame = renderer.capture_frame()
+        assert np.array_equal(frame, baseline)
+    finally:
+        settings.show_eyes = original
+
+
 def test_add_impact_custom_duration() -> None:
     renderer = Renderer(100, 100)
     duration = 0.5


### PR DESCRIPTION
## Summary
- add `show_eyes` setting to toggle eye rendering
- respect `show_eyes` flag in renderer and controller
- document and test disabling eyes

## Testing
- `ruff check app/core/config.py app/game/controller.py app/render/renderer.py tests/test_renderer.py`
- `mypy app/core/config.py app/game/controller.py app/render/renderer.py tests/test_renderer.py`
- `pytest tests/test_renderer.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `uv run pre-commit run --files README.md app/config.json app/core/config.py app/game/controller.py app/render/renderer.py tests/test_renderer.py` *(failed: Project virtual environment directory `.venv` cannot be used)*
- `pip install pre-commit` *(failed: Could not find a version that satisfies the requirement pre-commit)*
- `pip install numpy` *(failed: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68b45e8c98c8832ab1e355d312de791a