### PR TITLE
feat: add knife and bazooka weapons

### DIFF
--- a/app/game/controller.py
+++ b/app/game/controller.py
@@ -106,6 +106,12 @@ class _MatchView(WorldView):
                 p.ball.body.apply_impulse_at_local_point((vx, vy))
                 return
 
+    def add_speed_bonus(self, eid: EntityId, bonus: float) -> None:
+        for p in self.players:
+            if p.eid == eid:
+                p.ball.stats.max_speed += bonus
+                return
+
     def spawn_effect(self, effect: WeaponEffect) -> None:
         self.effects.append(effect)
 

--- a/app/weapons/__init__.py
+++ b/app/weapons/__init__.py
@@ -22,5 +22,7 @@ weapon_registry: Registry[Weapon] = Registry()
 # Import weapon modules to register them
 from . import katana as _katana  # noqa: F401,E402
 from . import shuriken as _shuriken  # noqa: F401,E402
+from . import knife as _knife  # noqa: F401,E402
+from . import bazooka as _bazooka  # noqa: F401,E402
 
 __all__ = ["Weapon", "weapon_registry"]

--- a/app/weapons/base.py
+++ b/app/weapons/base.py
@@ -31,6 +31,9 @@ class WorldView(Protocol):
     def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:
         """Apply an impulse to the entity's body."""
 
+    def add_speed_bonus(self, eid: EntityId, bonus: float) -> None:
+        """Increase ``eid``'s maximum speed by ``bonus`` units."""
+
     def spawn_effect(self, effect: WeaponEffect) -> None:
         """Register a new weapon effect to be processed by the match."""
 

--- a/app/weapons/bazooka.py
+++ b/app/weapons/bazooka.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import math
+
+from app.core.types import Damage, EntityId, Vec2
+from app.world.entities import DEFAULT_BALL_RADIUS
+from app.render.sprites import load_sprite
+
+from . import weapon_registry
+from .assets import load_weapon_sprite
+from .base import Weapon, WorldView
+from .effects import HeldSprite
+
+
+class Bazooka(Weapon):
+    """AI-controlled launcher that fires slow, heavy missiles."""
+
+    missile_radius: float
+
+    def __init__(self) -> None:
+        super().__init__(name="bazooka", cooldown=1.2, damage=Damage(20), speed=300.0)
+        weapon_size = DEFAULT_BALL_RADIUS * 2.0
+        self._sprite = load_weapon_sprite("bazooka", max_dim=weapon_size)
+        self._effect_initialized = False
+        self.missile_radius = DEFAULT_BALL_RADIUS / 2.0
+        missile_size = self.missile_radius * 2.0
+        self._missile_sprite = load_sprite("weapons/bazooka/missile.png", max_dim=missile_size)
+
+    def _fire(self, owner: EntityId, view: WorldView, direction: Vec2) -> None:  # noqa: D401
+        velocity = (direction[0] * self.speed, direction[1] * self.speed)
+        position = view.get_position(owner)
+        view.spawn_projectile(
+            owner,
+            position,
+            velocity,
+            radius=self.missile_radius,
+            damage=self.damage,
+            knockback=200.0,
+            ttl=1.5,
+            sprite=self._missile_sprite,
+        )
+
+    def update(self, owner: EntityId, view: WorldView, dt: float) -> None:  # noqa: D401
+        if not self._effect_initialized:
+            effect = HeldSprite(owner=owner, sprite=self._sprite)
+            view.spawn_effect(effect)
+            self._effect_initialized = True
+        enemy = view.get_enemy(owner)
+        if enemy is not None and self._timer <= 0.0:
+            target = view.get_position(enemy)
+            origin = view.get_position(owner)
+            dx, dy = target[0] - origin[0], target[1] - origin[1]
+            norm = math.hypot(dx, dy) or 1.0
+            direction = (dx / norm, dy / norm)
+            self._fire(owner, view, direction)
+            self._timer = self.cooldown
+        super().update(owner, view, dt)
+
+
+weapon_registry.register("bazooka", Bazooka)

--- a/app/weapons/effects.py
+++ b/app/weapons/effects.py
@@ -15,6 +15,31 @@ from .base import WeaponEffect, WorldView
 
 
 @dataclass(slots=True)
+class HeldSprite(WeaponEffect):
+    """Static sprite following its owner without interacting with the world."""
+
+    owner: EntityId
+    sprite: pygame.Surface
+    angle: float = 0.0
+
+    def step(self, dt: float) -> bool:  # noqa: D401
+        return True
+
+    def collides(self, view: WorldView, position: Vec2, radius: float) -> bool:  # noqa: D401
+        return False
+
+    def on_hit(self, view: WorldView, target: EntityId, timestamp: float) -> bool:  # noqa: D401
+        return True
+
+    def draw(self, renderer: Renderer, view: WorldView) -> None:  # noqa: D401
+        pos = view.get_position(self.owner)
+        renderer.draw_sprite(self.sprite, pos, self.angle)
+
+    def destroy(self) -> None:  # noqa: D401
+        return None
+
+
+@dataclass(slots=True)
 class OrbitingSprite(WeaponEffect):
     """Sprite rotating around its owner and applying damage on contact."""
 

