### PR TITLE
feat: introduce hold phase floating effect

### DIFF
--- a/app/intro/config.py
+++ b/app/intro/config.py
@@ -47,12 +47,17 @@ class IntroConfig:
     allow_skip, skip_key:
         Options controlling whether the intro can be skipped and which key
         triggers the skip. ``skip_key`` defaults to the Escape key.
+    hold_float_amplitude, hold_float_frequency:
+        Amplitude in pixels/degree and angular frequency in radians per second
+        for the gentle floating effect applied during the ``HOLD`` phase.
     """
 
     logo_in: float = 1.0
     weapons_in: float = 1.0
     hold: float = 1.0
     fade_out: float = 1.0
+    hold_float_amplitude: float = 5.0
+    hold_float_frequency: float = 2.0
     micro_bounce: Easing = ease_out_back
     pulse: Easing = monotone_pulse
     fade: Easing = ease_out_quad

--- a/app/intro/intro_manager.py
+++ b/app/intro/intro_manager.py
@@ -136,7 +136,15 @@ class IntroManager:
         if self._state is IntroState.FADE_OUT and self._targets is None:
             label_a, label_b, logo_rect, _ = hud.compute_layout(surface, labels)
             self._targets = (logo_rect, label_a, label_b)
-        self._renderer.draw(surface, labels, progress, self._state, self._targets, ball_positions)
+        self._renderer.draw(
+            surface,
+            labels,
+            progress,
+            self._state,
+            self._targets,
+            ball_positions,
+            self._elapsed,
+        )
 
     def is_finished(self) -> bool:
         """Return ``True`` if the intro has completed."""


### PR DESCRIPTION
## Summary
- add configurable floating effect during HOLD phase
- float intro elements using sinusoidal offset based on elapsed time
- test hold oscillation to ensure no drift

## Testing
- `pre-commit run --files app/intro/config.py app/intro/intro_manager.py app/render/intro_renderer.py tests/unit/test_intro_renderer.py` *(fails: command not found)*
- `pytest tests/unit/test_intro_renderer.py` *(skipped: pygame not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b558cf5c08832a80a3a1f3b106ca0e