### PR TITLE
feat: shorten intro animation timings

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -64,7 +64,6 @@ def run(
         intro_config = set_intro_weapons(
             paths.get("left"),
             paths.get("right"),
-            config=IntroConfig(hold=1.0, fade_out=0.25),
         )
 
     with temporary_sdl_audio_driver(driver):

--- a/app/game/match.py
+++ b/app/game/match.py
@@ -68,7 +68,7 @@ def create_controller(
         ),
     ]
 
-    intro_config = intro_config or IntroConfig(hold=1.0, fade_out=0.25)
+    intro_config = intro_config or IntroConfig()
     weapons_dir = Path(__file__).resolve().parents[2] / "assets" / "weapons"
     weapon_a_path = weapons_dir / weapon_a / "weapon.png"
     weapon_b_path = weapons_dir / weapon_b / "weapon.png"

--- a/app/intro/config.py
+++ b/app/intro/config.py
@@ -22,7 +22,9 @@ class IntroConfig:
     Parameters
     ----------
     logo_in, weapons_in, hold, fade_out:
-        Durations in seconds for each phase of the intro animation.
+        Durations in seconds for each phase of the intro animation. Defaults to
+        ``logo_in=0.0``, ``weapons_in=0.0``, ``hold=1.0`` and
+        ``fade_out=0.25``.
     micro_bounce, pulse, fade:
         Easing functions used for the various phases.
     left_pos_pct, right_pos_pct, center_pos_pct:
@@ -45,10 +47,10 @@ class IntroConfig:
         for the gentle floating effect applied during the ``HOLD`` phase.
     """
 
-    logo_in: float = 1.0
-    weapons_in: float = 1.0
+    logo_in: float = 0.0
+    weapons_in: float = 0.0
     hold: float = 1.0
-    fade_out: float = 1.0
+    fade_out: float = 0.25
     hold_float_amplitude: float = 5.0
     hold_float_frequency: float = 2.0
     micro_bounce: Easing = ease_out_back

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -17,7 +17,7 @@ Ce document décrit l'architecture de l'animation d'introduction avant chaque ma
 - Les images des armes (40 % de la largeur de l'écran) apparaissent juste au-dessus de leur nom,
   tous deux alignés horizontalement légèrement sous le milieu de l'écran.
 - Les noms sont rendus avec la police `assets/fonts/FightKickDemoRegular.ttf`.
-- Les éléments restent visibles pendant `hold=1s` puis disparaissent via `fade_out=0.25s`.
+- Les éléments apparaissent instantanément (`logo_in=0s`, `weapons_in=0s`), restent visibles pendant `hold=1s` puis disparaissent via `fade_out=0.25s`.
 
 ## Tween / Easing
 

--- a/tests/integration/test_postprocessed_slowmo.py
+++ b/tests/integration/test_postprocessed_slowmo.py
@@ -72,7 +72,7 @@ def test_postprocessed_slowmo(tmp_path: Path) -> None:
     video_dur = _stream_duration(out, "v")
     audio_dur = _stream_duration(out, "a")
     assert abs(video_dur - audio_dur) < 0.1
-    intro_config = IntroConfig(hold=1.0, fade_out=0.25)
+    intro_config = IntroConfig()
     intro_duration = (
         intro_config.logo_in + intro_config.weapons_in + intro_config.hold + intro_config.fade_out
     )

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -209,5 +209,7 @@ def test_intro_weapons_option(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     assert config is not None
     assert config.weapon_a_path == left
     assert config.weapon_b_path == right
+    assert config.logo_in == 0.0
+    assert config.weapons_in == 0.0
     assert config.hold == 1.0
     assert config.fade_out == 0.25

--- a/tests/test_headless_match_kill_audio.py
+++ b/tests/test_headless_match_kill_audio.py
@@ -60,7 +60,7 @@ def test_headless_match_records_kill_audio() -> None:
     run_match("instakill", "instakill", recorder, renderer, max_seconds=1)
     assert recorder.audio is not None
 
-    intro_config = IntroConfig(hold=1.0, fade_out=0.25)
+    intro_config = IntroConfig()
     intro_duration = (
         intro_config.logo_in + intro_config.weapons_in + intro_config.hold + intro_config.fade_out
     )


### PR DESCRIPTION
## Summary
- reduce intro animation defaults to instant logo/weapon reveal with 1s hold and 0.25s fade-out
- remove redundant timing overrides in CLI and match setup
- document instant intro and update tests for new defaults

## Testing
- `uv run pre-commit run --files app/intro/config.py docs/intro.md tests/test_cli_run.py tests/test_headless_match_kill_audio.py tests/integration/test_postprocessed_slowmo.py app/cli.py app/game/match.py` *(fails: Failed to download pydantic)*
- `uv run pytest` *(fails: Failed to download python-dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_68b563391ec4832aaba2233e16f7ccbb