### PR TITLE
fix: ensure throw sound always plays

### DIFF
--- a/app/audio/weapons.py
+++ b/app/audio/weapons.py
@@ -121,10 +121,15 @@ class WeaponAudio:
     # Events
     # ------------------------------------------------------------------
     def on_throw(self, timestamp: float | None = None) -> None:
-        """Play the throw sound for throwable weapons."""
+        """Play the throw sound for throwable weapons.
+
+        The underlying :class:`~app.audio.engine.AudioEngine` is instructed to
+        bypass its cooldown mechanism so that simultaneous throws always
+        trigger an audible cue.
+        """
         if self._throw_path is None:
             raise RuntimeError("This weapon type cannot throw")
-        self._engine.play_variation(self._throw_path, timestamp=timestamp)
+        self._engine.play_variation(self._throw_path, timestamp=timestamp, cooldown_ms=0)
 
     def on_touch(self, timestamp: float | None = None) -> None:
         """Play the touch/hit sound for any weapon."""

--- a/tests/test_audio_ball.py
+++ b/tests/test_audio_ball.py
@@ -22,7 +22,12 @@ class StubAudioEngine:
         self.timestamps: list[float | None] = []
 
     def play_variation(
-        self, path: str, volume: float | None = None, timestamp: float | None = None
+        self,
+        path: str,
+        volume: float | None = None,
+        timestamp: float | None = None,
+        *,
+        cooldown_ms: int | None = None,
     ) -> object:  # noqa: D401
         self.played.append(path)
         self.timestamps.append(timestamp)

--- a/tests/test_audio_engine.py
+++ b/tests/test_audio_engine.py
@@ -20,6 +20,15 @@ def test_cache_and_cooldown() -> None:
     engine.shutdown()
 
 
+def test_play_variation_no_cooldown() -> None:
+    engine = AudioEngine()
+    path = "assets/weapons/katana/touch.ogg"
+    handle1 = engine.play_variation(path, cooldown_ms=0)
+    handle2 = engine.play_variation(path, cooldown_ms=0)
+    assert handle1 is not None and handle2 is not None
+    engine.shutdown()
+
+
 def test_capture_mixdown() -> None:
     engine = AudioEngine()
     engine.start_capture()

--- a/tests/test_audio_weapons.py
+++ b/tests/test_audio_weapons.py
@@ -7,7 +7,7 @@ from app.audio.weapons import WeaponAudio
 
 class StubAudioEngine:
     def __init__(self) -> None:
-        self.played: list[tuple[str, object]] = []
+        self.played: list[tuple[str, int | None, object]] = []
         self.stopped: list[tuple[object, float | None]] = []
         self.stop_all_called = False
 
@@ -16,9 +16,11 @@ class StubAudioEngine:
         path: str,
         volume: float | None = None,
         timestamp: float | None = None,
+        *,
+        cooldown_ms: int | None = None,
     ) -> object:  # noqa: D401
         handle: object = object()
-        self.played.append((path, handle))
+        self.played.append((path, cooldown_ms, handle))
         return handle
 
     def get_length(self, path: str) -> float:  # noqa: D401
@@ -38,9 +40,9 @@ def test_melee_idle_and_touch() -> None:
     time.sleep(0.05)
     audio.on_touch(timestamp=0.05)
     audio.stop_idle(timestamp=0.05)
-    idle_handles = [h for p, h in engine.played if p.endswith("idle.ogg")]
+    idle_handles = [h for p, _c, h in engine.played if p.endswith("idle.ogg")]
     assert idle_handles
-    assert any(p.endswith("touch.ogg") for p, _ in engine.played)
+    assert any(p.endswith("touch.ogg") for p, _c, _h in engine.played)
     assert engine.stopped[0][0] == idle_handles[-1]
     assert engine.stopped[0][1] == 0.05
     assert not engine.stop_all_called
@@ -51,5 +53,14 @@ def test_throw_events() -> None:
     audio = WeaponAudio("throw", "shuriken", engine=cast(AudioEngine, engine))
     audio.on_throw(timestamp=0.0)
     audio.on_touch(timestamp=0.1)
-    assert any(p.endswith("throw.ogg") for p, _ in engine.played)
-    assert any(p.endswith("touch.ogg") for p, _ in engine.played)
+    assert any(p.endswith("throw.ogg") for p, _c, _h in engine.played)
+    assert any(p.endswith("touch.ogg") for p, _c, _h in engine.played)
+
+
+def test_throw_ignores_cooldown() -> None:
+    engine = StubAudioEngine()
+    audio = WeaponAudio("throw", "shuriken", engine=cast(AudioEngine, engine))
+    audio.on_throw()
+    audio.on_throw()
+    assert len(engine.played) == 2
+    assert all(c == 0 for _, c, _ in engine.played)

--- a/tests/test_ball_death_sound.py
+++ b/tests/test_ball_death_sound.py
@@ -49,7 +49,12 @@ class DummyEngine:
         self.timestamps: list[float | None] = []
 
     def play_variation(
-        self, path: str, volume: float | None = None, timestamp: float | None = None
+        self,
+        path: str,
+        volume: float | None = None,
+        timestamp: float | None = None,
+        *,
+        cooldown_ms: int | None = None,
     ) -> object:
         self.paths.append(path)
         self.timestamps.append(timestamp)

--- a/tests/test_ball_hit_sound.py
+++ b/tests/test_ball_hit_sound.py
@@ -49,7 +49,12 @@ class DummyEngine:
         self.timestamps: list[float | None] = []
 
     def play_variation(
-        self, path: str, volume: float | None = None, timestamp: float | None = None
+        self,
+        path: str,
+        volume: float | None = None,
+        timestamp: float | None = None,
+        *,
+        cooldown_ms: int | None = None,
     ) -> object:
         self.paths.append(path)
         self.timestamps.append(timestamp)

--- a/tests/unit/test_intro_manager.py
+++ b/tests/unit/test_intro_manager.py
@@ -15,7 +15,12 @@ class StubEngine:
         self.played: list[tuple[str, float | None]] = []
 
     def play_variation(
-        self, path: str, volume: float | None = None, timestamp: float | None = None
+        self,
+        path: str,
+        volume: float | None = None,
+        timestamp: float | None = None,
+        *,
+        cooldown_ms: int | None = None,
     ) -> None:
         self.played.append((path, timestamp))
 


### PR DESCRIPTION
## Summary
- allow audio engine cooldown to be overridden per play
- bypass cooldown for throw sounds so every projectile launch plays audio
- cover audio engine and weapon throw behaviour with tests

## Testing
- `make lint` *(fails: Failed to download python-dotenv==1.1.1)*
- `make test` *(fails: Failed to download typing-extensions==4.14.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a7d4703c832a8bf01ac302e2a1e7