### PR TITLE
feat: cache intro positions across intro phases

### DIFF
--- a/app/intro/intro_manager.py
+++ b/app/intro/intro_manager.py
@@ -73,9 +73,11 @@ class IntroManager:
     def start(self) -> None:
         """Start the intro sequence if idle.
 
-        Calling :meth:`start` while the introduction is already running or has
-        completed has no effect. This guards against unintended resets when the
-        caller triggers ``start`` multiple times.
+        The associated :class:`~app.render.intro_renderer.IntroRenderer` is
+        reset to clear any cached positions. Calling :meth:`start` while the
+        introduction is already running or has completed has no effect. This
+        guards against unintended resets when the caller triggers ``start``
+        multiple times.
         """
 
         if self._state is not IntroState.IDLE:
@@ -83,6 +85,7 @@ class IntroManager:
         self._state = IntroState.LOGO_IN
         self._elapsed = 0.0
         self._targets = None
+        self._renderer.reset()
 
     def update(self, dt: float, events: Sequence[pygame.event.Event] | None = None) -> None:
         """Advance the intro state machine.

--- a/tests/unit/test_intro_manager.py
+++ b/tests/unit/test_intro_manager.py
@@ -7,6 +7,7 @@ import pytest
 pygame = pytest.importorskip("pygame")
 
 from app.intro import IntroConfig, IntroManager, IntroState  # noqa: E402
+from app.render.intro_renderer import IntroRenderer  # noqa: E402
 
 
 class StubEngine:
@@ -90,6 +91,14 @@ def test_intro_manager_fight_sound() -> None:
     assert path.endswith("fight.ogg")
     expected = config.logo_in + config.weapons_in + config.hold
     assert timestamp == pytest.approx(expected)
+
+
+def test_start_resets_renderer() -> None:
+    renderer = IntroRenderer(200, 100)
+    renderer._final_positions = ((1.0, 1.0), (2.0, 2.0), (3.0, 3.0))
+    manager = IntroManager(intro_renderer=renderer)
+    manager.start()
+    assert renderer._final_positions is None
 
 
 def test_intro_manager_start_ignored_when_running_or_done() -> None:

--- a/tests/unit/test_intro_renderer.py
+++ b/tests/unit/test_intro_renderer.py
@@ -287,3 +287,29 @@ def test_weapon_animation_reaches_ball(monkeypatch: pytest.MonkeyPatch) -> None:
     for center in expected:
         assert center in blits
     pygame.quit()
+
+
+def test_cached_positions_and_reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    pygame.init()
+    renderer = IntroRenderer(200, 100)
+    surface = pygame.Surface((200, 100), flags=pygame.SRCALPHA)
+    calls: list[float] = []
+
+    original_compute = renderer.compute_positions
+
+    def tracking(progress: float):
+        calls.append(progress)
+        return original_compute(progress)
+
+    monkeypatch.setattr(renderer, "compute_positions", tracking)
+
+    renderer.draw(surface, ("A", "B"), 1.0, IntroState.WEAPONS_IN)
+    renderer.draw(surface, ("A", "B"), 0.0, IntroState.HOLD)
+    renderer.draw(surface, ("A", "B"), 0.0, IntroState.FADE_OUT)
+
+    assert calls == [1.0]
+
+    renderer.reset()
+    renderer.draw(surface, ("A", "B"), 0.0, IntroState.HOLD)
+    assert calls == [1.0, 1.0]
+    pygame.quit()


### PR DESCRIPTION
## Summary
- cache final intro positions at end of WEAPONS_IN
- reuse cached positions in HOLD and FADE_OUT and allow renderer reset
- reset intro renderer when starting new intro sequence

## Testing
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest tests/unit/test_intro_renderer.py tests/unit/test_intro_manager.py` *(skipped: 2)*

------
https://chatgpt.com/codex/tasks/task_e_68b4be80c7f8832abfa0c3702d3323f3