### PR TITLE
refactor: narrow projectile hit handler type

### DIFF
--- a/app/world/physics.py
+++ b/app/world/physics.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import pymunk
 
@@ -72,7 +72,7 @@ class PhysicsWorld:
         self._timestamp = timestamp
 
     def _handle_projectile_hit(
-        self, arbiter: pymunk.Arbiter, _space: pymunk.Space, _data: Any
+        self, arbiter: pymunk.Arbiter, _space: pymunk.Space, _data: object
     ) -> bool:
         proj_shape, ball_shape = arbiter.shapes
         projectile = self._projectiles.get(proj_shape)

--- a/tests/unit/test_physics_collision_handler.py
+++ b/tests/unit/test_physics_collision_handler.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import pytest
 
 pymunk = pytest.importorskip("pymunk")
@@ -20,7 +18,7 @@ class _TrackingPhysicsWorld(PhysicsWorld):
         self.hit_called = False
 
     def _handle_projectile_hit(
-        self, arbiter: object, space: object, data: Any
+        self, arbiter: object, space: object, data: object
     ) -> bool:
         self.hit_called = True
         return super()._handle_projectile_hit(arbiter, space, data)


### PR DESCRIPTION
## Summary
- narrow projectile collision handler `_data` parameter from `Any` to `object`
- align test collision handler override with stricter type

## Testing
- `ruff check --fix app/world/physics.py tests/unit/test_physics_collision_handler.py`
- `pytest -vv tests/unit/test_physics_collision_handler.py`
- `mypy app/world/physics.py tests/unit/test_physics_collision_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5bf6332c8832ab410bc5acca34cc4