### PR TITLE
feat: support physics substeps

### DIFF
--- a/app/config.json
+++ b/app/config.json
@@ -14,5 +14,6 @@
         "post_s": 1.0,
         "slow_factor": 0.5
     },
-    "show_eyes": true
+    "show_eyes": true,
+    "physics_substeps": 4
 }

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from typing import cast
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.core.types import Color
 from app.render.theme import TeamColors, Theme
@@ -64,6 +64,7 @@ class Settings(BaseModel):  # type: ignore[misc]
     background_color: Color = (30, 30, 30)
     ball_color: Color = (220, 220, 220)
     show_eyes: bool = True  # Render eyes on balls when ``True``.
+    physics_substeps: int = Field(default=4, ge=1)  # Physics integration substeps
 
     @property
     def width(self) -> int:

--- a/app/game/controller.py
+++ b/app/game/controller.py
@@ -247,7 +247,7 @@ class GameController:
             self._update_players()
             self._update_effects(current_time)
             self.world.set_context(self.view, current_time)
-            self.world.step(settings.dt)
+            self.world.step(settings.dt, settings.physics_substeps)
             self._render_frame()
             self._capture_frame()
 

--- a/app/world/physics.py
+++ b/app/world/physics.py
@@ -86,5 +86,29 @@ class PhysicsWorld:
                 self._on_projectile_removed(projectile)
         return False
 
-    def step(self, dt: float) -> None:
-        self.space.step(dt)
+    def step(self, dt: float, substeps: int = 1) -> None:
+        """Advance the physics simulation.
+
+        Parameters
+        ----------
+        dt:
+            Total delta time for this update in seconds.
+        substeps:
+            Number of internal substeps used to integrate ``dt``. A value of
+            one performs a single step, while higher values subdivide ``dt`` to
+            reduce tunneling when entities move at high speed. Must be at least
+            one.
+
+        Raises
+        ------
+        ValueError
+            If ``substeps`` is less than one.
+        """
+
+        if substeps < 1:
+            msg = "substeps must be >= 1"
+            raise ValueError(msg)
+
+        sub_dt = dt / float(substeps)
+        for _ in range(substeps):
+            self.space.step(sub_dt)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,61 @@
+"""Utility classes and helpers for tests."""
+from __future__ import annotations
+
+import pygame
+
+from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
+from app.weapons.base import WeaponEffect, WorldView
+from app.world.entities import Ball
+
+
+class StubWorldView(WorldView):
+    """Minimal :class:`WorldView` implementation for physics tests."""
+
+    def __init__(self, ball: Ball) -> None:
+        self.ball = ball
+
+    def get_enemy(self, owner: EntityId) -> EntityId | None:  # pragma: no cover - unused
+        return None
+
+    def get_position(self, eid: EntityId) -> Vec2:
+        pos = self.ball.body.position
+        return (float(pos.x), float(pos.y))
+
+    def get_velocity(self, eid: EntityId) -> Vec2:  # pragma: no cover - unused
+        return (0.0, 0.0)
+
+    def get_health_ratio(self, eid: EntityId) -> float:  # pragma: no cover - unused
+        return 1.0
+
+    def deal_damage(self, eid: EntityId, damage: Damage, timestamp: float) -> None:
+        self.ball.take_damage(damage)
+
+    def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:  # pragma: no cover - unused
+        self.ball.body.apply_impulse_at_local_point((vx, vy))
+
+    def add_speed_bonus(self, eid: EntityId, bonus: float) -> None:  # pragma: no cover - unused
+        pass
+
+    def spawn_effect(self, effect: WeaponEffect) -> None:  # pragma: no cover - unused
+        pass
+
+    def spawn_projectile(
+        self,
+        owner: EntityId,
+        position: Vec2,
+        velocity: Vec2,
+        radius: float,
+        damage: Damage,
+        knockback: float,
+        ttl: float,
+        sprite: pygame.Surface | None = None,
+        spin: float = 0.0,
+        trail_color: tuple[int, int, int] | None = None,
+        acceleration: float = 0.0,
+    ) -> WeaponEffect:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    def iter_projectiles(
+        self, excluding: EntityId | None = None
+    ) -> list[ProjectileInfo]:  # pragma: no cover - unused
+        return []

--- a/tests/unit/test_physics_substeps.py
+++ b/tests/unit/test_physics_substeps.py
@@ -7,7 +7,8 @@ from app.world.projectiles import Projectile
 from tests.helpers import StubWorldView
 
 
-def test_high_speed_projectile_hits_ball() -> None:
+def test_substeps_high_speed_projectile_collision() -> None:
+    """High-speed projectiles still collide when using substeps."""
     pygame.init()
     world = PhysicsWorld()
     ball = Ball.spawn(world, position=(400.0, 300.0), radius=20.0)
@@ -15,13 +16,23 @@ def test_high_speed_projectile_hits_ball() -> None:
     world.set_context(view, 0.0)
     Projectile.spawn(
         world,
-        owner=EntityId(99),
+        owner=EntityId(1),
         position=(100.0, 300.0),
-        velocity=(50000.0, 0.0),
+        velocity=(200000.0, 0.0),
         radius=5.0,
         damage=Damage(10.0),
         knockback=0.0,
         ttl=1.0,
     )
-    world.step(1 / 60)
+    world.step(1 / 60, substeps=4)
     assert ball.health < ball.stats.max_health
+
+
+def test_substeps_high_speed_ball_wall_collision() -> None:
+    """Balls moving at high speed still bounce on walls with substeps."""
+    pygame.init()
+    world = PhysicsWorld()
+    ball = Ball.spawn(world, position=(50.0, 300.0), radius=20.0)
+    ball.body.velocity = (-200000.0, 0.0)
+    world.step(1 / 60, substeps=4)
+    assert ball.body.position.x >= ball.shape.radius


### PR DESCRIPTION
## Summary
- allow PhysicsWorld.step to subdivide dt
- run match loop with configurable physics substeps
- test high-speed collisions handled with substeps

## Testing
- `uv run ruff .` *(fails: Failed to download `imageio-ffmpeg==0.6.0`)*
- `uv run mypy .` *(fails: Failed to download `pymunk==7.1.0`)*
- `uv run pytest` *(fails: Failed to download `python-dotenv==1.1.1`)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ae744f20832ab52673de0c1d0917