### PR TITLE
feat: accelerate bazooka missiles

### DIFF
--- a/app/game/controller.py
+++ b/app/game/controller.py
@@ -127,6 +127,7 @@ class _MatchView(WorldView):
         sprite: pygame.Surface | None = None,
         spin: float = 0.0,
         trail_color: Color | None = None,
+        acceleration: float = 0.0,
     ) -> WeaponEffect:
         proj = Projectile.spawn(
             self.world,
@@ -140,6 +141,7 @@ class _MatchView(WorldView):
             sprite,
             spin,
             trail_color,
+            acceleration,
         )
         self.effects.append(proj)
         return proj

--- a/app/weapons/__init__.py
+++ b/app/weapons/__init__.py
@@ -20,9 +20,9 @@ from .base import Weapon
 weapon_registry: Registry[Weapon] = Registry()
 
 # Import weapon modules to register them
-from . import katana as _katana  # noqa: F401,E402
-from . import shuriken as _shuriken  # noqa: F401,E402
-from . import knife as _knife  # noqa: F401,E402
 from . import bazooka as _bazooka  # noqa: F401,E402
+from . import katana as _katana  # noqa: F401,E402
+from . import knife as _knife  # noqa: F401,E402
+from . import shuriken as _shuriken  # noqa: F401,E402
 
 __all__ = ["Weapon", "weapon_registry"]

--- a/app/weapons/base.py
+++ b/app/weapons/base.py
@@ -49,6 +49,7 @@ class WorldView(Protocol):
         sprite: pygame.Surface | None = None,
         spin: float = 0.0,
         trail_color: Color | None = None,
+        acceleration: float = 0.0,
     ) -> WeaponEffect:
         """Spawn a projectile owned by *owner* and register it."""
 

--- a/app/weapons/bazooka.py
+++ b/app/weapons/bazooka.py
@@ -19,6 +19,7 @@ class Bazooka(Weapon):
     """AI-controlled launcher that fires slow, heavy missiles."""
 
     missile_radius: float
+    acceleration: float
 
     def __init__(self) -> None:
         super().__init__(name="bazooka", cooldown=0.8, damage=Damage(20), speed=300.0)
@@ -31,6 +32,7 @@ class Bazooka(Weapon):
         self._missile_sprite = load_sprite("weapons/bazooka/missile.png", max_dim=missile_size)
 
         self.audio = WeaponAudio("throw", "bazooka")
+        self.acceleration = 50.0
 
     def _fire(self, owner: EntityId, view: WorldView, direction: Vec2) -> None:  # noqa: D401
         self.audio.on_throw()
@@ -48,9 +50,10 @@ class Bazooka(Weapon):
                 radius=self.missile_radius,
                 damage=self.damage,
                 knockback=200.0,
-                ttl=15.0,  # portée/longévité augmentée
+                ttl=float("inf"),
                 sprite=self._missile_sprite,
                 trail_color=(255, 200, 50),
+                acceleration=self.acceleration,
             ),
         )
 

--- a/app/weapons/effects.py
+++ b/app/weapons/effects.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 import math
+from dataclasses import dataclass, field
 from math import tau
 
 import numpy as np

--- a/app/world/projectiles.py
+++ b/app/world/projectiles.py
@@ -33,6 +33,7 @@ class Projectile(WeaponEffect):
     trail_color: Color | None = None
     trail: list[Vec2] = field(default_factory=list)
     trail_width: int = 2
+    acceleration: float = 0.0
 
     @classmethod
     def spawn(
@@ -48,6 +49,7 @@ class Projectile(WeaponEffect):
         sprite: pygame.Surface | None = None,
         spin: float = 0.0,
         trail_color: Color | None = None,
+        acceleration: float = 0.0,
     ) -> Projectile:
         """Create and add a projectile to the physics world."""
         moment = pymunk.moment_for_circle(1.0, 0, radius)
@@ -70,11 +72,20 @@ class Projectile(WeaponEffect):
             sprite=sprite,
             spin=spin,
             trail_color=trail_color,
+            acceleration=acceleration,
         )
 
     def step(self, dt: float) -> bool:
         """Advance state and return ``True`` while the projectile is alive."""
         self.ttl -= dt
+        if self.acceleration != 0.0:
+            vx = float(self.body.velocity.x)
+            vy = float(self.body.velocity.y)
+            speed = sqrt(vx * vx + vy * vy)
+            if speed > 0.0:
+                new_speed = speed + self.acceleration * dt
+                scale = new_speed / speed
+                self.body.velocity = (vx * scale, vy * scale)
         if self.sprite is not None:
             if self.spin != 0.0:
                 self.angle = (self.angle + self.spin * dt) % (2 * pi)

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -59,6 +59,7 @@ class DummyView(WorldView):
         sprite: object | None = None,
         spin: float = 0.0,
         trail_color: tuple[int, int, int] | None = None,
+        acceleration: float = 0.0,
     ) -> WeaponEffect:  # noqa: D401
         self.last_velocity = velocity
 

--- a/tests/test_weapon_audio_integration.py
+++ b/tests/test_weapon_audio_integration.py
@@ -51,6 +51,7 @@ class ProjectileView:
         ttl: float,
         sprite: object | None = None,
         spin: float = 0.0,
+        acceleration: float = 0.0,
     ) -> WeaponEffect:
         proj = Projectile.spawn(
             self.world,
@@ -63,6 +64,7 @@ class ProjectileView:
             ttl,
             sprite,
             spin,
+            acceleration=acceleration,
         )
         self.projectile = proj
         return proj
