### PR TITLE
fix: stop idle audio after any death

### DIFF
--- a/app/game/controller.py
+++ b/app/game/controller.py
@@ -93,9 +93,10 @@ class _MatchView(WorldView):
                 else:
                     self.renderer.add_impact(pos, duration=2.0)
                     p.audio.on_explode(timestamp=timestamp)
-                    weapon_audio = getattr(p.weapon, "audio", None)
-                    if weapon_audio is not None:
-                        weapon_audio.stop_idle(timestamp)
+                    for other in self.players:
+                        weapon_audio = getattr(other.weapon, "audio", None)
+                        if weapon_audio is not None:
+                            weapon_audio.stop_idle(timestamp)
                 self.renderer.trigger_blink(p.color, int(damage.amount))
                 self.renderer.trigger_hit_flash(p.color)
                 return

--- a/tests/test_idle_sounds_stop_on_death.py
+++ b/tests/test_idle_sounds_stop_on_death.py
@@ -40,7 +40,7 @@ class KillerWeapon(Weapon):
         if not self._done:
             enemy = view.get_enemy(owner)
             if enemy is not None:
-                view.deal_damage(enemy, self.damage, timestamp=0.0)
+                view.deal_damage(enemy, self.damage, timestamp=0.5)
                 self._done = True
         super().update(owner, view, dt)
 
@@ -66,8 +66,8 @@ class DummyRecorder(Recorder):
         self.audio = audio
 
 
-def test_winner_idle_sound_stops_on_victory() -> None:
-    """Ensure the winner's idle sound stops when the match ends."""
+def test_idle_sounds_stop_on_death() -> None:
+    """Idle loops for both players stop immediately when a death occurs."""
 
     reset_default_engine()
     engine = get_default_engine()
@@ -84,12 +84,9 @@ def test_winner_idle_sound_stops_on_victory() -> None:
     controller = create_controller("killer_test", "passive_test", recorder, renderer, max_seconds=1)
     controller.run()
 
-    assert audio_a.stopped_at is not None
-    assert controller.death_ts is not None
-    assert audio_a.stopped_at == pytest.approx(controller.death_ts)
-    intro_duration = controller.intro_manager._duration  # type: ignore[attr-defined]
-    assert audio_a.stopped_at >= intro_duration
-    assert audio_b.stopped_at is not None
+    assert audio_a.stopped_at == pytest.approx(0.5)
+    assert audio_b.stopped_at == pytest.approx(0.5)
+    assert audio_a.stopped_at == audio_b.stopped_at
 
     weapon_registry._factories.pop("killer_test")
     weapon_registry._factories.pop("passive_test")


### PR DESCRIPTION
## Summary
- stop idle loops for all weapons when any player dies
- cover idle-loop shutdown with regression test

## Testing
- `uv run ruff check .` *(fails: Failed to download `typing-extensions==4.14.1`)*
- `uv run ruff format .` *(fails: Failed to download `python-dotenv==1.1.1`)*
- `uv run mypy .` *(fails: Failed to download `pygments==2.19.2`)*
- `uv run pytest` *(fails: Failed to download `click==8.2.1`)*

------
https://chatgpt.com/codex/tasks/task_e_68b587f56bfc832a89fe0421f94997cd