### PR TITLE
feat: tune bazooka and knife behaviours

### DIFF
--- a/app/game/match.py
+++ b/app/game/match.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from app.ai.policy import SimplePolicy
+from app.ai.policy import policy_for_weapon
 from app.audio import BallAudio, get_default_engine
 from app.core.config import settings
 from app.game.controller import (
@@ -52,7 +52,7 @@ def create_controller(
             ball_a.eid,
             ball_a,
             weapon_registry.create(weapon_a),
-            SimplePolicy("aggressive"),
+            policy_for_weapon(weapon_a),
             (1.0, 0.0),
             settings.theme.team_a.primary,
             BallAudio(engine=engine),
@@ -61,7 +61,7 @@ def create_controller(
             ball_b.eid,
             ball_b,
             weapon_registry.create(weapon_b),
-            SimplePolicy("kiter"),
+            policy_for_weapon(weapon_b),
             (-1.0, 0.0),
             settings.theme.team_b.primary,
             BallAudio(engine=engine),

--- a/app/weapons/knife.py
+++ b/app/weapons/knife.py
@@ -15,10 +15,10 @@ from .effects import OrbitingSprite
 class Knife(Weapon):
     """Fast orbiting blade that grants its wielder extra speed."""
 
-    player_speed_bonus: float = 80.0
+    player_speed_bonus: float = 120.0
 
     def __init__(self) -> None:
-        super().__init__(name="knife", cooldown=0.0, damage=Damage(8), speed=9.0)
+        super().__init__(name="knife", cooldown=0.0, damage=Damage(8), speed=12.0)
         blade_height = DEFAULT_BALL_RADIUS * 2.0
         self._sprite = pygame.transform.rotate(
             load_weapon_sprite("knife", max_dim=blade_height),

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -5,7 +5,7 @@ from typing import Literal
 
 import pytest
 
-from app.ai.policy import SimplePolicy
+from app.ai.policy import SimplePolicy, policy_for_weapon
 from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
 from app.weapons.base import WeaponEffect, WorldView
 from app.weapons.shuriken import Shuriken
@@ -165,3 +165,15 @@ def test_aggressive_dodges_projectiles() -> None:
     policy = SimplePolicy("aggressive")
     accel, _, _ = policy.decide(me, view, 600.0)
     assert accel[1] < 0  # dodges downward
+
+
+def test_policy_for_bazooka_is_kiter() -> None:
+    policy = policy_for_weapon("bazooka")
+    assert policy.style == "kiter"
+    assert policy.desired_dist_factor > 0.5
+
+
+def test_policy_for_knife_prioritises_dodging() -> None:
+    policy = policy_for_weapon("knife")
+    assert policy.style == "aggressive"
+    assert policy.dodge_bias > 0.5

--- a/tests/unit/test_weapons.py
+++ b/tests/unit/test_weapons.py
@@ -106,9 +106,11 @@ def test_weapon_speed_attribute() -> None:
     """Weapons expose their projectile speed on the base class."""
     katana = Katana()
     shuriken = Shuriken()
+    knife = Knife()
 
     assert katana.speed == 5.0
     assert shuriken.speed == 600.0
+    assert knife.speed == 12.0
 
 
 def test_knife_applies_speed_bonus() -> None:
@@ -116,6 +118,7 @@ def test_knife_applies_speed_bonus() -> None:
     knife = Knife()
     knife.update(EntityId(1), view, 0.0)
     assert view.speed_bonus[EntityId(1)] == knife.player_speed_bonus
+    assert knife.player_speed_bonus == 120.0
     assert len(view.effects) == 1
 
 
@@ -150,7 +153,7 @@ def test_bazooka_leads_moving_target() -> None:
     bazooka = Bazooka()
     bazooka.update(EntityId(1), view, 0.0)
     projectile = view.projectiles[0]
-    vx, vy = projectile["velocity"]
+    vx, vy = cast(Vec2, projectile["velocity"])
     distance = math.hypot(300.0, 0.0)
     time_to_target = distance / bazooka.speed
     predicted_y = 0.0 + 100.0 * time_to_target


### PR DESCRIPTION
## Summary
- refine AI policy with weapon-aware factory so bazooka kites and knife dodges more
- increase knife speed bonus and orbit speed
- extend tests for policy factory and knife speeds

## Testing
- `ruff check app/ai/policy.py app/game/match.py app/weapons/knife.py tests/test_policy.py tests/unit/test_weapons.py`
- `mypy app/ai/policy.py app/game/match.py app/weapons/knife.py tests/test_policy.py tests/unit/test_weapons.py`
- `pytest tests/test_policy.py tests/unit/test_weapons.py` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_68b570ae796c832a8394a8be701e26f5