### PR TITLE
feat: animate intro weapon sprites toward ball positions

### DIFF
--- a/app/game/controller.py
+++ b/app/game/controller.py
@@ -196,11 +196,23 @@ class GameController:
             if not self.display:
                 self.engine.start_capture()
             labels = (self.weapon_a.capitalize(), self.weapon_b.capitalize())
+            ball_positions: tuple[Vec2, Vec2] = (
+                (
+                    float(self.players[0].ball.body.position.x),
+                    float(self.players[0].ball.body.position.y),
+                ),
+                (
+                    float(self.players[1].ball.body.position.x),
+                    float(self.players[1].ball.body.position.y),
+                ),
+            )
             self.intro_manager.start()
             while not self.intro_manager.is_finished():
                 self.intro_manager.update(settings.dt)
                 self.renderer.clear()
-                self.intro_manager.draw(self.renderer.surface, labels, self.hud)
+                self.intro_manager.draw(
+                    self.renderer.surface, labels, self.hud, ball_positions
+                )
                 self.hud.draw_title(self.renderer.surface, settings.hud.title)
                 self.hud.draw_watermark(self.renderer.surface, settings.hud.watermark)
                 self.renderer.present()

--- a/app/intro/intro_manager.py
+++ b/app/intro/intro_manager.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 import pygame
 
 from app.core.config import settings
+from app.core.types import Vec2
 from app.core.utils import clamp
 from app.render.hud import Hud
 from app.render.intro_renderer import IntroRenderer
@@ -105,7 +106,11 @@ class IntroManager:
             self._advance_state()
 
     def draw(
-        self, surface: pygame.Surface, labels: tuple[str, str], hud: Hud
+        self,
+        surface: pygame.Surface,
+        labels: tuple[str, str],
+        hud: Hud,
+        ball_positions: tuple[Vec2, Vec2] | None = None,
     ) -> None:  # pragma: no cover - visual
         """Render the intro on ``surface`` using the configured renderer."""
 
@@ -113,7 +118,9 @@ class IntroManager:
         if self._state is IntroState.FADE_OUT and self._targets is None:
             label_a, label_b, logo_rect, _ = hud.compute_layout(surface, labels)
             self._targets = (logo_rect, label_a, label_b)
-        self._renderer.draw(surface, labels, progress, self._state, self._targets)
+        self._renderer.draw(
+            surface, labels, progress, self._state, self._targets, ball_positions
+        )
 
     def is_finished(self) -> bool:
         """Return ``True`` if the intro has completed."""


### PR DESCRIPTION
## Summary
- capture initial ball coordinates during intro and pass them to IntroRenderer
- animate weapon sprites toward their balls with shrinking scale
- ensure weapon intro interpolation reaches exact ball location at sequence end

## Testing
- `uv run pre-commit run --files app/game/controller.py app/intro/intro_manager.py app/render/intro_renderer.py tests/unit/test_intro_renderer.py` *(failed: Failed to download pydantic-settings==2.10.1)*
- `uv run pytest tests/unit/test_intro_renderer.py::test_weapon_animation_reaches_ball` *(failed: Failed to download markdown-it-py==4.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ba573e0c832abeee9143f8b9c89f