### PR TITLE
feat: add missile reorientation and trail

### DIFF
--- a/app/game/controller.py
+++ b/app/game/controller.py
@@ -126,6 +126,7 @@ class _MatchView(WorldView):
         ttl: float,
         sprite: pygame.Surface | None = None,
         spin: float = 0.0,
+        trail_color: Color | None = None,
     ) -> WeaponEffect:
         proj = Projectile.spawn(
             self.world,
@@ -138,6 +139,7 @@ class _MatchView(WorldView):
             ttl,
             sprite,
             spin,
+            trail_color,
         )
         self.effects.append(proj)
         return proj

--- a/app/weapons/base.py
+++ b/app/weapons/base.py
@@ -6,7 +6,7 @@ from typing import Protocol
 
 import pygame
 
-from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
+from app.core.types import Color, Damage, EntityId, ProjectileInfo, Vec2
 from app.render.renderer import Renderer
 
 
@@ -48,6 +48,7 @@ class WorldView(Protocol):
         ttl: float,
         sprite: pygame.Surface | None = None,
         spin: float = 0.0,
+        trail_color: Color | None = None,
     ) -> WeaponEffect:
         """Spawn a projectile owned by *owner* and register it."""
 

--- a/app/weapons/bazooka.py
+++ b/app/weapons/bazooka.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import math
+from typing import cast
 
 from app.core.types import Damage, EntityId, Vec2
-from app.world.entities import DEFAULT_BALL_RADIUS
 from app.render.sprites import load_sprite
+from app.world.entities import DEFAULT_BALL_RADIUS
+from app.world.projectiles import Projectile
 
 from . import weapon_registry
 from .assets import load_weapon_sprite
@@ -29,15 +31,19 @@ class Bazooka(Weapon):
     def _fire(self, owner: EntityId, view: WorldView, direction: Vec2) -> None:  # noqa: D401
         velocity = (direction[0] * self.speed, direction[1] * self.speed)
         position = view.get_position(owner)
-        proj = view.spawn_projectile(
-            owner,
-            position,
-            velocity,
-            radius=self.missile_radius,
-            damage=self.damage,
-            knockback=200.0,
-            ttl=1.5,
-            sprite=self._missile_sprite,
+        proj = cast(
+            Projectile,
+            view.spawn_projectile(
+                owner,
+                position,
+                velocity,
+                radius=self.missile_radius,
+                damage=self.damage,
+                knockback=200.0,
+                ttl=1.5,
+                sprite=self._missile_sprite,
+                trail_color=(255, 200, 50),
+            ),
         )
         proj.angle = math.atan2(direction[1], direction[0]) + math.pi / 2
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -58,6 +58,7 @@ class DummyView(WorldView):
         ttl: float,
         sprite: object | None = None,
         spin: float = 0.0,
+        trail_color: tuple[int, int, int] | None = None,
     ) -> WeaponEffect:  # noqa: D401
         self.last_velocity = velocity
 

--- a/tests/test_weapon_audio_integration.py
+++ b/tests/test_weapon_audio_integration.py
@@ -79,6 +79,7 @@ def test_shuriken_audio_events() -> None:
             ttl: float,
             sprite: object | None = None,
             spin: float = 0.0,
+            trail_color: tuple[int, int, int] | None = None,
         ) -> WeaponEffect:
             proj = Projectile.spawn(
                 self.world,
@@ -91,6 +92,7 @@ def test_shuriken_audio_events() -> None:
                 ttl,
                 sprite,
                 spin,
+                trail_color,
             )
             self.projectile = proj
             return proj

--- a/tests/unit/test_katana_deflect.py
+++ b/tests/unit/test_katana_deflect.py
@@ -50,6 +50,7 @@ class DummyView(WorldView):
         ttl: float,
         sprite: pygame.Surface | None = None,
         spin: float = 0.0,
+        trail_color: tuple[int, int, int] | None = None,
     ) -> WeaponEffect:
         raise NotImplementedError
 

--- a/tests/unit/test_policy_angles.py
+++ b/tests/unit/test_policy_angles.py
@@ -53,6 +53,7 @@ class DummyView(WorldView):
         ttl: float,
         sprite: object | None = None,
         spin: float = 0.0,
+        trail_color: tuple[int, int, int] | None = None,
     ) -> WeaponEffect:  # noqa: D401
         self.last_velocity = velocity
 

--- a/tests/unit/test_projectile_reorient.py
+++ b/tests/unit/test_projectile_reorient.py
@@ -1,0 +1,33 @@
+import math
+
+import pygame
+import pytest
+
+from app.core.types import Damage, EntityId
+from app.world.physics import PhysicsWorld
+from app.world.projectiles import Projectile
+
+
+def test_projectile_reorients_and_trails() -> None:
+    pygame.init()
+    world = PhysicsWorld()
+    sprite = pygame.Surface((10, 10))
+    projectile = Projectile.spawn(
+        world,
+        owner=EntityId(1),
+        position=(0.0, 0.0),
+        velocity=(10.0, 0.0),
+        radius=1.0,
+        damage=Damage(1),
+        knockback=0.0,
+        ttl=1.0,
+        sprite=sprite,
+        trail_color=(255, 255, 255),
+    )
+    projectile.step(0.1)
+    assert projectile.angle == pytest.approx(math.pi / 2)
+    assert len(projectile.trail) == 1
+    projectile.body.velocity = (0.0, 10.0)
+    projectile.step(0.1)
+    assert projectile.angle == pytest.approx(math.pi)
+    assert len(projectile.trail) == 2

