### PR TITLE
feat: handle projectile collisions in physics

### DIFF
--- a/app/world/entities.py
+++ b/app/world/entities.py
@@ -11,6 +11,9 @@ from app.world.physics import PhysicsWorld
 DEFAULT_BALL_RADIUS: float = 40.0
 """Default radius used for spawned balls in pixels."""
 
+BALL_COLLISION_TYPE: int = 1
+"""Pymunk collision type value for ball shapes."""
+
 _id_gen = itertools.count(1)
 
 
@@ -40,9 +43,12 @@ class Ball:
         shape = pymunk.Circle(body, radius)
         shape.elasticity = 1.0
         shape.friction = 0.0
+        shape.collision_type = BALL_COLLISION_TYPE
         world.space.add(body, shape)
         stats = stats or Stats(max_health=100.0, max_speed=400.0)
-        return cls(eid=eid, body=body, shape=shape, stats=stats, health=stats.max_health)
+        ball = cls(eid=eid, body=body, shape=shape, stats=stats, health=stats.max_health)
+        world.register_ball(ball)
+        return ball
 
     def take_damage(self, damage: Damage) -> bool:
         """Apply damage and return True if entity is dead."""

--- a/app/world/physics.py
+++ b/app/world/physics.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import Any, TYPE_CHECKING
+
 import pymunk
 
 from app.core.config import settings
+
+if TYPE_CHECKING:
+    from app.weapons.base import WorldView
+    from .entities import Ball
+    from .projectiles import Projectile
 
 
 class PhysicsWorld:
@@ -11,7 +19,13 @@ class PhysicsWorld:
     def __init__(self) -> None:
         self.space = pymunk.Space()
         self.space.gravity = (0.0, 0.0)
+        self._projectiles: dict[pymunk.Shape, Projectile] = {}
+        self._balls: dict[pymunk.Shape, Ball] = {}
+        self._on_projectile_removed: Callable[[Projectile], None] | None = None
+        self._view: WorldView | None = None
+        self._timestamp: float = 0.0
         self._add_bounds()
+        self._register_handlers()
 
     def _add_bounds(self) -> None:
         thickness = float(settings.wall_thickness)
@@ -27,6 +41,49 @@ class PhysicsWorld:
             segment.elasticity = 1.0
             segment.friction = 0.0
         self.space.add(*segments)
+
+    def _register_handlers(self) -> None:
+        from .entities import BALL_COLLISION_TYPE
+        from .projectiles import PROJECTILE_COLLISION_TYPE
+
+        handler = self.space.add_collision_handler(
+            PROJECTILE_COLLISION_TYPE, BALL_COLLISION_TYPE
+        )
+        handler.begin = self._handle_projectile_hit
+
+    def register_ball(self, ball: Ball) -> None:
+        self._balls[ball.shape] = ball
+
+    def register_projectile(self, projectile: Projectile) -> None:
+        self._projectiles[projectile.shape] = projectile
+
+    def unregister_projectile(self, projectile: Projectile) -> None:
+        self._projectiles.pop(projectile.shape, None)
+
+    def set_projectile_removed_callback(
+        self, callback: Callable[[Projectile], None]
+    ) -> None:
+        self._on_projectile_removed = callback
+
+    def set_context(self, view: WorldView, timestamp: float) -> None:
+        """Provide view and current timestamp for collision callbacks."""
+        self._view = view
+        self._timestamp = timestamp
+
+    def _handle_projectile_hit(
+        self, arbiter: pymunk.Arbiter, _space: pymunk.Space, _data: Any
+    ) -> bool:
+        proj_shape, ball_shape = arbiter.shapes
+        projectile = self._projectiles.get(proj_shape)
+        ball = self._balls.get(ball_shape)
+        if projectile is None or ball is None or self._view is None:
+            return True
+        keep = projectile.on_hit(self._view, ball.eid, self._timestamp)
+        if not keep:
+            projectile.destroy()
+            if self._on_projectile_removed is not None:
+                self._on_projectile_removed(projectile)
+        return False
 
     def step(self, dt: float) -> None:
         self.space.step(dt)

--- a/app/world/projectiles.py
+++ b/app/world/projectiles.py
@@ -13,6 +13,9 @@ from app.render.renderer import Renderer
 from app.weapons.base import WeaponEffect, WorldView
 from app.world.physics import PhysicsWorld
 
+PROJECTILE_COLLISION_TYPE: int = 2
+"""Pymunk collision type value for projectile shapes."""
+
 
 @dataclass(slots=True)
 class Projectile(WeaponEffect):