@@ -143,7 +145,8 @@ def test_shuriken_audio_events() -> None:
     projectile = view_obj.projectile
     assert projectile is not None
     projectile.on_hit(view, EntityId(2), timestamp=0.0)
-    assert stub_audio.touched*
+    assert stub_audio.touched
+
     class View:
         def __init__(self) -> None:
             self.world = PhysicsWorld()
@@ -165,6 +168,7 @@ def test_shuriken_audio_events() -> None:
             sprite: object | None = None,
             spin: float = 0.0,
             trail_color: tuple[int, int, int] | None = None,
+            acceleration: float = 0.0,
         ) -> WeaponEffect:
             proj = Projectile.spawn(
                 self.world,
@@ -178,6 +182,7 @@ def test_shuriken_audio_events() -> None:
                 sprite,
                 spin,
                 trail_color,
+                acceleration,
             )
             self.projectile = proj
             return proj

--- a/tests/test_weapons.py
+++ b/tests/test_weapons.py
@@ -1,7 +1,7 @@
-from app.weapons.katana import Katana
-from app.weapons.shuriken import Shuriken
-from app.weapons.knife import Knife
 from app.weapons.bazooka import Bazooka
+from app.weapons.katana import Katana
+from app.weapons.knife import Knife
+from app.weapons.shuriken import Shuriken
 from app.world.entities import DEFAULT_BALL_RADIUS
 
 

--- a/tests/unit/test_katana_deflect.py
+++ b/tests/unit/test_katana_deflect.py
@@ -51,6 +51,7 @@ class DummyView(WorldView):
         sprite: pygame.Surface | None = None,
         spin: float = 0.0,
         trail_color: tuple[int, int, int] | None = None,
+        acceleration: float = 0.0,
     ) -> WeaponEffect:
         raise NotImplementedError
 

--- a/tests/unit/test_policy_angles.py
+++ b/tests/unit/test_policy_angles.py
@@ -54,6 +54,7 @@ class DummyView(WorldView):
         sprite: object | None = None,
         spin: float = 0.0,
         trail_color: tuple[int, int, int] | None = None,
+        acceleration: float = 0.0,
     ) -> WeaponEffect:  # noqa: D401
         self.last_velocity = velocity
 

--- a/tests/unit/test_projectile_reorient.py
+++ b/tests/unit/test_projectile_reorient.py
@@ -31,3 +31,23 @@ def test_projectile_reorients_and_trails() -> None:
     projectile.step(0.1)
     assert projectile.angle == pytest.approx(math.pi)
     assert len(projectile.trail) == 2
+
+
+def test_projectile_accelerates() -> None:
+    pygame.init()
+    world = PhysicsWorld()
+    projectile = Projectile.spawn(
+        world,
+        owner=EntityId(1),
+        position=(0.0, 0.0),
+        velocity=(10.0, 0.0),
+        radius=1.0,
+        damage=Damage(1),
+        knockback=0.0,
+        ttl=1.0,
+        acceleration=10.0,
+    )
+    projectile.step(0.5)
+    vx = float(projectile.body.velocity.x)
+    speed = math.hypot(vx, float(projectile.body.velocity.y))
+    assert speed == pytest.approx(15.0)

--- a/tests/unit/test_weapons.py
+++ b/tests/unit/test_weapons.py
@@ -62,6 +62,7 @@ class DummyView(WorldView):
         sprite: object | None = None,
         spin: float = 0.0,
         trail_color: tuple[int, int, int] | None = None,
+        acceleration: float = 0.0,
     ) -> WeaponEffect:  # noqa: D401,E501
         self.projectiles.append(
             {
@@ -72,6 +73,7 @@ class DummyView(WorldView):
                 "damage": damage,
                 "ttl": ttl,
                 "trail_color": trail_color,
+                "acceleration": acceleration,
             }
         )
 
@@ -138,7 +140,7 @@ def test_bazooka_fires_missile() -> None:
     assert vx == pytest.approx(bazooka.speed)
     assert vy == pytest.approx(0.0)
     assert projectile["radius"] == bazooka.missile_radius
-    assert projectile["ttl"] == pytest.approx(15.0)
+    assert math.isinf(cast(float, projectile["ttl"]))
     assert projectile["trail_color"] == (255, 200, 50)
     effect = view.effects[0]
     assert effect.collides(view, (0.0, 0.0), 1.0) is False
@@ -204,6 +206,7 @@ class _OrientView(WorldView):
         sprite: object | None = None,
         spin: float = 0.0,
         trail_color: tuple[int, int, int] | None = None,
+        acceleration: float = 0.0,
     ) -> WeaponEffect:  # noqa: D401
         class _Dummy(WeaponEffect):
             owner: EntityId = owner


### PR DESCRIPTION
## Summary
- allow projectiles to accelerate over time
- make bazooka missiles speed up continuously and persist until they hit
- expose acceleration through `WorldView.spawn_projectile`

## Testing
- `ruff check`
- `mypy app/world/projectiles.py app/weapons/bazooka.py app/weapons/base.py app/game/controller.py tests/unit/test_weapons.py tests/unit/test_projectile_reorient.py tests/unit/test_policy_angles.py tests/test_policy.py tests/test_weapon_audio_integration.py tests/unit/test_katana_deflect.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'imageio_ffmpeg')*


------
https://chatgpt.com/codex/tasks/task_e_68b5813db160832a989131527f068c53