--- a/tests/unit/test_weapons.py
+++ b/tests/unit/test_weapons.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 import math
+from dataclasses import dataclass, field
+from typing import Any, cast
 
 import pytest
 
@@ -12,10 +13,10 @@ from app.render.renderer import Renderer
 from app.video.recorder import NullRecorder
 from app.weapons import weapon_registry
 from app.weapons.base import Weapon, WeaponEffect, WorldView
-from app.weapons.katana import Katana
-from app.weapons.shuriken import Shuriken
-from app.weapons.knife import Knife
 from app.weapons.bazooka import Bazooka
+from app.weapons.katana import Katana
+from app.weapons.knife import Knife
+from app.weapons.shuriken import Shuriken
 
 
 @dataclass
@@ -48,15 +49,30 @@ class DummyView(WorldView):
     def spawn_effect(self, effect: WeaponEffect) -> None:  # noqa: D401
         self.effects.append(effect)
 
-    def spawn_projectile(self, owner: EntityId, position: Vec2, velocity: Vec2, radius: float, damage: Damage, knockback: float, ttl: float, sprite: object | None = None, spin: float = 0.0) -> WeaponEffect:  # noqa: D401,E501
-        self.projectiles.append({
-            "owner": owner,
-            "position": position,
-            "velocity": velocity,
-            "radius": radius,
-            "damage": damage,
-            "ttl": ttl,
-        })
+    def spawn_projectile(
+        self,
+        owner: EntityId,
+        position: Vec2,
+        velocity: Vec2,
+        radius: float,
+        damage: Damage,
+        knockback: float,
+        ttl: float,
+        sprite: object | None = None,
+        spin: float = 0.0,
+        trail_color: tuple[int, int, int] | None = None,
+    ) -> WeaponEffect:  # noqa: D401,E501
+        self.projectiles.append(
+            {
+                "owner": owner,
+                "position": position,
+                "velocity": velocity,
+                "radius": radius,
+                "damage": damage,
+                "ttl": ttl,
+                "trail_color": trail_color,
+            }
+        )
 
         class _Dummy(WeaponEffect):
             owner: EntityId = EntityId(0)
@@ -114,10 +130,11 @@ def test_bazooka_fires_missile() -> None:
     bazooka.update(EntityId(1), view, 0.0)
     assert len(view.projectiles) == 1
     projectile = view.projectiles[0]
-    vx, vy = projectile["velocity"]
+    vx, vy = cast(Vec2, projectile["velocity"])
     assert vx == pytest.approx(bazooka.speed)
     assert vy == pytest.approx(0.0)
     assert projectile["radius"] == bazooka.missile_radius
+    assert projectile["trail_color"] == (255, 200, 50)
     effect = view.effects[0]
     assert effect.collides(view, (0.0, 0.0), 1.0) is False
 
@@ -127,7 +144,7 @@ class _OrientView(WorldView):
     enemy: EntityId
     enemy_pos: Vec2
     effects: list[WeaponEffect] = field(default_factory=list)
-    projectile: WeaponEffect | None = None
+    projectile: object | None = None
 
     def get_enemy(self, owner: EntityId) -> EntityId | None:  # noqa: D401
         return self.enemy
@@ -161,6 +178,7 @@ class _OrientView(WorldView):
         ttl: float,
         sprite: object | None = None,
         spin: float = 0.0,
+        trail_color: tuple[int, int, int] | None = None,
     ) -> WeaponEffect:  # noqa: D401
         class _Dummy(WeaponEffect):
             owner: EntityId = owner
@@ -198,12 +216,13 @@ def test_bazooka_sprite_and_projectile_orientation() -> None:
     bazooka.update(EntityId(1), view, 0.0)
     assert view.projectile is not None
     assert len(view.effects) == 1
-    effect = view.effects[0]
+    effect = cast(Any, view.effects[0])
     dx, dy = 100.0, 100.0
     expected_weapon_angle = math.atan2(dy, dx)
     expected_projectile_angle = math.atan2(dy, dx) + math.pi / 2
     assert effect.angle == pytest.approx(expected_weapon_angle)
-    assert view.projectile.angle == pytest.approx(expected_projectile_angle)
+    proj = cast(Any, view.projectile)
+    assert proj.angle == pytest.approx(expected_projectile_angle)
 
 
 class SpyWeapon(Weapon):


### PR DESCRIPTION
## Summary
- orient bazooka missiles to match velocity and leave a fading trail
- expose optional `trail_color` when spawning projectiles
- cover projectile reorientation and trail with unit tests

## Testing
- `ruff check app/world/projectiles.py app/weapons/base.py app/game/controller.py app/weapons/bazooka.py tests/unit/test_weapons.py tests/test_weapon_audio_integration.py tests/test_policy.py tests/unit/test_policy_angles.py tests/unit/test_projectile_reorient.py tests/unit/test_katana_deflect.py`
- `mypy app/world/projectiles.py app/weapons/base.py app/game/controller.py app/weapons/bazooka.py tests/unit/test_weapons.py tests/test_weapon_audio_integration.py tests/test_policy.py tests/unit/test_policy_angles.py tests/unit/test_projectile_reorient.py tests/unit/test_katana_deflect.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic', etc.)*
- `pip install pydantic numpy pygame pymunk imageio imageio-ffmpeg` *(fails: Could not find a version that satisfies the requirement pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_68b56c724430832aa9abca0cdb65fb3f