### PR TITLE
feat: animate logo transition into HUD

### DIFF
--- a/app/intro/intro_manager.py
+++ b/app/intro/intro_manager.py
@@ -111,7 +111,8 @@ class IntroManager:
 
         progress = self._progress()
         if self._state is IntroState.FADE_OUT and self._targets is None:
-            self._targets = hud.compute_layout(surface, labels)
+            label_a, label_b, logo_rect, _ = hud.compute_layout(surface, labels)
+            self._targets = (logo_rect, label_a, label_b)
         self._renderer.draw(surface, labels, progress, self._state, self._targets)
 
     def is_finished(self) -> bool:

--- a/app/render/hud.py
+++ b/app/render/hud.py
@@ -16,6 +16,7 @@ class Hud:
     LABEL_PADDING: int = 10
     VS_WIDTH_RATIO: float = 0.2
     VS_MARGIN: int = -100
+    LOGO_MARGIN: int = 20
 
     def __init__(self, theme: Theme) -> None:
         """Initialize the HUD renderer.
@@ -38,8 +39,8 @@ class Hud:
 
     def compute_layout(
         self, surface: pygame.Surface, labels: tuple[str, str]
-    ) -> tuple[pygame.Rect, pygame.Rect, pygame.Rect]:
-        """Return target rectangles for the labels and ``VS`` marker.
+    ) -> tuple[pygame.Rect, pygame.Rect, pygame.Rect, pygame.Rect]:
+        """Return target rectangles for the labels, logo and ``VS`` marker.
 
         Parameters
         ----------
@@ -50,9 +51,9 @@ class Hud:
 
         Returns
         -------
-        tuple[pygame.Rect, pygame.Rect, pygame.Rect]
-            Rectangles of the two labels and the ``VS`` marker positioned as
-            they would appear when drawn.
+        tuple[pygame.Rect, pygame.Rect, pygame.Rect, pygame.Rect]
+            Rectangles of the two labels, the final logo and the ``VS`` marker
+            positioned as they would appear when drawn.
         """
 
         bar_width = max(1, int(surface.get_width() * self.BAR_WIDTH_RATIO))
@@ -83,10 +84,15 @@ class Hud:
         target_width = max(1, int(surface.get_width() * self.VS_WIDTH_RATIO))
         width, height = self.vs_image.get_size()
         scale = target_width / width
