### PR TITLE
feat: introduce stateful AI policy with parry mechanic

### DIFF
--- a/app/ai/stateful_policy.py
+++ b/app/ai/stateful_policy.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+"""Stateful AI policy with attack, dodge, parry and retreat states."""
+
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Literal
+
+from app.core.types import Damage, EntityId, Vec2
+from app.weapons.base import WorldView
+from app.ai.policy import (
+    SimplePolicy,
+    _lead_target,
+    _projectile_dodge,
+)
+
+
+class State(Enum):
+    """Possible high-level behaviours for :class:`StatefulPolicy`."""
+
+    ATTACK = "attack"
+    DODGE = "dodge"
+    PARRY = "parry"
+    RETREAT = "retreat"
+
+
+@dataclass(slots=True)
+class StatefulPolicy(SimplePolicy):
+    """Finite state policy handling basic combat behaviours.
+
+    The policy starts in :class:`State.ATTACK` and transitions to other states
+    based on health and incoming threats. It reuses the motion primitives of
+    :class:`app.ai.policy.SimplePolicy` but exposes clearer state specific
+    methods to ease future extensions.
+    """
+
+    state: State = State.ATTACK
+    parry_window: float = 0.15
+    _incoming_time: float = field(default=float("inf"), init=False)
+
+    def decide(
+        self, me: EntityId, view: WorldView, projectile_speed: float | None = None
+    ) -> tuple[Vec2, Vec2, bool]:
+        """Return acceleration, facing vector and fire decision."""
+
+        enemy = view.get_enemy(me)
+        assert enemy is not None
+        my_pos = view.get_position(me)
+        enemy_pos = view.get_position(enemy)
+        enemy_vel = view.get_velocity(enemy)
+        dx = enemy_pos[0] - my_pos[0]
+        dy = enemy_pos[1] - my_pos[1]
+        dist = math.hypot(dx, dy)
+        direction = (dx / dist, dy / dist) if dist else (1.0, 0.0)
+        my_health = view.get_health_ratio(me)
+        enemy_health = view.get_health_ratio(enemy)
+
+        face: Vec2 = _lead_target(my_pos, enemy_pos, enemy_vel, projectile_speed or 0.0)
+        cos_thresh = math.cos(math.radians(18))
+
+        both_critical = my_health < 0.15 and enemy_health < 0.15
+        if my_health < 0.15 and not both_critical:
+            self.state = State.RETREAT
+        else:
+            vel, t_hit = self._incoming_projectile(me, view, my_pos)
+            self._incoming_time = t_hit
+            if vel is not None and t_hit <= self.parry_window:
+                self.state = State.PARRY
+            elif vel is not None:
+                self.state = State.DODGE
+            else:
+                self.state = State.ATTACK
+
+        style = "aggressive" if both_critical else self.style
+
+        if self.state == State.ATTACK:
+            accel, fire = self._attack(
+                style, me, view, my_pos, direction, dist, face, cos_thresh, projectile_speed
+            )
+        elif self.state == State.DODGE:
+            accel, fire = self._dodge(me, view, my_pos, direction)
+        elif self.state == State.PARRY:
+            accel, fire = self._parry(direction)
+        else:  # retreat
+            # Fire decision still follows attack logic
+            _, fire = self._attack(
+                style, me, view, my_pos, direction, dist, face, cos_thresh, projectile_speed
+            )
+            accel = (-direction[0] * 400.0, -direction[1] * 400.0)
+
+        if abs(dy) <= 1e-6:
+            offset_face = (direction[0], self.vertical_offset)
+            norm = math.hypot(*offset_face) or 1.0
+            face = (offset_face[0] / norm, offset_face[1] / norm)
+
+        return accel, face, fire
+
+    # State handlers -----------------------------------------------------
+    def _attack(
+        self,
+        style: Literal["aggressive", "kiter", "evader"],
+        me: EntityId,
+        view: WorldView,
+        my_pos: Vec2,
+        direction: Vec2,
+        dist: float,
+        face: Vec2,
+        cos_thresh: float,
+        projectile_speed: float | None,
+    ) -> tuple[Vec2, bool]:
+        if style == "aggressive":
+            return self._aggressive(me, view, my_pos, direction, dist, face, cos_thresh)
+        if style == "evader":
+            return self._evader(
+                me, view, my_pos, direction, dist, face, cos_thresh, projectile_speed
+            )
+        return self._kiter(direction, dist, face, cos_thresh, projectile_speed)
+
+    def _dodge(
+        self,
+        me: EntityId,
+        view: WorldView,
+        my_pos: Vec2,
+        direction: Vec2,
+    ) -> tuple[Vec2, bool]:
+        dodge = _projectile_dodge(me, view, my_pos, direction)
+        accel = (dodge[0] * 400.0, dodge[1] * 400.0)
+        return accel, False
+
+    def _parry(self, direction: Vec2) -> tuple[Vec2, bool]:
+        # Stand still and face the threat; firing is disabled
+        accel = (0.0, 0.0)
+        return accel, False
+
+    # Utilities ----------------------------------------------------------
+    def _incoming_projectile(
+        self, me: EntityId, view: WorldView, position: Vec2
+    ) -> tuple[Vec2 | None, float]:
+        closest_t = float("inf")
+        best_vel: Vec2 | None = None
+        for proj in view.iter_projectiles(excluding=me):
+            px, py = proj.position
+            vx, vy = proj.velocity
+            rx = px - position[0]
+            ry = py - position[1]
+            approach = rx * vx + ry * vy
+            if approach >= 0.0:
+                continue
+            speed_sq = vx * vx + vy * vy
+            if speed_sq <= 1e-6:
+                continue
+            t = -approach / speed_sq
+            if t >= closest_t or t > 1.0 or t <= 0.0:
+                continue
+            hit_x = rx + vx * t
+            hit_y = ry + vy * t
+            if hit_x * hit_x + hit_y * hit_y > 200.0**2:
+                continue
+            closest_t = t
+            best_vel = (vx, vy)
+        return best_vel, closest_t
+
+    def parry_damage(self, damage: Damage) -> Damage:
+        """Return modified ``damage`` after a parry attempt."""
+        if self.state == State.PARRY and self._incoming_time <= self.parry_window:
+            return Damage(0.0)
+        return damage
+
+
+def policy_for_weapon(weapon_name: str) -> StatefulPolicy:
+    """Return a :class:`StatefulPolicy` tuned for ``weapon_name``."""
+
+    if weapon_name == "bazooka":
+        return StatefulPolicy(
+            "evader",
+            desired_dist_factor=1.2,
+            fire_range_factor=1.2,
+        )
+    if weapon_name == "knife":
+        return StatefulPolicy("aggressive", dodge_bias=1.0)
+    if weapon_name == "shuriken":
+        return StatefulPolicy("aggressive", fire_range=float("inf"))
+    return StatefulPolicy("aggressive")

