### PR TITLE
fix: reduce knife damage

### DIFF
--- a/app/weapons/knife.py
+++ b/app/weapons/knife.py
@@ -17,7 +17,7 @@ class Knife(Weapon):
     player_speed_bonus: float = 80.0
 
     def __init__(self) -> None:
-        super().__init__(name="knife", cooldown=0.0, damage=Damage(14), speed=8.0)
+        super().__init__(name="knife", cooldown=0.0, damage=Damage(8), speed=8.0)
         blade_height = DEFAULT_BALL_RADIUS * 2.0
         self._sprite = pygame.transform.rotate(
             load_weapon_sprite("knife", max_dim=blade_height),

--- a/tests/unit/test_weapons.py
+++ b/tests/unit/test_weapons.py
@@ -101,6 +101,12 @@ def test_knife_applies_speed_bonus() -> None:
     assert len(view.effects) == 1
 
 
+def test_knife_damage_value() -> None:
+    """Knife base damage should reflect its lighter attack power."""
+    knife = Knife()
+    assert knife.damage.amount == 8
+
+
 def test_bazooka_fires_missile() -> None:
     view = DummyView(enemy=EntityId(2), enemy_pos=(100.0, 0.0))
     bazooka = Bazooka()


### PR DESCRIPTION
## Summary
- tone down knife damage for better balance
- cover knife damage with a dedicated unit test

## Testing
- `make lint` *(fails: Failed to download `pydantic==2.11.7`; tunnel error)*
- `make test` *(fails: Failed to download `imageio-ffmpeg==0.6.0`; tunnel error)*

------
https://chatgpt.com/codex/tasks/task_e_68b56b020108832ab9fcf1073ba3f34b