### PR TITLE
fix: simplify collision handler registration

### DIFF
--- a/app/world/physics.py
+++ b/app/world/physics.py
@@ -49,12 +49,9 @@ class PhysicsWorld:
         from .entities import BALL_COLLISION_TYPE
         from .projectiles import PROJECTILE_COLLISION_TYPE
 
-        if hasattr(self.space, "add_collision_handler"):
-            handler = self.space.add_collision_handler(
-                PROJECTILE_COLLISION_TYPE, BALL_COLLISION_TYPE
-            )
-        else:
-            handler = self.space.collision_handler(PROJECTILE_COLLISION_TYPE, BALL_COLLISION_TYPE)
+        handler = self.space.add_collision_handler(
+            PROJECTILE_COLLISION_TYPE, BALL_COLLISION_TYPE
+        )
         handler.begin = self._handle_projectile_hit
 
     def register_ball(self, ball: Ball) -> None:


### PR DESCRIPTION
## Summary
- simplify projectile and ball collision handling by always using `add_collision_handler`

## Testing
- `ruff check app/world/physics.py tests/unit/test_physics_collision_handler.py`
- `mypy app/world/physics.py tests/unit/test_physics_collision_handler.py`
- `pytest tests/unit/test_physics_collision_handler.py` *(fails: 1 skipped: No module named 'pymunk')*

------
https://chatgpt.com/codex/tasks/task_e_68b5bd208f40832ab4ff310ca4781306