### PR TITLE
build: constrain pymunk to <8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
   "pygame>=2.6.0",
-  "pymunk>=6.6.0",
+  "pymunk>=7,<8",
   "imageio>=2.36.0",
   "imageio-ffmpeg>=0.5.0",
   "typer>=0.12.0",

--- a/uv.lock
+++ b/uv.lock
@@ -66,7 +66,7 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.8.0" },
     { name = "pydantic-settings", specifier = ">=2.4.0" },
     { name = "pygame", specifier = ">=2.6.0" },
-    { name = "pymunk", specifier = ">=6.6.0" },
+    { name = "pymunk", specifier = ">=7,<8" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.8" },


### PR DESCRIPTION
## Summary
- limit pymunk to major version 7 to avoid future breaking changes

## Testing
- `ruff check .`
- `mypy .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'imageio_ffmpeg')*
- `uv lock` *(fails: Failed to fetch)*
- `uv run pre-commit run --files pyproject.toml uv.lock` *(fails: Failed to download `markdown-it-py==4.0.0`)*
- `uv run pip-audit` *(fails: Failed to download `rich==14.1.0`)*
- `uv run bandit -r app` *(fails: Failed to download `python-dotenv==1.1.1`)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b46acdf0832ab66b0969a39e33ba