### PR TITLE
feat: add knockback to orbiting sprite

### DIFF
--- a/app/weapons/effects.py
+++ b/app/weapons/effects.py
@@ -80,6 +80,7 @@ class OrbitingSprite(WeaponEffect):
     radius: float
     angle: float
     speed: float
+    knockback: float = 0.0
     trail_color: Color = (255, 255, 255)
     trail: list[Vec2] = field(default_factory=list)
     trail_len: int = 8
@@ -102,8 +103,14 @@ class OrbitingSprite(WeaponEffect):
         return bool(dx * dx + dy * dy <= (hit_rad + radius) ** 2)
 
     def on_hit(self, view: WorldView, target: EntityId, timestamp: float) -> bool:  # noqa: D401
-        """Apply damage to ``target`` at ``timestamp``."""
+        """Apply damage and knock back ``target`` at ``timestamp``."""
         view.deal_damage(target, self.damage, timestamp)
+        blade_pos = self._position(view)
+        target_pos = view.get_position(target)
+        dx = target_pos[0] - blade_pos[0]
+        dy = target_pos[1] - blade_pos[1]
+        norm = math.hypot(dx, dy) or 1.0
+        view.apply_impulse(target, dx / norm * self.knockback, dy / norm * self.knockback)
         if self.audio is not None:
             self.audio.on_touch(timestamp)
         return True

--- a/app/weapons/katana.py
+++ b/app/weapons/katana.py
@@ -37,6 +37,7 @@ class Katana(Weapon):
                 radius=60.0,
                 angle=0.0,
                 speed=self.speed,
+                knockback=220.0,
                 audio=self.audio,
             )
             view.spawn_effect(effect)

--- a/app/weapons/knife.py
+++ b/app/weapons/knife.py
@@ -40,6 +40,7 @@ class Knife(Weapon):
                 radius=60.0,
                 angle=0.0,
                 speed=self.speed,
+                knockback=120.0,
                 audio=self.audio,
             )
             view.spawn_effect(effect)

--- a/tests/unit/test_orbiting_sprite_knockback.py
+++ b/tests/unit/test_orbiting_sprite_knockback.py
@@ -1,0 +1,76 @@
+from dataclasses import dataclass, field
+
+import pygame
+
+from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
+from app.weapons.base import WeaponEffect, WorldView
+from app.weapons.effects import OrbitingSprite
+
+
+@dataclass
+class DummyView(WorldView):
+    positions: dict[EntityId, Vec2]
+    impulses: dict[EntityId, Vec2] = field(default_factory=dict)
+
+    def get_enemy(self, owner: EntityId) -> EntityId | None:
+        return None
+
+    def get_position(self, eid: EntityId) -> Vec2:
+        return self.positions[eid]
+
+    def get_velocity(self, eid: EntityId) -> Vec2:
+        return (0.0, 0.0)
+
+    def get_health_ratio(self, eid: EntityId) -> float:
+        return 1.0
+
+    def deal_damage(self, eid: EntityId, damage: Damage, timestamp: float) -> None:
+        return None
+
+    def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:
+        self.impulses[eid] = (vx, vy)
+
+    def spawn_effect(self, effect: WeaponEffect) -> None:
+        return None
+
+    def add_speed_bonus(self, eid: EntityId, bonus: float) -> None:
+        return None
+
+    def spawn_projectile(
+        self,
+        owner: EntityId,
+        position: Vec2,
+        velocity: Vec2,
+        radius: float,
+        damage: Damage,
+        knockback: float,
+        ttl: float,
+        sprite: pygame.Surface | None = None,
+        spin: float = 0.0,
+        trail_color: tuple[int, int, int] | None = None,
+        acceleration: float = 0.0,
+    ) -> WeaponEffect:
+        raise NotImplementedError
+
+    def iter_projectiles(self, excluding: EntityId | None = None) -> list[ProjectileInfo]:
+        return []
+
+
+def test_orbiting_sprite_applies_knockback() -> None:
+    pygame.init()
+    owner = EntityId(1)
+    target = EntityId(2)
+    positions = {owner: (0.0, 0.0), target: (20.0, 0.0)}
+    view = DummyView(positions)
+    sprite = pygame.Surface((10, 10))
+    blade = OrbitingSprite(
+        owner=owner,
+        damage=Damage(0),
+        sprite=sprite,
+        radius=10.0,
+        angle=0.0,
+        speed=0.0,
+        knockback=100.0,
+    )
+    blade.on_hit(view, target, timestamp=0.0)
+    assert view.impulses[target] == (100.0, 0.0)


### PR DESCRIPTION
## Summary
- add configurable knockback to orbiting sprite and apply impulse on hit
- wire knockback into katana and knife weapons
- cover orbiting sprite knockback behavior with tests

## Testing
- `uv run ruff app tests` *(failed: Failed to download `pymunk==7.1.0`)*
- `uv run mypy app tests` *(failed: Failed to download `pydantic==2.11.7`)*
- `uv run pytest` *(failed: Failed to download `pydantic-settings==2.10.1`)*

------
https://chatgpt.com/codex/tasks/task_e_68b598040320832a819177bbdbc6ea62