--- a/app/game/controller.py
+++ b/app/game/controller.py
@@ -8,7 +8,7 @@ from math import sqrt
 import numpy as np
 import pygame
 
-from app.ai.policy import SimplePolicy
+from app.ai.stateful_policy import StatefulPolicy
 from app.audio import AudioEngine, BallAudio
 from app.core.config import settings
 from app.core.types import Color, Damage, EntityId, ProjectileInfo, Vec2
@@ -28,7 +28,7 @@ class Player:
     eid: EntityId
     ball: Ball
     weapon: Weapon
-    policy: SimplePolicy
+    policy: StatefulPolicy
     face: Vec2
     color: Color
     audio: BallAudio

--- a/app/game/match.py
+++ b/app/game/match.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from app.ai.policy import policy_for_weapon
+from app.ai.stateful_policy import policy_for_weapon
 from app.audio import BallAudio, get_default_engine
 from app.core.config import settings
 from app.game.controller import (

--- a/tests/test_stateful_policy.py
+++ b/tests/test_stateful_policy.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+from app.ai.stateful_policy import StatefulPolicy, State
+from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
+from app.weapons.base import WeaponEffect, WorldView
+
+
+@dataclass
+class DummyView(WorldView):
+    me: EntityId
+    enemy: EntityId
+    pos_me: Vec2
+    pos_enemy: Vec2
+    vel_enemy: Vec2 = (0.0, 0.0)
+    health_me: float = 1.0
+    health_enemy: float = 1.0
+    projectiles: list[ProjectileInfo] = field(default_factory=list)
+
+    def get_enemy(self, owner: EntityId) -> EntityId | None:  # noqa: D401
+        return self.enemy
+
+    def get_position(self, eid: EntityId) -> Vec2:  # noqa: D401
+        return self.pos_me if eid == self.me else self.pos_enemy
+
+    def get_velocity(self, eid: EntityId) -> Vec2:  # noqa: D401
+        return (0.0, 0.0) if eid == self.me else self.vel_enemy
+
+    def get_health_ratio(self, eid: EntityId) -> float:  # noqa: D401
+        return self.health_me if eid == self.me else self.health_enemy
+
+    def deal_damage(self, eid: EntityId, damage: Damage, timestamp: float) -> None:  # noqa: D401
+        return None
+
+    def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:  # noqa: D401
+        return None
+
+    def spawn_effect(self, effect: WeaponEffect) -> None:  # noqa: D401
+        return None
+
+    def add_speed_bonus(self, eid: EntityId, bonus: float) -> None:  # noqa: D401
+        return None
+
+    def spawn_projectile(
+        self,
+        owner: EntityId,
+        position: Vec2,
+        velocity: Vec2,
+        radius: float,
+        damage: Damage,
+        knockback: float,
+        ttl: float,
+        sprite: object | None = None,
+        spin: float = 0.0,
+        trail_color: tuple[int, int, int] | None = None,
+        acceleration: float = 0.0,
+    ) -> WeaponEffect:  # noqa: D401
+        raise NotImplementedError
+
+    def iter_projectiles(self, excluding: EntityId | None = None) -> list[ProjectileInfo]:  # noqa: D401
+        return self.projectiles
+
+
+def test_attack_then_dodge() -> None:
+    me = EntityId(1)
+    enemy = EntityId(2)
+    view = DummyView(me, enemy, (0.0, 0.0), (100.0, 0.0))
+    policy = StatefulPolicy("aggressive")
+    policy.decide(me, view, 600.0)
+    assert policy.state is State.ATTACK
+
+    projectile = ProjectileInfo(owner=enemy, position=(50.0, 0.0), velocity=(-80.0, 0.0))
+    view.projectiles = [projectile]
+    policy.decide(me, view, 600.0)
+    assert policy.state is State.DODGE
+
+
+def test_parry_reduces_damage() -> None:
+    me = EntityId(1)
+    enemy = EntityId(2)
+    projectile = ProjectileInfo(owner=enemy, position=(20.0, 0.0), velocity=(-200.0, 0.0))
+    view = DummyView(me, enemy, (0.0, 0.0), (100.0, 0.0), projectiles=[projectile])
+    policy = StatefulPolicy("aggressive")
+    policy.decide(me, view, 600.0)
+    assert policy.state is State.PARRY
+    reduced = policy.parry_damage(Damage(10.0))
+    assert reduced.amount == 0.0
+
+
+def test_retreat_on_low_health() -> None:
+    me = EntityId(1)
+    enemy = EntityId(2)
+    view = DummyView(me, enemy, (0.0, 0.0), (100.0, 0.0), health_me=0.1)
+    policy = StatefulPolicy("aggressive")
+    accel, _, _ = policy.decide(me, view, 600.0)
+    assert policy.state is State.RETREAT
+    assert accel[0] < 0


### PR DESCRIPTION
## Summary
- implement `StatefulPolicy` finite state machine (attack, dodge, parry, retreat)
- integrate `StatefulPolicy` into game controller and match setup
- add unit tests for state transitions and parry damage reduction

## Testing
- `ruff --version` *(fails: command not found)*
- `mypy --version` *(fails: command not found)*
- `python3 -m pytest --version` *(fails: No module named pytest)*


------
https://chatgpt.com/codex/tasks/task_e_68b5a8aee42c832aacac536e53661c09