### PR TITLE
feat: introduce animation timeline for intro sequence

### DIFF
--- a/app/core/animation.py
+++ b/app/core/animation.py
@@ -1,0 +1,122 @@
+"""Generic animation utilities with composable timelines."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from .tween import linear
+
+Easing = Callable[[float], float]
+Interpolator = Callable[[float, float, float], float]
+
+
+def _lerp(start: float, end: float, t: float) -> float:
+    """Return the linear interpolation between ``start`` and ``end``."""
+    return start + (end - start) * t
+
+
+@dataclass
+class Animation:
+    """Interpolate a value from ``start`` to ``end`` over ``duration`` seconds."""
+
+    start: float
+    end: float
+    duration: float
+    easing: Easing = linear
+    interpolate: Interpolator = _lerp
+    elapsed: float = 0.0
+    finished: bool = False
+
+    def update(self, dt: float) -> None:
+        """Advance the animation by ``dt`` seconds."""
+        if self.finished:
+            return
+        self.elapsed += dt
+        if self.elapsed >= self.duration:
+            self.elapsed = self.duration
+            self.finished = True
+
+    @property
+    def progress(self) -> float:
+        """Return the normalised progress in ``[0, 1]``."""
+        if self.duration == 0.0:
+            return 1.0
+        return min(self.elapsed / self.duration, 1.0)
+
+    @property
+    def value(self) -> float:
+        """Return the interpolated value at the current progress."""
+        t = self.easing(self.progress)
+        return self.interpolate(self.start, self.end, t)
+
+    def cancel(self) -> None:
+        """Stop the animation immediately."""
+        self.finished = True
+
+
+class Animator:
+    """Update and query multiple animations in parallel."""
+
+    def __init__(self) -> None:
+        self._animations: dict[str, Animation] = {}
+
+    def add(self, name: str, animation: Animation) -> None:
+        self._animations[name] = animation
+
+    def update(self, dt: float) -> None:
+        for key in list(self._animations.keys()):
+            anim = self._animations[key]
+            anim.update(dt)
+            if anim.finished:
+                self._animations.pop(key)
+
+    def get(self, name: str) -> Animation | None:
+        return self._animations.get(name)
+
+    def value(self, name: str, default: float) -> float:
+        anim = self._animations.get(name)
+        return anim.value if anim is not None else default
+
+    def cancel(self, name: str) -> None:
+        anim = self._animations.pop(name, None)
+        if anim is not None:
+            anim.cancel()
+
+
+class Timeline:
+    """Chain animations sequentially."""
+
+    def __init__(self) -> None:
+        self._queue: list[Animation] = []
+        self._current: Animation | None = None
+        self.finished: bool = False
+
+    def add(self, animation: Animation) -> None:
+        self._queue.append(animation)
+        if self._current is None:
+            self._current = self._queue.pop(0)
+
+    @property
+    def current(self) -> Animation | None:
+        return self._current
+
+    def update(self, dt: float) -> None:
+        if self.finished or self._current is None:
+            return
+        self._current.update(dt)
+        if self._current.finished:
+            if self._queue:
+                self._current = self._queue.pop(0)
+            else:
+                self._current = None
+                self.finished = True
+
+    def cancel(self) -> None:
+        """Cancel the timeline and all pending animations."""
+        self._queue.clear()
+        self._current = None
+        self.finished = True
+
+__all__ = ["Animation", "Animator", "Timeline"]
+

--- a/app/render/intro_renderer.py
+++ b/app/render/intro_renderer.py
@@ -17,9 +17,12 @@ if TYPE_CHECKING:  # pragma: no cover - hints only
 class IntroRenderer:
     """Render the pre-match introduction with slide, glow and fade effects.
 
-    Final positions after the slide-in are cached so they can be reused during
-    the ``WEAPONS_IN``, ``HOLD`` and ``FADE_OUT`` phases. Use :meth:`reset` when
-    starting a new introduction sequence to clear this cache.
+    Animations for positions, opacity and scale are driven by the external
+    :class:`~app.core.animation.Timeline` used by
+    :class:`~app.intro.intro_manager.IntroManager`. Final positions after the
+    slide-in are cached so they can be reused during the ``WEAPONS_IN``, ``HOLD``
+    and ``FADE_OUT`` phases. Use :meth:`reset` when starting a new introduction
+    sequence to clear this cache.
     """
 
     WEAPON_WIDTH_RATIO: float = 0.4

--- a/tests/unit/test_animation.py
+++ b/tests/unit/test_animation.py
@@ -1,0 +1,30 @@
+import pytest
+
+from app.core.animation import Animation, Timeline
+
+
+def test_animation_interpolates() -> None:
+    anim = Animation(0.0, 10.0, 2.0)
+    anim.update(1.0)
+    assert anim.value == pytest.approx(5.0)
+    assert anim.progress == pytest.approx(0.5)
+
+
+def test_animation_cancel() -> None:
+    anim = Animation(0.0, 10.0, 2.0)
+    anim.cancel()
+    anim.update(1.0)
+    assert anim.finished
+    assert anim.value == pytest.approx(0.0)
+
+
+def test_timeline_chaining() -> None:
+    first = Animation(0.0, 1.0, 1.0)
+    second = Animation(1.0, 2.0, 1.0)
+    tl = Timeline()
+    tl.add(first)
+    tl.add(second)
+    tl.update(1.0)
+    assert tl.current is second and not tl.finished
+    tl.update(1.0)
+    assert tl.finished


### PR DESCRIPTION
## Summary
- add core animation utilities with Animation, Animator and Timeline
- refactor intro manager to drive states via a timeline
- document renderer integration and cover animation utilities with tests

## Testing
- `ruff check`
- `mypy app/core/animation.py app/intro/intro_manager.py app/render/intro_renderer.py tests/unit/test_animation.py`
- `pytest tests/unit/test_animation.py tests/unit/test_intro_manager.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68b55f470274832ab97cf54e76def322