### PR TITLE
fix: reduce intro VS logo scale

### DIFF
--- a/app/intro/config.py
+++ b/app/intro/config.py
@@ -35,7 +35,8 @@ class IntroConfig:
         start sliding.
     logo_scale, weapon_scale:
         Multiplicative factors applied to the logo and weapon images when
-        rendering.
+        rendering. ``logo_scale`` defaults to ``0.5`` so the VS logo appears at
+        half of its source size.
     font_path, logo_path, weapon_a_path, weapon_b_path:
         Paths to the font and images used by the introduction. When ``None`` or
         missing, fallbacks will be generated.
@@ -60,7 +61,7 @@ class IntroConfig:
     right_pos_pct: Vec2 = (0.75, 0.6)
     center_pos_pct: Vec2 = (0.5, 0.45)
     slide_offset_pct: float = 0.5
-    logo_scale: float = 1.0
+    logo_scale: float = 0.5
     weapon_scale: float = 1.0
     font_path: Path | None = None
     logo_path: Path | None = None

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -13,7 +13,7 @@ Ce document décrit l'architecture de l'animation d'introduction avant chaque ma
 
 - Calcule les positions et l'opacité des éléments selon le `progress` fourni par le gestionnaire.
 - Utilise les paramètres d'`IntroConfig` pour les dimensions, les positions et les fonctions d'interpolation.
-- Affiche le logo VS centré au-dessus des noms des armes.
+- Affiche le logo VS centré au-dessus des noms des armes, à 50 % de sa taille d'origine.
 - Les images des armes (40 % de la largeur de l'écran) apparaissent juste au-dessus de leur nom,
   tous deux alignés horizontalement légèrement sous le milieu de l'écran.
 - Les noms sont rendus avec la police `assets/fonts/FightKickDemoRegular.ttf`.

--- a/tests/unit/test_intro_renderer.py
+++ b/tests/unit/test_intro_renderer.py
@@ -162,6 +162,7 @@ def test_draw_with_assets(monkeypatch: pytest.MonkeyPatch) -> None:
         weapon_a_path=Path("assets/ball-a.png"),
         weapon_b_path=Path("assets/ball-b.png"),
     )
+    assert config.logo_scale == 0.5
     assets = IntroAssets.load(config)
     renderer = IntroRenderer(200, 100, config=config, assets=assets)
     surface = pygame.Surface((200, 100), flags=pygame.SRCALPHA)
@@ -216,6 +217,27 @@ def test_draw_with_assets(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert len(blits) == len(expected_centers)
     assert set(expected_centers).issubset(set(blits))
+    pygame.quit()
+
+
+def test_logo_scaled_to_config() -> None:
+    pygame.init()
+    config = IntroConfig(
+        font_path=Path("assets/fonts/FightKickDemoRegular.ttf"),
+        logo_path=Path("assets/vs.png"),
+        weapon_a_path=Path("assets/ball-a.png"),
+        weapon_b_path=Path("assets/ball-b.png"),
+    )
+    assets = IntroAssets.load(config)
+    renderer = IntroRenderer(200, 100, config=config, assets=assets)
+    left, right, center = renderer.compute_positions(1.0)
+    elements = renderer._prepare_elements(("A", "B"), 1.0, left, right, center)
+    logo_surface = elements[2][0]
+    angle, scale_factor = renderer._compute_transform(1.0)
+    expected_logo = pygame.transform.rotozoom(
+        assets.logo, angle, config.logo_scale * scale_factor
+    )
+    assert logo_surface.get_size() == expected_logo.get_size()
     pygame.quit()
 
 


### PR DESCRIPTION
## Summary
- shrink VS logo in intro by default
- document smaller logo scale
- cover intro logo scaling with a unit test

## Testing
- `uv run pre-commit run --files app/intro/config.py docs/intro.md tests/unit/test_intro_renderer.py` *(failed: Failed to download typing-extensions==4.14.1)*
- `uv run pytest tests/unit/test_intro_renderer.py::test_logo_scaled_to_config` *(failed: Failed to download markdown-it-py==4.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b588aee638832ab93c8b24ada1c445