### PR TITLE
feat: add parry mechanic

### DIFF
--- a/app/ai/policy.py
+++ b/app/ai/policy.py
@@ -121,8 +121,8 @@ class SimplePolicy:
 
     def decide(
         self, me: EntityId, view: WorldView, projectile_speed: float | None = None
-    ) -> tuple[Vec2, Vec2, bool]:
-        """Return acceleration, facing vector and fire decision.
+    ) -> tuple[Vec2, Vec2, bool, bool]:
+        """Return acceleration, facing vector, fire and parry decisions.
 
         The agent retreats when its health falls below ``15%``. If both
         combatants are in this critical state the retreat is cancelled and the
@@ -164,7 +164,7 @@ class SimplePolicy:
             norm = math.hypot(*offset_face) or 1.0
             face = (offset_face[0] / norm, offset_face[1] / norm)
 
-        return accel, face, fire
+        return accel, face, fire, False
 
     def _aggressive(
         self,

--- a/app/game/controller.py
+++ b/app/game/controller.py
@@ -271,7 +271,7 @@ class GameController:
         for p in self.players:
             if not p.alive:
                 continue
-            accel, face, fire = p.policy.decide(p.eid, self.view, p.weapon.speed)
+            accel, face, fire, parry = p.policy.decide(p.eid, self.view, p.weapon.speed)
             p.face = face
             p.ball.body.velocity = (
                 p.ball.body.velocity[0] + accel[0] * settings.dt,
@@ -279,7 +279,9 @@ class GameController:
             )
             p.weapon.step(settings.dt)
             p.weapon.update(p.eid, self.view, settings.dt)
-            if fire:
+            if parry:
+                p.weapon.parry(p.eid, self.view)
+            elif fire:
                 p.weapon.trigger(p.eid, self.view, face)
             p.ball.cap_speed()
 

--- a/app/weapons/base.py
+++ b/app/weapons/base.py
@@ -135,6 +135,25 @@ class Weapon:
         self._fire(owner, view, direction)
         self._timer = self.cooldown
 
+    def parry(self, owner: EntityId, view: WorldView) -> None:
+        """Attempt to block incoming attacks.
+
+        Parameters
+        ----------
+        owner:
+            Entity identifier owning the weapon.
+        view:
+            Read-only access to the game state.
+
+        Notes
+        -----
+        Subclasses may override to spawn defensive effects or modify state.
+        The default implementation performs no action, making the method
+        optional for offensive-only weapons.
+        """
+
+        return None
+
     def _fire(self, owner: EntityId, view: WorldView, direction: Vec2) -> None:
         """Execute the weapon's effect. Subclasses must override."""
         raise NotImplementedError

--- a/app/weapons/katana.py
+++ b/app/weapons/katana.py
@@ -10,6 +10,7 @@ from . import weapon_registry
 from .assets import load_weapon_sprite
 from .base import Weapon, WorldView
 from .effects import OrbitingSprite
+from .parry import ParryEffect
 
 
 class Katana(Weapon):
@@ -44,6 +45,10 @@ class Katana(Weapon):
             self.audio.start_idle()
             self._initialized = True
         super().update(owner, view, dt)
+
+    def parry(self, owner: EntityId, view: WorldView) -> None:  # noqa: D401
+        effect = ParryEffect(owner=owner, radius=80.0, duration=0.15)
+        view.spawn_effect(effect)
 
 
 weapon_registry.register("katana", Katana)

--- a/app/weapons/knife.py
+++ b/app/weapons/knife.py
@@ -10,6 +10,7 @@ from . import weapon_registry
 from .assets import load_weapon_sprite
 from .base import Weapon, WorldView
 from .effects import OrbitingSprite
+from .parry import ParryEffect
 
 
 class Knife(Weapon):
@@ -50,6 +51,10 @@ class Knife(Weapon):
             view.add_speed_bonus(owner, self.player_speed_bonus)
             self._boost_applied = True
         super().update(owner, view, dt)
+
+    def parry(self, owner: EntityId, view: WorldView) -> None:  # noqa: D401
+        effect = ParryEffect(owner=owner, radius=80.0, duration=0.15)
+        view.spawn_effect(effect)
 
 
 weapon_registry.register("knife", Knife)

--- a/app/weapons/parry.py
+++ b/app/weapons/parry.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.core.types import EntityId, Vec2
+from app.render.renderer import Renderer
+from app.world.projectiles import Projectile
+
+from .base import WeaponEffect, WorldView
+
+
+@dataclass(slots=True)
+class ParryEffect(WeaponEffect):
+    """Short-lived shield that deflects projectiles near its owner."""
+
+    owner: EntityId
+    radius: float
+    duration: float
+    _remaining: float = 0.0
+
+    def __post_init__(self) -> None:
+        self._remaining = self.duration
+
+    def step(self, dt: float) -> bool:
+        """Decrease remaining parry time and report activity."""
+        self._remaining -= dt
+        return self._remaining > 0.0
+
+    def collides(self, view: WorldView, position: Vec2, radius: float) -> bool:
+        cx, cy = view.get_position(self.owner)
+        dx = cx - position[0]
+        dy = cy - position[1]
+        return dx * dx + dy * dy <= (self.radius + radius) ** 2
+
+    def on_hit(self, view: WorldView, target: EntityId, timestamp: float) -> bool:  # noqa: D401
+        return True
+
+    def deflect_projectile(self, view: WorldView, projectile: Projectile, timestamp: float) -> None:
+        """Reflect ``projectile`` away from the owner."""
+        enemy = view.get_enemy(self.owner)
+        if enemy is not None:
+            target = view.get_position(enemy)
+            projectile.retarget(target, self.owner)
+        else:
+            vx, vy = projectile.body.velocity
+            projectile.body.velocity = (-vx, -vy)
+            projectile.owner = self.owner
+            projectile.ttl = projectile.max_ttl
+        if projectile.audio is not None:
+            projectile.audio.on_touch(timestamp)
+
+    def draw(self, renderer: Renderer, view: WorldView) -> None:  # noqa: D401
+        return None
+
+    def destroy(self) -> None:  # noqa: D401
+        return None

--- a/app/world/physics.py
+++ b/app/world/physics.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pymunk
 
@@ -9,6 +9,7 @@ from app.core.config import settings
 
 if TYPE_CHECKING:
     from app.weapons.base import WorldView
+
     from .entities import Ball
     from .projectiles import Projectile
 

--- a/tests/integration/test_intro_loop.py
+++ b/tests/integration/test_intro_loop.py
@@ -46,7 +46,11 @@ class StubIntroManager(IntroManager):
             self._skipped = True
 
     def draw(
-        self, surface: pygame.Surface, labels: tuple[str, str], hud: Hud
+        self,
+        surface: pygame.Surface,
+        labels: tuple[str, str],
+        hud: Hud | None = None,
+        ball_positions: tuple[tuple[float, float], tuple[float, float]] | None = None,
     ) -> None:  # pragma: no cover - simple counter
         self.draws += 1
 

--- a/tests/integration/test_parry_slows_match.py
+++ b/tests/integration/test_parry_slows_match.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from app.audio import reset_default_engine
+from app.core.config import settings
+from app.game.match import create_controller
+from app.render.renderer import Renderer
+
+
+class DummyRecorder:
+    """Recorder stub writing to a temporary path."""
+
+    def __init__(self, path: Path) -> None:
+        self.path: Path | None = path
+
+    def add_frame(self, _frame: object) -> None:  # pragma: no cover - stub
+        return None
+
+    def close(self, audio: object | None = None, rate: int = 48_000) -> None:  # pragma: no cover - stub
+        return None
+
+
+def _match_duration(tmp_path: Path, parry: bool) -> float:
+    reset_default_engine()
+    recorder = DummyRecorder(tmp_path / "out.mp4")
+    renderer = Renderer(settings.width, settings.height)
+    controller = create_controller("knife", "knife", recorder, renderer, max_seconds=20)
+    if not parry:
+        for p in controller.players:
+            p.policy.parry_window = 0.0
+    controller.run()
+    return controller.elapsed
+
+
+def test_parry_slows_match(tmp_path: Path) -> None:
+    os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+    duration_no_parry = _match_duration(tmp_path, parry=False)
+    duration_with_parry = _match_duration(tmp_path, parry=True)
+    assert duration_with_parry > duration_no_parry

--- a/tests/test_ball_death_sound.py
+++ b/tests/test_ball_death_sound.py
@@ -25,7 +25,7 @@ from app.world.entities import Ball  # noqa: E402
 from app.world.physics import PhysicsWorld  # noqa: E402
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
-    from app.ai.policy import SimplePolicy
+    from app.ai.stateful_policy import StatefulPolicy
     from app.audio import AudioEngine
     from app.render.renderer import Renderer
     from app.weapons.base import Weapon
@@ -65,7 +65,7 @@ def test_deal_damage_triggers_explosion_sound_on_death() -> None:
     world = PhysicsWorld()
     ball = Ball.spawn(world, (0.0, 0.0))
     weapon = cast("Weapon", object())
-    policy = cast("SimplePolicy", object())
+    policy = cast("StatefulPolicy", object())
     dummy_engine = DummyEngine()
     engine = cast("AudioEngine", dummy_engine)
     audio = BallAudio(engine=engine)

--- a/tests/test_ball_hit_sound.py
+++ b/tests/test_ball_hit_sound.py
@@ -25,7 +25,7 @@ from app.world.entities import Ball  # noqa: E402
 from app.world.physics import PhysicsWorld  # noqa: E402
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
-    from app.ai.policy import SimplePolicy
+    from app.ai.stateful_policy import StatefulPolicy
     from app.audio import AudioEngine
     from app.render.renderer import Renderer
     from app.weapons.base import Weapon
@@ -65,7 +65,7 @@ def test_deal_damage_triggers_hit_sound(monkeypatch: Any) -> None:
     world = PhysicsWorld()
     ball = Ball.spawn(world, (0.0, 0.0))
     weapon = cast("Weapon", object())
-    policy = cast("SimplePolicy", object())
+    policy = cast("StatefulPolicy", object())
     dummy_engine = DummyEngine()
     engine = cast("AudioEngine", dummy_engine)
     audio = BallAudio(engine=engine)

--- a/tests/test_stateful_policy.py
+++ b/tests/test_stateful_policy.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-
-from app.ai.stateful_policy import StatefulPolicy, State
+from app.ai.stateful_policy import State, StatefulPolicy
 from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
 from app.weapons.base import WeaponEffect, WorldView
 
@@ -74,7 +73,7 @@ def test_attack_then_dodge() -> None:
     projectile = ProjectileInfo(owner=enemy, position=(50.0, 0.0), velocity=(-80.0, 0.0))
     view.projectiles = [projectile]
     policy.decide(me, view, 600.0)
-    assert policy.state is State.DODGE
+    assert policy.state == State.DODGE  # type: ignore[comparison-overlap]
 
 
 def test_parry_reduces_damage() -> None:
@@ -94,6 +93,6 @@ def test_retreat_on_low_health() -> None:
     enemy = EntityId(2)
     view = DummyView(me, enemy, (0.0, 0.0), (100.0, 0.0), health_me=0.1)
     policy = StatefulPolicy("aggressive")
-    accel, _, _ = policy.decide(me, view, 600.0)
+    accel, _, _, _ = policy.decide(me, view, 600.0)
     assert policy.state is State.RETREAT
     assert accel[0] < 0

--- a/tests/unit/test_policy_angles.py
+++ b/tests/unit/test_policy_angles.py
@@ -87,9 +87,10 @@ def test_policy_angle_has_vertical_component() -> None:
     enemy = EntityId(2)
     view = DummyView(me, enemy, (0.0, 0.0), (50.0, 0.0))
     policy = SimplePolicy("aggressive")
-    accel, face, fire = policy.decide(me, view, 600.0)
+    accel, face, fire, parry = policy.decide(me, view, 600.0)
     assert fire is True
     assert face[1] != 0.0
+    assert parry is False
     weapon = Shuriken()
     weapon.trigger(me, view, face)
     assert view.last_velocity is not None

--- a/tests/unit/test_projectile_high_speed_collision.py
+++ b/tests/unit/test_projectile_high_speed_collision.py
@@ -1,10 +1,10 @@
 import pygame
 
-from app.core.types import Damage, EntityId, Vec2
+from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
+from app.weapons.base import WeaponEffect, WorldView
 from app.world.entities import Ball
 from app.world.physics import PhysicsWorld
 from app.world.projectiles import Projectile
-from app.weapons.base import WorldView, WeaponEffect
 
 
 class _StubView(WorldView):
@@ -54,8 +54,10 @@ class _StubView(WorldView):
     ) -> WeaponEffect:  # pragma: no cover - unused
         raise NotImplementedError
 
-    def iter_projectiles(self, excluding: EntityId | None = None):  # pragma: no cover - unused
-        return iter(())
+    def iter_projectiles(
+        self, excluding: EntityId | None = None
+    ) -> list[ProjectileInfo]:  # pragma: no cover - unused
+        return []
 
 
 def test_high_speed_projectile_hits_ball() -> None:


### PR DESCRIPTION
## Summary
- add optional parry hook to weapons and new ParryEffect for deflecting projectiles
- teach katana and knife to parry and update controller & AI to use it
- add integration test confirming parry lengthens matches

## Testing
- `ruff check . --fix`
- `mypy .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'imageio_ffmpeg', 'pygame', 'numpy')*
- `pip-audit` *(command not found and installation failed)*
- `bandit -r .` *(command not found and installation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5acb6e328832aa5c2d2597afe09dc