### PR TITLE
refactor: extract intro renderer helpers

### DIFF
--- a/tests/unit/test_intro_hold_fade_positions.py
+++ b/tests/unit/test_intro_hold_fade_positions.py
@@ -11,26 +11,21 @@ from app.render.intro_renderer import IntroRenderer  # noqa: E402
 def test_positions_static_between_hold_and_fade_out(monkeypatch: pytest.MonkeyPatch) -> None:
     pygame.init()
     renderer = IntroRenderer(200, 100)
-    surface = pygame.Surface((200, 100), flags=pygame.SRCALPHA)
-    labels = ("A", "B")
-
     positions: list[tuple[tuple[float, float], tuple[float, float], tuple[float, float]]] = []
 
     original_compute = renderer.compute_positions
 
-    def tracking(
-        progress: float,
-    ) -> tuple[tuple[float, float], tuple[float, float], tuple[float, float]]:
+    def tracking(progress: float) -> tuple[tuple[float, float], tuple[float, float], tuple[float, float]]:
         pos = original_compute(progress)
         positions.append(pos)
         return pos
 
     monkeypatch.setattr(renderer, "compute_positions", tracking)
 
-    renderer.draw(surface, labels, 0.0, IntroState.WEAPONS_IN)
-    renderer.draw(surface, labels, 0.0, IntroState.HOLD)
+    renderer._compute_state_positions(0.0, IntroState.WEAPONS_IN)
+    renderer._compute_state_positions(0.0, IntroState.HOLD)
     for progress in (1.0, 0.5, 0.0):
-        renderer.draw(surface, labels, progress, IntroState.FADE_OUT)
+        renderer._compute_state_positions(progress, IntroState.FADE_OUT)
 
     assert len({pos for pos in positions}) == 1
     pygame.quit()
@@ -41,48 +36,21 @@ def test_first_fade_out_frame_matches_last_hold_frame(
 ) -> None:
     pygame.init()
     renderer = IntroRenderer(200, 100)
-    surface = pygame.Surface((200, 100), flags=pygame.SRCALPHA)
-    labels = ("A", "B")
 
     # Ensure final positions are cached
-    renderer.draw(surface, labels, 0.0, IntroState.WEAPONS_IN)
+    renderer._compute_state_positions(0.0, IntroState.WEAPONS_IN)
 
-    # Prepare deterministic elements and offsets
     base = pygame.Surface((10, 10), flags=pygame.SRCALPHA)
-    monkeypatch.setattr(
-        renderer,
-        "_prepare_elements",
-        lambda labels, progress, lp, rp, cp: [(base, (10.0, 10.0))],
-    )
-    monkeypatch.setattr(renderer, "_compute_transform", lambda progress: (0.0, 1.0))
+    elements = [(base, (10.0, 10.0))]
     monkeypatch.setattr(renderer, "_hold_offset", lambda elapsed: 5.0)
 
-    angles: list[float] = []
-    monkeypatch.setattr(
-        pygame.transform,
-        "rotozoom",
-        lambda surf, angle, scale: angles.append(angle) or surf,
+    hold_elements, hold_angle = renderer._apply_hold_effect(elements, 0.0, 0.0)
+
+    left, right, center = renderer._compute_state_positions(1.0, IntroState.FADE_OUT)
+    fade_elements, fade_angle = renderer._apply_fade_out(
+        elements, 0.0, 1.0, None, None, left, right, center
     )
 
-    blits: list[tuple[int, int]] = []
-
-    def fake_blit(self: pygame.Surface, src: pygame.Surface, dest, *args, **kwargs):
-        rect = dest if isinstance(dest, pygame.Rect) else pygame.Rect(dest, src.get_size())
-        blits.append(rect.center)
-        return rect
-
-    monkeypatch.setattr(pygame.Surface, "blit", fake_blit, raising=False)
-
-    renderer.draw(surface, labels, 0.0, IntroState.HOLD, elapsed=0.0)
-    hold_angle = angles[-1]
-    hold_pos = blits[-1]
-
-    angles.clear()
-    blits.clear()
-    renderer.draw(surface, labels, 1.0, IntroState.FADE_OUT)
-    fade_angle = angles[-1]
-    fade_pos = blits[-1]
-
-    assert fade_angle == hold_angle
-    assert fade_pos == hold_pos
+    assert hold_angle == fade_angle
+    assert hold_elements[0][1] == fade_elements[0][1]
     pygame.quit()


### PR DESCRIPTION
## Summary
- refactor intro renderer `draw` into helper methods for state positions, hold effect, fade out, and blitting
- reinstate complexity check by removing `noqa: C901`
- adjust intro renderer unit tests to target new helpers

## Testing
- `ruff check app/render/intro_renderer.py tests/unit/test_intro_renderer.py tests/unit/test_intro_hold_fade_positions.py`
- `mypy app/render/intro_renderer.py tests/unit/test_intro_renderer.py tests/unit/test_intro_hold_fade_positions.py`
- `pytest tests/unit/test_intro_renderer.py tests/unit/test_intro_hold_fade_positions.py`


------
https://chatgpt.com/codex/tasks/task_e_68b55e0f311c832a83d4f542ab2fbdb0