### PR TITLE
feat: add knife audio

### DIFF
--- a/app/weapons/knife.py
+++ b/app/weapons/knife.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pygame
 
+from app.audio.weapons import WeaponAudio
 from app.core.types import Damage, EntityId, Vec2
 from app.world.entities import DEFAULT_BALL_RADIUS
 
@@ -23,6 +24,7 @@ class Knife(Weapon):
             load_weapon_sprite("knife", max_dim=blade_height),
             -90,
         )
+        self.audio = WeaponAudio("melee", "knife")
         self._initialized = False
         self._boost_applied = False
 
@@ -38,8 +40,10 @@ class Knife(Weapon):
                 radius=60.0,
                 angle=0.0,
                 speed=self.speed,
+                audio=self.audio,
             )
             view.spawn_effect(effect)
+            self.audio.start_idle()
             self._initialized = True
         if not self._boost_applied:
             view.add_speed_bonus(owner, self.player_speed_bonus)

--- a/tests/test_weapon_audio_integration.py
+++ b/tests/test_weapon_audio_integration.py
@@ -6,6 +6,7 @@ from app.audio.weapons import WeaponAudio
 from app.core.types import Damage, EntityId, Vec2
 from app.weapons.base import WeaponEffect, WorldView
 from app.weapons.katana import Katana
+from app.weapons.knife import Knife
 from app.weapons.shuriken import Shuriken
 from app.world.physics import PhysicsWorld
 from app.world.projectiles import Projectile
@@ -48,6 +49,36 @@ def test_katana_audio_events() -> None:
     view_obj = View()
     view = cast(WorldView, view_obj)
     katana.update(EntityId(1), view, 0.0)
+    assert stub_audio.idle_started
+    effect = view_obj.effects[0]
+    effect.on_hit(view, EntityId(2), timestamp=0.0)
+    assert stub_audio.touched
+
+
+def test_knife_audio_events() -> None:
+    knife = Knife()
+    stub_audio = StubAudio()
+    knife.audio = cast(WeaponAudio, stub_audio)
+
+    class View:
+        def __init__(self) -> None:
+            self.effects: list[WeaponEffect] = []
+
+        def spawn_effect(self, effect: WeaponEffect) -> None:  # noqa: D401
+            self.effects.append(effect)
+
+        def get_position(self, eid: EntityId) -> Vec2:  # noqa: D401
+            return (0.0, 0.0)
+
+        def deal_damage(self, eid: EntityId, damage: Damage, timestamp: float) -> None:  # noqa: D401
+            pass
+
+        def add_speed_bonus(self, eid: EntityId, bonus: float) -> None:  # noqa: D401
+            pass
+
+    view_obj = View()
+    view = cast(WorldView, view_obj)
+    knife.update(EntityId(1), view, 0.0)
     assert stub_audio.idle_started
     effect = view_obj.effects[0]
     effect.on_hit(view, EntityId(2), timestamp=0.0)


### PR DESCRIPTION
## Summary
- add idle and hit sounds for the knife weapon
- test knife audio events

## Testing
- `ruff check app/weapons/knife.py tests/test_weapon_audio_integration.py`
- `mypy app/weapons/knife.py tests/test_weapon_audio_integration.py`
- `pytest` *(fails: No module named 'imageio_ffmpeg')*

------
https://chatgpt.com/codex/tasks/task_e_68b56bd2bd64832a849353b419b87a1f