@@ -61,8 +64,9 @@ class Projectile(WeaponEffect):
         shape = pymunk.Circle(body, radius)
         shape.elasticity = 1.0
         shape.friction = 0.0
+        shape.collision_type = PROJECTILE_COLLISION_TYPE
         world.space.add(body, shape)
-        return cls(
+        projectile = cls(
             world=world,
             owner=owner,
             body=body,
@@ -77,6 +81,8 @@ class Projectile(WeaponEffect):
             acceleration=acceleration,
             last_velocity=(float(velocity[0]), float(velocity[1])),
         )
+        world.register_projectile(projectile)
+        return projectile
 
     def step(self, dt: float) -> bool:
         """Advance state and return ``True`` while the projectile is alive."""
@@ -158,4 +164,5 @@ class Projectile(WeaponEffect):
             renderer.draw_projectile(pos, int(self.shape.radius), (255, 255, 0))
 
     def destroy(self) -> None:
+        self.world.unregister_projectile(self)
         self.world.space.remove(self.body, self.shape)

--- a/tests/unit/test_projectile_high_speed_collision.py
+++ b/tests/unit/test_projectile_high_speed_collision.py
@@ -1,0 +1,78 @@
+import pygame
+
+from app.core.types import Damage, EntityId, Vec2
+from app.world.entities import Ball
+from app.world.physics import PhysicsWorld
+from app.world.projectiles import Projectile
+from app.weapons.base import WorldView, WeaponEffect
+
+
+class _StubView(WorldView):
+    """Minimal view implementation used for collision tests."""
+
+    def __init__(self, ball: Ball) -> None:
+        self.ball = ball
+
+    def get_enemy(self, owner: EntityId) -> EntityId | None:  # pragma: no cover - unused
+        return None
+
+    def get_position(self, eid: EntityId) -> Vec2:
+        pos = self.ball.body.position
+        return (float(pos.x), float(pos.y))
+
+    def get_velocity(self, eid: EntityId) -> Vec2:  # pragma: no cover - unused
+        return (0.0, 0.0)
+
+    def get_health_ratio(self, eid: EntityId) -> float:  # pragma: no cover - unused
+        return 1.0
+
+    def deal_damage(self, eid: EntityId, damage: Damage, timestamp: float) -> None:
+        self.ball.take_damage(damage)
+
+    def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:  # pragma: no cover - unused
+        self.ball.body.apply_impulse_at_local_point((vx, vy))
+
+    def add_speed_bonus(self, eid: EntityId, bonus: float) -> None:  # pragma: no cover - unused
+        pass
+
+    def spawn_effect(self, effect: WeaponEffect) -> None:  # pragma: no cover - unused
+        pass
+
+    def spawn_projectile(
+        self,
+        owner: EntityId,
+        position: Vec2,
+        velocity: Vec2,
+        radius: float,
+        damage: Damage,
+        knockback: float,
+        ttl: float,
+        sprite: pygame.Surface | None = None,
+        spin: float = 0.0,
+        trail_color: tuple[int, int, int] | None = None,
+        acceleration: float = 0.0,
+    ) -> WeaponEffect:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    def iter_projectiles(self, excluding: EntityId | None = None):  # pragma: no cover - unused
+        return iter(())
+
+
+def test_high_speed_projectile_hits_ball() -> None:
+    pygame.init()
+    world = PhysicsWorld()
+    ball = Ball.spawn(world, position=(400.0, 300.0), radius=20.0)
+    view = _StubView(ball)
+    world.set_context(view, 0.0)
+    Projectile.spawn(
+        world,
+        owner=EntityId(99),
+        position=(100.0, 300.0),
+        velocity=(50000.0, 0.0),
+        radius=5.0,
+        damage=Damage(10.0),
+        knockback=0.0,
+        ttl=1.0,
+    )
+    world.step(1 / 60)
+    assert ball.health < ball.stats.max_health


### PR DESCRIPTION
## Summary
- assign distinct Pymunk collision types to balls and projectiles
- register projectile/ball collision handler that invokes on-hit logic
- rely on physics callbacks instead of manual collision checks
- add regression test for high-speed projectile impacts

## Testing
- `uv run ruff format .` *(fails: Failed to download `pydantic==2.11.7`)*
- `uv run ruff check .` *(fails: Failed to download `click==8.2.1`)*
- `uv run mypy .` *(fails: Failed to download `pycparser==2.22`)*
- `uv run pytest --cov=.` *(fails: Failed to download `pydantic-settings==2.10.1`)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a8bde6d8832a9ff517cac52eb7c5