### PR TITLE
feat: extend shuriken projectile range and lifespan

### DIFF
--- a/app/ai/policy.py
+++ b/app/ai/policy.py
@@ -106,6 +106,7 @@ class SimplePolicy:
     dodge_bias: float = 0.5
     desired_dist_factor: float = 0.5
     fire_range_factor: float = 0.8
+    fire_range: float = 150.0
 
     def decide(
         self, me: EntityId, view: WorldView, projectile_speed: float | None = None
@@ -173,7 +174,7 @@ class SimplePolicy:
         )
         norm = math.hypot(*combined) or 1.0
         accel = (combined[0] / norm * 400.0, combined[1] / norm * 400.0)
-        fire = dist <= 150 and direction[0] * face[0] + direction[1] * face[1] >= cos_thresh
+        fire = dist <= self.fire_range and direction[0] * face[0] + direction[1] * face[1] >= cos_thresh
         return accel, fire
 
     def _evader(
@@ -249,4 +250,6 @@ def policy_for_weapon(weapon_name: str) -> SimplePolicy:
         )
     if weapon_name == "knife":
         return SimplePolicy("aggressive", dodge_bias=1.0)
+    if weapon_name == "shuriken":
+        return SimplePolicy("aggressive", fire_range=float("inf"))
     return SimplePolicy("aggressive")

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -230,3 +230,10 @@ def test_policy_for_knife_prioritises_dodging() -> None:
     policy = policy_for_weapon("knife")
     assert policy.style == "aggressive"
     assert policy.dodge_bias > 0.5
+
+
+def test_shuriken_policy_fires_at_any_distance() -> None:
+    view = DummyView(EntityId(1), EntityId(2), (0.0, 0.0), (1000.0, 0.0))
+    policy = policy_for_weapon("shuriken")
+    _, _, fire = policy.decide(EntityId(1), view, 600.0)
+    assert fire is True

--- a/tests/unit/test_projectile_bounces.py
+++ b/tests/unit/test_projectile_bounces.py
@@ -1,0 +1,47 @@
+import pygame
+
+from app.core.types import Damage, EntityId
+from app.world.physics import PhysicsWorld
+from app.world.projectiles import Projectile
+
+
+def test_projectile_requires_two_bounces_for_expiration() -> None:
+    pygame.init()
+    world = PhysicsWorld()
+    projectile = Projectile.spawn(
+        world,
+        owner=EntityId(1),
+        position=(0.0, 0.0),
+        velocity=(100.0, 0.0),
+        radius=1.0,
+        damage=Damage(1),
+        knockback=0.0,
+        ttl=0.1,
+    )
+    assert projectile.step(0.2) is True
+    projectile.body.velocity = (-100.0, 0.0)
+    assert projectile.step(0.0) is True
+    assert projectile.bounces == 1
+    projectile.body.velocity = (100.0, 0.0)
+    assert projectile.step(0.0) is False
+    assert projectile.bounces == 2
+
+
+def test_retarget_resets_bounce_counter() -> None:
+    pygame.init()
+    world = PhysicsWorld()
+    projectile = Projectile.spawn(
+        world,
+        owner=EntityId(1),
+        position=(0.0, 0.0),
+        velocity=(100.0, 0.0),
+        radius=1.0,
+        damage=Damage(1),
+        knockback=0.0,
+        ttl=1.0,
+    )
+    projectile.body.velocity = (-100.0, 0.0)
+    projectile.step(0.0)
+    assert projectile.bounces == 1
+    projectile.retarget((0.0, 0.0), EntityId(2))
+    assert projectile.bounces == 0


### PR DESCRIPTION
## Summary
- allow Shuriken users to fire from any distance by adding `fire_range` to `SimplePolicy` and setting shuriken range to infinity
- require projectiles to bounce twice before expiring and reset bounce count when deflected
- add tests for projectile bounce lifetime and shuriken firing policy

## Testing
- `uv run pre-commit run --files app/ai/policy.py app/world/projectiles.py tests/test_policy.py tests/unit/test_projectile_bounces.py` *(failed: tunnel error while downloading pygame)*
- `uv run mypy app/ai/policy.py app/world/projectiles.py tests/test_policy.py tests/unit/test_projectile_bounces.py` *(failed: tunnel error while downloading python-dotenv)*
- `uv run pytest tests/test_policy.py tests/unit/test_projectile_bounces.py` *(failed: tunnel error while downloading imageio)*

------
https://chatgpt.com/codex/tasks/task_e_68b599380f48832a961efb25561d8189