### PR TITLE
fix: handle missing pymunk version_info

### DIFF
--- a/app/world/physics.py
+++ b/app/world/physics.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -7,10 +8,25 @@ import pymunk
 
 from app.core.config import settings
 
-# ``pymunk.version_info`` already exposes numeric components. Using it avoids
-# string parsing and ensures version comparisons operate on integers.
-PYMUNK_VERSION = tuple(pymunk.version_info[:2])
-PYMUNK_VERSION_STR = ".".join(map(str, pymunk.version_info))
+
+def _get_pymunk_version() -> tuple[tuple[int, ...], str]:
+    """Return the pymunk version as numeric tuple and original string.
+
+    ``pymunk`` exposes ``version_info`` in newer releases, which already
+    contains numeric components. Some older distributions only provide the
+    ``__version__`` string, so this helper parses it into integers when
+    ``version_info`` is absent.
+    """
+
+    if hasattr(pymunk, "version_info"):
+        info = tuple(int(part) for part in pymunk.version_info)
+        return info, ".".join(str(x) for x in info)
+    version_str = getattr(pymunk, "__version__", "")
+    numbers = tuple(int(part) for part in re.findall(r"\d+", version_str))
+    return numbers, version_str
+
+
+PYMUNK_VERSION, PYMUNK_VERSION_STR = _get_pymunk_version()
 
 if TYPE_CHECKING:
     from app.weapons.base import WorldView

--- a/tests/unit/test_physics_version.py
+++ b/tests/unit/test_physics_version.py
@@ -5,6 +5,19 @@ pymunk = pytest.importorskip("pymunk")
 from app.world import physics  # noqa: E402
 
 
+def test_version_helper_parses_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fallback parsing uses ``__version__`` when ``version_info`` is absent."""
+
+    class FakePymunk:
+        __version__ = "6.1"
+
+    monkeypatch.setattr(physics, "pymunk", FakePymunk, raising=False)
+    version, version_str = physics._get_pymunk_version()
+
+    assert version == (6, 1)
+    assert version_str == "6.1"
+
+
 def test_init_raises_runtime_error_for_old_pymunk(monkeypatch: pytest.MonkeyPatch) -> None:
     """PhysicsWorld refuses to run with unsupported pymunk versions."""
     monkeypatch.setattr(physics, "PYMUNK_VERSION", (6, 0))


### PR DESCRIPTION
## Summary
- handle missing `pymunk.version_info` by parsing `__version__`
- ensure physics version guard uses helper and add fallback test

## Testing
- `uv run ruff check .` *(fails: Failed to download urllib3==2.5.0)*
- `uv run ruff format .` *(fails: Failed to download pymunk==7.1.0)*
- `uv run mypy .` *(fails: Failed to download typer==0.17.3)*
- `uv run pytest --cov=.` *(fails: Failed to download imageio-ffmpeg==0.6.0)*
- `ruff check app/world/physics.py tests/unit/test_physics_version.py`
- `ruff format app/world/physics.py tests/unit/test_physics_version.py`
- `mypy app/world/physics.py tests/unit/test_physics_version.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5c7e52aac832abc78b0e160bd2f0d