### PR TITLE
fix: preserve floating offset into fade out

### DIFF
--- a/app/render/intro_renderer.py
+++ b/app/render/intro_renderer.py
@@ -42,17 +42,20 @@ class IntroRenderer:
         self.assets = assets
         self._final_positions: tuple[Vec2, Vec2, Vec2] | None
         self._base_progress = 1.0
+        self._fade_start_offset = 0.0
         self.reset()
 
     def reset(self) -> None:
-        """Clear any cached final positions.
+        """Clear cached final positions and floating offset.
 
         This should be called when starting a new intro sequence to ensure
         that the slide-in animation begins from the correct initial
-        positions.
+        positions and that no floating offset from a previous sequence
+        persists.
         """
         self._final_positions = None
         self._base_progress = 1.0
+        self._fade_start_offset = 0.0
 
     def compute_positions(self, progress: float) -> tuple[Vec2, Vec2, Vec2]:
         """Return positions for the two labels and the central marker.
@@ -290,12 +293,20 @@ class IntroRenderer:
             offset = self._hold_offset(elapsed)
             angle += offset
             elements = [(img, (pos[0], pos[1] + offset)) for img, pos in elements]
+            self._fade_start_offset = offset
 
         if state is _IntroState.FADE_OUT:
+            offset = self._fade_start_offset
+            angle += offset
+            elements = [(img, (pos[0], pos[1] + offset)) for img, pos in elements]
             if targets is not None:
                 self._interpolate_to_targets(
                     elements,
-                    (center_pos, left_pos, right_pos),
+                    (
+                        (center_pos[0], center_pos[1] + offset),
+                        (left_pos[0], left_pos[1] + offset),
+                        (right_pos[0], right_pos[1] + offset),
+                    ),
                     targets,
                     progress,
                 )

--- a/tests/unit/test_intro_hold_fade_positions.py
+++ b/tests/unit/test_intro_hold_fade_positions.py
@@ -34,3 +34,55 @@ def test_positions_static_between_hold_and_fade_out(monkeypatch: pytest.MonkeyPa
 
     assert len({pos for pos in positions}) == 1
     pygame.quit()
+
+
+def test_first_fade_out_frame_matches_last_hold_frame(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pygame.init()
+    renderer = IntroRenderer(200, 100)
+    surface = pygame.Surface((200, 100), flags=pygame.SRCALPHA)
+    labels = ("A", "B")
+
+    # Ensure final positions are cached
+    renderer.draw(surface, labels, 0.0, IntroState.WEAPONS_IN)
+
+    # Prepare deterministic elements and offsets
+    base = pygame.Surface((10, 10), flags=pygame.SRCALPHA)
+    monkeypatch.setattr(
+        renderer,
+        "_prepare_elements",
+        lambda labels, progress, lp, rp, cp: [(base, (10.0, 10.0))],
+    )
+    monkeypatch.setattr(renderer, "_compute_transform", lambda progress: (0.0, 1.0))
+    monkeypatch.setattr(renderer, "_hold_offset", lambda elapsed: 5.0)
+
+    angles: list[float] = []
+    monkeypatch.setattr(
+        pygame.transform,
+        "rotozoom",
+        lambda surf, angle, scale: angles.append(angle) or surf,
+    )
+
+    blits: list[tuple[int, int]] = []
+
+    def fake_blit(self: pygame.Surface, src: pygame.Surface, dest, *args, **kwargs):
+        rect = dest if isinstance(dest, pygame.Rect) else pygame.Rect(dest, src.get_size())
+        blits.append(rect.center)
+        return rect
+
+    monkeypatch.setattr(pygame.Surface, "blit", fake_blit, raising=False)
+
+    renderer.draw(surface, labels, 0.0, IntroState.HOLD, elapsed=0.0)
+    hold_angle = angles[-1]
+    hold_pos = blits[-1]
+
+    angles.clear()
+    blits.clear()
+    renderer.draw(surface, labels, 1.0, IntroState.FADE_OUT)
+    fade_angle = angles[-1]
+    fade_pos = blits[-1]
+
+    assert fade_angle == hold_angle
+    assert fade_pos == hold_pos
+    pygame.quit()


### PR DESCRIPTION
## Summary
- keep last HOLD floating offset when transitioning to FADE_OUT
- test that FADE_OUT starts from HOLD's final frame

## Testing
- `python -m py_compile app/render/intro_renderer.py tests/unit/test_intro_hold_fade_positions.py`
- `uv sync --all-extras --dev` *(fails: Failed to download `pyyaml==6.0.2`)*
- `uv run ruff --version` *(fails: Failed to download `pymunk==7.1.0`)*

------
https://chatgpt.com/codex/tasks/task_e_68b55a66bc68832a8c1299aa182be9ab