### PR TITLE
fix: guard pymunk version and support legacy handler

### DIFF
--- a/tests/unit/test_physics_version.py
+++ b/tests/unit/test_physics_version.py
@@ -1,0 +1,53 @@
+import pytest
+
+pymunk = pytest.importorskip("pymunk")
+
+from app.world import physics  # noqa: E402
+
+
+def test_init_raises_runtime_error_for_old_pymunk(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PhysicsWorld refuses to run with unsupported pymunk versions."""
+    monkeypatch.setattr(physics, "PYMUNK_VERSION", (6, 0))
+    with pytest.raises(RuntimeError, match="pymunk >= 7.0"):
+        physics.PhysicsWorld()
+
+
+def test_register_handlers_falls_back_when_add_handler_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy collision_handler API is used when add_collision_handler is absent."""
+
+    class FakeHandler:
+        def __init__(self) -> None:
+            self.begin = None
+
+    class FakeSpace:
+        def __init__(self) -> None:
+            self.gravity = (0.0, 0.0)
+            self.handler_called = False
+            self.handler: FakeHandler | None = None
+
+        def collision_handler(self, a: int, b: int) -> FakeHandler:
+            self.handler_called = True
+            self.handler = FakeHandler()
+            return self.handler
+
+        def add(self, *args: object) -> None:  # pragma: no cover - not used in test
+            pass
+
+        def step(self, _dt: float) -> None:  # pragma: no cover - not used in test
+            pass
+
+    fake_space = FakeSpace()
+    monkeypatch.setattr(physics.pymunk, "Space", lambda: fake_space)  # type: ignore[attr-defined]
+    monkeypatch.setattr(physics, "PYMUNK_VERSION", (7, 0))
+
+    class NoBoundsWorld(physics.PhysicsWorld):
+        def _add_bounds(self) -> None:  # pragma: no cover - avoids pymunk deps
+            pass
+
+    world = NoBoundsWorld()
+
+    assert fake_space.handler_called
+    assert fake_space.handler is not None
+    assert fake_space.handler.begin is world._handle_projectile_hit


### PR DESCRIPTION
## Summary
- ensure pymunk version >= 7.0 before registering handlers
- fall back to `collision_handler` when `add_collision_handler` is absent
- test version guard and legacy handler fallback

## Testing
- `ruff check app/world/physics.py tests/unit/test_physics_version.py`
- `mypy app/world/physics.py tests/unit/test_physics_version.py`
- `pytest tests/unit/test_physics_version.py` *(fails: module 'pymunk' not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68b5c1a1a748832a92cc1d4c123a1475