### PR TITLE
fix: support Pymunk 7 collision handler API

### DIFF
--- a/app/world/physics.py
+++ b/app/world/physics.py
@@ -44,12 +44,17 @@ class PhysicsWorld:
         self.space.add(*segments)
 
     def _register_handlers(self) -> None:
+        """Register collision callbacks for projectiles hitting balls."""
+
         from .entities import BALL_COLLISION_TYPE
         from .projectiles import PROJECTILE_COLLISION_TYPE
 
-        handler = self.space.add_collision_handler(
-            PROJECTILE_COLLISION_TYPE, BALL_COLLISION_TYPE
-        )
+        if hasattr(self.space, "add_collision_handler"):
+            handler = self.space.add_collision_handler(
+                PROJECTILE_COLLISION_TYPE, BALL_COLLISION_TYPE
+            )
+        else:
+            handler = self.space.collision_handler(PROJECTILE_COLLISION_TYPE, BALL_COLLISION_TYPE)
         handler.begin = self._handle_projectile_hit
 
     def register_ball(self, ball: Ball) -> None:
@@ -61,9 +66,7 @@ class PhysicsWorld:
     def unregister_projectile(self, projectile: Projectile) -> None:
         self._projectiles.pop(projectile.shape, None)
 
-    def set_projectile_removed_callback(
-        self, callback: Callable[[Projectile], None]
-    ) -> None:
+    def set_projectile_removed_callback(self, callback: Callable[[Projectile], None]) -> None:
         self._on_projectile_removed = callback
 
     def set_context(self, view: WorldView, timestamp: float) -> None:

--- a/tests/unit/test_physics_collision_handler.py
+++ b/tests/unit/test_physics_collision_handler.py
@@ -1,0 +1,49 @@
+from typing import Any
+
+import pytest
+
+pymunk = pytest.importorskip("pymunk")
+pygame = pytest.importorskip("pygame")
+
+from app.core.types import Damage, EntityId  # noqa: E402
+from app.world.entities import Ball  # noqa: E402
+from app.world.physics import PhysicsWorld  # noqa: E402
+from app.world.projectiles import Projectile  # noqa: E402
+from tests.helpers import StubWorldView  # noqa: E402
+
+
+class _TrackingPhysicsWorld(PhysicsWorld):
+    """Physics world subclass tracking projectile hit callbacks."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.hit_called = False
+
+    def _handle_projectile_hit(
+        self, arbiter: object, space: object, data: Any
+    ) -> bool:
+        self.hit_called = True
+        return super()._handle_projectile_hit(arbiter, space, data)
+
+
+def test_projectile_collision_triggers_handler() -> None:
+    """Collisions invoke the projectile hit handler without errors."""
+    pygame.init()
+    world = _TrackingPhysicsWorld()
+    ball = Ball.spawn(world, position=(400.0, 300.0), radius=20.0)
+    view = StubWorldView(ball)
+    world.set_context(view, 0.0)
+
+    Projectile.spawn(
+        world,
+        owner=EntityId(1),
+        position=(400.0, 300.0),
+        velocity=(0.0, 0.0),
+        radius=5.0,
+        damage=Damage(1.0),
+        knockback=0.0,
+        ttl=1.0,
+    )
+
+    world.step(1 / 60)
+    assert world.hit_called


### PR DESCRIPTION
## Summary
- support `Space.collision_handler` when `Space.add_collision_handler` is absent (Pymunk ≥7)
- add regression test ensuring projectile-ball collisions trigger `_handle_projectile_hit`

## Testing
- `ruff check tests/unit/test_physics_collision_handler.py app/world/physics.py`
- `mypy app/world/physics.py tests/unit/test_physics_collision_handler.py`
- `pytest tests/unit/test_physics_collision_handler.py` *(skipped: missing pygame & pymunk)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b1495868832ab64db3d08a1feda9