### PR TITLE
fix: cache weapon intro positions

### DIFF
--- a/tests/unit/test_intro_hold_fade_positions.py
+++ b/tests/unit/test_intro_hold_fade_positions.py
@@ -18,14 +18,16 @@ def test_positions_static_between_hold_and_fade_out(monkeypatch: pytest.MonkeyPa
 
     original_compute = renderer.compute_positions
 
-    def tracking(progress: float) -> tuple[tuple[float, float], tuple[float, float], tuple[float, float]]:
+    def tracking(
+        progress: float,
+    ) -> tuple[tuple[float, float], tuple[float, float], tuple[float, float]]:
         pos = original_compute(progress)
         positions.append(pos)
         return pos
 
     monkeypatch.setattr(renderer, "compute_positions", tracking)
 
-    renderer.draw(surface, labels, 1.0, IntroState.WEAPONS_IN)
+    renderer.draw(surface, labels, 0.0, IntroState.WEAPONS_IN)
     renderer.draw(surface, labels, 0.0, IntroState.HOLD)
     for progress in (1.0, 0.5, 0.0):
         renderer.draw(surface, labels, progress, IntroState.FADE_OUT)


### PR DESCRIPTION
## Summary
- reuse cached positions from logo phase during WEAPONS_IN
- initialise cached positions on first weapon frame
- test intro renderer caching and progress handling

## Testing
- `ruff check app/render/intro_renderer.py tests/unit/test_intro_hold_fade_positions.py tests/unit/test_intro_renderer.py`
- `mypy app/render/intro_renderer.py tests/unit/test_intro_hold_fade_positions.py tests/unit/test_intro_renderer.py`
- `pytest tests/unit/test_intro_hold_fade_positions.py tests/unit/test_intro_renderer.py` *(skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b549adf4a8832a80408af9f88e64fe