### PR TITLE
fix: maintain weapon intro continuity

### DIFF
--- a/app/intro/intro_manager.py
+++ b/app/intro/intro_manager.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:  # pragma: no cover - hints only
 
 
 FIGHT_SOUND: str = "assets/fight.ogg"
+WEAPON_PULSE_AMPLITUDE: float = 0.05
 
 
 class IntroState(Enum):
@@ -180,7 +181,7 @@ class IntroManager:
         if self._state is IntroState.LOGO_IN:
             return self.config.micro_bounce(t)
         if self._state is IntroState.WEAPONS_IN:
-            return self.config.pulse(t)
+            return 1.0 + self.config.pulse(t) * WEAPON_PULSE_AMPLITUDE
         if self._state is IntroState.HOLD:
             return 1.0
         if self._state is IntroState.FADE_OUT:

--- a/tests/unit/test_intro_renderer.py
+++ b/tests/unit/test_intro_renderer.py
@@ -289,6 +289,40 @@ def test_weapon_animation_reaches_ball(monkeypatch: pytest.MonkeyPatch) -> None:
     pygame.quit()
 
 
+def test_weapons_in_starts_from_logo_in_final(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pygame.init()
+    config = IntroConfig(
+        font_path=Path("assets/fonts/FightKickDemoRegular.ttf"),
+        logo_path=Path("assets/vs.png"),
+        weapon_a_path=Path("assets/ball-a.png"),
+        weapon_b_path=Path("assets/ball-b.png"),
+    )
+    assets = IntroAssets.load(config)
+    renderer = IntroRenderer(200, 100, config=config, assets=assets)
+    surface = pygame.Surface((200, 100), flags=pygame.SRCALPHA)
+    calls: list[tuple[float, float]] = []
+
+    original_rotozoom = pygame.transform.rotozoom
+
+    def tracking_rotozoom(
+        img: _pygame.Surface, angle: float, scale: float
+    ) -> _pygame.Surface:
+        calls.append((angle, scale))
+        return original_rotozoom(img, angle, scale)
+
+    monkeypatch.setattr(pygame.transform, "rotozoom", tracking_rotozoom)
+
+    renderer.draw(surface, ("A", "B"), 1.0, IntroState.LOGO_IN)
+    logo_calls = calls.copy()
+    calls.clear()
+    renderer.draw(surface, ("A", "B"), 1.0, IntroState.WEAPONS_IN)
+
+    assert calls == logo_calls
+    pygame.quit()
+
+
 def test_weapons_in_uses_cache_and_progress(monkeypatch: pytest.MonkeyPatch) -> None:
     pygame.init()
     renderer = IntroRenderer(200, 100)


### PR DESCRIPTION
## Summary
- keep WEAPONS_IN progress anchored at 1.0 and apply pulse as relative offset
- compute intro rotations and scales from LOGO_IN baseline
- verify weapon intro begins with logo's final transform

## Testing
- `ruff check .`
- `mypy app tests/unit`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68b557499134832aa4ad3e9e088aace4