### PR TITLE
feat: engage at critical health

### DIFF
--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -150,6 +150,22 @@ def test_low_health_fire_requires_range(style: Literal["aggressive", "kiter", "e
     assert fire is False
 
 
+@pytest.mark.parametrize("style", ["aggressive", "kiter", "evader"])
+def test_both_low_health_engage(style: Literal["aggressive", "kiter", "evader"]) -> None:
+    view = DummyView(
+        EntityId(1),
+        EntityId(2),
+        (0.0, 0.0),
+        (50.0, 0.0),
+        health_me=0.1,
+        health_enemy=0.1,
+    )
+    policy = SimplePolicy(style)
+    accel, _, fire = policy.decide(EntityId(1), view, 600.0)
+    assert accel[0] > 0  # moves toward enemy
+    assert fire is True
+
+
 def test_horizontal_alignment_has_vertical_component() -> None:
     me = EntityId(1)
     enemy = EntityId(2)


### PR DESCRIPTION
## Summary
- switch to aggressive AI when both fighters have critical health
- test engagement when both fighters are low on health

## Testing
- `python -m ruff check app/ai/policy.py tests/test_policy.py`
- `python -m mypy app/ai/policy.py tests/test_policy.py`
- `python -m pytest tests/test_policy.py` *(fails: ModuleNotFoundError: No module named 'pygame')*


------
https://chatgpt.com/codex/tasks/task_e_68b5944d5f7c832aa3e5d9341447a63f