### PR TITLE
fix: preserve intro final frame

### DIFF
--- a/app/intro/intro_manager.py
+++ b/app/intro/intro_manager.py
@@ -124,6 +124,12 @@ class IntroManager:
         ball_positions: tuple[Vec2, Vec2] | None = None,
     ) -> None:  # pragma: no cover - visual
         """Render the intro on ``surface`` using the configured renderer."""
+        if self._state is IntroState.DONE:
+            # Preserve the final frame of the intro sequence by skipping any
+            # further rendering once all animations have completed. This
+            # mirrors ``animation-fill-mode: forwards`` in CSS where the last
+            # frame remains visible instead of resetting to the initial state.
+            return
 
         progress = self._progress()
         if self._state is IntroState.FADE_OUT and self._targets is None:

--- a/tests/unit/test_intro_manager.py
+++ b/tests/unit/test_intro_manager.py
@@ -176,3 +176,26 @@ def test_weapons_in_monotonic_then_hold_and_fade() -> None:
     assert 0.0 <= fade_mid < fade_start
     manager.update(0.25)
     assert manager._progress() < fade_mid
+
+
+def test_draw_ignored_when_done(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Once the intro is complete, ``draw`` should not reset element states."""
+
+    config = IntroConfig(logo_in=0.0, weapons_in=0.0, hold=0.0, fade_out=0.0, allow_skip=False)
+    renderer = IntroRenderer(200, 100)
+    manager = IntroManager(config=config, intro_renderer=renderer)
+    manager.start()
+    for _ in range(4):
+        manager.update(0.0)
+    assert manager.state is IntroState.DONE
+
+    called = False
+
+    def fake_draw(*args: Any, **kwargs: Any) -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(renderer, "draw", fake_draw)
+    surface = pygame.Surface((10, 10))
+    manager.draw(surface, ("A", "B"), cast(Any, object()))
+    assert not called


### PR DESCRIPTION
## Summary
- ensure intro renderer keeps last frame instead of resetting
- test that draw is skipped once intro finishes

## Testing
- `ruff check app/intro/intro_manager.py tests/unit/test_intro_manager.py`
- `python -m mypy app/intro/intro_manager.py tests/unit/test_intro_manager.py`
- `pytest tests/unit/test_intro_manager.py` *(fails: 1 skipped in 0.02s)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c0e3f800832a82c67ab567304645