--- a/app/weapons/knife.py
+++ b/app/weapons/knife.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pygame
+
+from app.core.types import Damage, EntityId, Vec2
+from app.world.entities import DEFAULT_BALL_RADIUS
+
+from . import weapon_registry
+from .assets import load_weapon_sprite
+from .base import Weapon, WorldView
+from .effects import OrbitingSprite
+
+
+class Knife(Weapon):
+    """Fast orbiting blade that grants its wielder extra speed."""
+
+    player_speed_bonus: float = 80.0
+
+    def __init__(self) -> None:
+        super().__init__(name="knife", cooldown=0.0, damage=Damage(14), speed=8.0)
+        blade_height = DEFAULT_BALL_RADIUS * 2.0
+        self._sprite = pygame.transform.rotate(
+            load_weapon_sprite("knife", max_dim=blade_height),
+            -90,
+        )
+        self._initialized = False
+        self._boost_applied = False
+
+    def _fire(self, owner: EntityId, view: WorldView, direction: Vec2) -> None:  # noqa: D401
+        return None
+
+    def update(self, owner: EntityId, view: WorldView, dt: float) -> None:  # noqa: D401
+        if not self._initialized:
+            effect = OrbitingSprite(
+                owner=owner,
+                damage=self.damage,
+                sprite=self._sprite,
+                radius=60.0,
+                angle=0.0,
+                speed=self.speed,
+            )
+            view.spawn_effect(effect)
+            self._initialized = True
+        if not self._boost_applied:
+            view.add_speed_bonus(owner, self.player_speed_bonus)
+            self._boost_applied = True
+        super().update(owner, view, dt)
+
+
+weapon_registry.register("knife", Knife)

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -44,6 +44,9 @@ class DummyView(WorldView):
     def spawn_effect(self, effect: WeaponEffect) -> None:  # noqa: D401
         return
 
+    def add_speed_bonus(self, eid: EntityId, bonus: float) -> None:  # noqa: D401
+        return
+
     def spawn_projectile(
         self,
         owner: EntityId,

--- a/tests/test_weapons.py
+++ b/tests/test_weapons.py
@@ -1,5 +1,7 @@
 from app.weapons.katana import Katana
 from app.weapons.shuriken import Shuriken
+from app.weapons.knife import Knife
+from app.weapons.bazooka import Bazooka
 from app.world.entities import DEFAULT_BALL_RADIUS
 
 
@@ -16,3 +18,14 @@ def test_katana_sprite_height() -> None:
     expected_height = int(DEFAULT_BALL_RADIUS * 3)
     _, height = katana._sprite.get_size()
     assert height == expected_height
+
+
+def test_knife_sprite_loaded() -> None:
+    knife = Knife()
+    width, height = knife._sprite.get_size()
+    assert width > 0 and height > 0
+
+
+def test_bazooka_missile_radius() -> None:
+    bazooka = Bazooka()
+    assert bazooka.missile_radius > DEFAULT_BALL_RADIUS / 3

--- a/tests/unit/test_katana_deflect.py
+++ b/tests/unit/test_katana_deflect.py
@@ -36,6 +36,9 @@ class DummyView(WorldView):
     def spawn_effect(self, effect: WeaponEffect) -> None:
         return None
 
+    def add_speed_bonus(self, eid: EntityId, bonus: float) -> None:  # noqa: D401
+        return None
+
     def spawn_projectile(
         self,
         owner: EntityId,

--- a/tests/unit/test_policy_angles.py
+++ b/tests/unit/test_policy_angles.py
@@ -39,6 +39,9 @@ class DummyView(WorldView):
     def spawn_effect(self, effect: WeaponEffect) -> None:  # noqa: D401
         return
 
+    def add_speed_bonus(self, eid: EntityId, bonus: float) -> None:  # noqa: D401
+        return
+
     def spawn_projectile(
         self,
         owner: EntityId,


### PR DESCRIPTION
## Summary
- add Knife melee weapon with increased rotation speed and player speed bonus
- introduce Bazooka weapon that auto-fires missiles at enemies
- support speed bonuses via WorldView and add HeldSprite effect

## Testing
- `make lint` *(fails: Project virtual environment directory `/workspace/satisfaxaife/.venv` cannot be used because it is not a valid Python environment)*
- `pytest` *(fails: 29 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b565bbc5cc832aa779bab13c70ceaf