+        logo_rect = pygame.Rect(0, 0, target_width, int(height * scale))
+        logo_rect.midbottom = (
+            surface.get_width() // 2,
+            left_rect.top - self.LOGO_MARGIN,
+        )
         vs_rect = pygame.Rect(0, 0, target_width, int(height * scale))
         vs_rect.midbottom = (surface.get_width() // 2, left_rect.top - self.VS_MARGIN)
 
-        return label_a_rect, label_b_rect, vs_rect
+        return label_a_rect, label_b_rect, logo_rect, vs_rect
 
     def update_hp(self, hp_a: float, hp_b: float) -> None:
         """Interpolate the displayed health toward the target values.
@@ -139,7 +145,7 @@ class Hud:
 
     def draw_hp_bars(
         self, surface: pygame.Surface, hp_a: float, hp_b: float, labels: tuple[str, str]
-    ) -> tuple[pygame.Rect, pygame.Rect, pygame.Rect]:
+    ) -> tuple[pygame.Rect, pygame.Rect, pygame.Rect, pygame.Rect]:
         """Draw two symmetrical health bars with labels.
 
         The bar dimensions scale with the given surface so that the HUD adapts
@@ -148,8 +154,8 @@ class Hud:
 
         Returns
         -------
-        tuple[pygame.Rect, pygame.Rect, pygame.Rect]
-            Rectangles of the two label texts and the ``VS`` marker.
+        tuple[pygame.Rect, pygame.Rect, pygame.Rect, pygame.Rect]
+            Rectangles of the two label texts, the logo and the ``VS`` marker.
         """
 
         bar_width = max(1, int(surface.get_width() * self.BAR_WIDTH_RATIO))
@@ -158,7 +164,7 @@ class Hud:
 
         self.update_hp(hp_a, hp_b)
 
-        layout_a, layout_b, vs_rect = self.compute_layout(surface, labels)
+        layout_a, layout_b, logo_rect, vs_rect = self.compute_layout(surface, labels)
 
         # Left bar (team A)
         left_rect = pygame.Rect(margin, 120, bar_width, bar_height)
@@ -197,7 +203,7 @@ class Hud:
         scaled_vs = pygame.transform.smoothscale(self.vs_image, vs_rect.size)
         surface.blit(scaled_vs, vs_rect)
 
-        return layout_a, layout_b, vs_rect
+        return layout_a, layout_b, logo_rect, vs_rect
 
     def draw_watermark(self, surface: pygame.Surface, text: str) -> None:
         """Draw a small watermark at the bottom-left corner."""

--- a/app/render/intro_renderer.py
+++ b/app/render/intro_renderer.py
@@ -91,7 +91,12 @@ class IntroRenderer:
         targets: tuple[pygame.Rect, pygame.Rect, pygame.Rect],
         progress: float,
     ) -> None:
-        """Mutate ``elements`` to move and scale toward ``targets``."""
+        """Mutate elements to move and scale toward their target rectangles.
+
+        The last three entries of ``elements`` are expected to be the logo, the
+        left label and the right label in that order. ``start_positions`` and
+        ``targets`` must follow the same ordering.
+        """
 
         q = clamp(1.0 - progress, 0.0, 1.0)
         start_index = len(elements) - 3
@@ -138,14 +143,16 @@ class IntroRenderer:
             logo_img = pygame.transform.rotozoom(
                 self.assets.logo, (progress - 0.5) * 10, self.config.logo_scale
             )
-            return weapon_surfaces + [(logo_img, center_pos)] + text_surfaces
+            logo_and_text = [(logo_img, center_pos)] + text_surfaces
+            return weapon_surfaces + logo_and_text
         if self.font is None:
             pygame.font.init()
             self.font = pygame.font.Font(None, 72)
+        logo = self.font.render("VS", True, (255, 255, 255))
         return [
+            (logo, center_pos),
             (self.font.render(labels[0], True, (255, 255, 255)), left_pos),
             (self.font.render(labels[1], True, (255, 255, 255)), right_pos),
-            (self.font.render("VS", True, (255, 255, 255)), center_pos),
         ]
 
     def draw(
@@ -170,8 +177,8 @@ class IntroRenderer:
             Current :class:`~app.intro.intro_manager.IntroState` controlling the
             fade behaviour.
         targets:
-            Optional rectangles defining target positions and sizes for the two
-            labels and the centre marker. When provided and ``state`` is
+            Optional rectangles defining target positions and sizes for the
+            logo and the two labels. When provided and ``state`` is
             ``FADE_OUT``, elements interpolate toward these rectangles.
         """
         from app.intro.intro_manager import IntroState as _IntroState
@@ -185,7 +192,10 @@ class IntroRenderer:
 
         if state is _IntroState.FADE_OUT and targets is not None:
             self._interpolate_to_targets(
-                elements, (left_pos, right_pos, center_pos), targets, progress
+                elements,
+                (center_pos, left_pos, right_pos),
+                targets,
+                progress,
             )
 
         for img, pos in elements:

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -96,7 +96,9 @@ def test_hp_interpolation_converges() -> None:
 def test_hp_label_and_vs_positions() -> None:
     hud = Hud(settings.theme)
     surface = pygame.Surface((800, 600))
-    label_a_rect, label_b_rect, vs_rect = hud.draw_hp_bars(surface, 1.0, 1.0, ("Alpha", "Beta"))
+    label_a_rect, label_b_rect, logo_rect, vs_rect = hud.draw_hp_bars(
+        surface, 1.0, 1.0, ("Alpha", "Beta")
+    )
 
     bar_width = int(surface.get_width() * Hud.BAR_WIDTH_RATIO)
     bar_height = int(surface.get_height() * Hud.BAR_HEIGHT_RATIO)
@@ -111,6 +113,8 @@ def test_hp_label_and_vs_positions() -> None:
     assert vs_rect.centerx == surface.get_width() // 2
     assert vs_rect.bottom == left_rect.top - Hud.VS_MARGIN
     assert vs_rect.width == int(surface.get_width() * Hud.VS_WIDTH_RATIO)
+    assert logo_rect.centerx == surface.get_width() // 2
+    assert logo_rect.bottom == left_rect.top - Hud.LOGO_MARGIN
 
 
 def test_hp_gradient_static() -> None:

--- a/tests/unit/test_intro_renderer.py
+++ b/tests/unit/test_intro_renderer.py
@@ -220,7 +220,8 @@ def test_fade_out_interpolates_to_hud(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     hud = Hud(theme)
     labels = ("A", "B")
-    targets = hud.compute_layout(surface, labels)
+    label_a_rect, label_b_rect, logo_rect, _ = hud.compute_layout(surface, labels)
+    targets = (logo_rect, label_a_rect, label_b_rect)
     blits: list[tuple[int, int]] = []
 
     original_blit = pygame.Surface.blit
@@ -239,10 +240,11 @@ def test_fade_out_interpolates_to_hud(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(pygame.Surface, "blit", tracking_blit)
 
     renderer.draw(surface, labels, 0.5, IntroState.FADE_OUT, targets)
-    start_positions = renderer.compute_positions(1.0)
+    left_start, right_start, center_start = renderer.compute_positions(1.0)
+    ordered_starts = (center_start, left_start, right_start)
     expected_mid = [
         (int((s[0] + t.centerx) / 2), int((s[1] + t.centery) / 2))
-        for s, t in zip(start_positions, targets, strict=False)
+        for s, t in zip(ordered_starts, targets, strict=False)
     ]
     for center in expected_mid:
         assert center in blits


### PR DESCRIPTION
## Summary
- compute HUD logo target above health bars
- fade intro logo into HUD position alongside labels
- cover logo positioning with unit tests

## Testing
- `uv run ruff check .` *(fails: Failed to download `pillow==11.3.0`)*
- `uv run ruff format .` *(fails: Failed to download `typing-inspection==0.4.1`)*
- `uv run mypy .` *(fails: Failed to download `pydantic==2.11.7`)*
- `uv run pytest --cov=.` *(fails: Failed to download `typing-extensions==4.14.1`)*

------
https://chatgpt.com/codex/tasks/task_e_68b48beafb04832a9989165289b7ad52