### PR TITLE
fix: randomize facing offset in stateful policy

### DIFF
--- a/app/ai/stateful_policy.py
+++ b/app/ai/stateful_policy.py
@@ -44,7 +44,11 @@ class StatefulPolicy(SimplePolicy):
     def decide(
         self, me: EntityId, view: WorldView, projectile_speed: float | None = None
     ) -> tuple[Vec2, Vec2, bool, bool]:
-        """Return acceleration, facing vector, fire and parry decisions."""
+        """Return acceleration, facing vector, fire and parry decisions.
+
+        The facing orientation includes a small randomised vertical offset,
+        making the result dependent on the policy's pseudo-random generator.
+        """
 
         enemy = view.get_enemy(me)
         assert enemy is not None
@@ -96,7 +100,8 @@ class StatefulPolicy(SimplePolicy):
             parry = False
 
         if abs(dy) <= 1e-6:
-            offset_face = (direction[0], self.vertical_offset)
+            offset = self.vertical_offset + self.rng.uniform(-0.05, 0.05)
+            offset_face = (direction[0], offset)
             norm = math.hypot(*offset_face) or 1.0
             face = (offset_face[0] / norm, offset_face[1] / norm)
 

--- a/tests/test_stateful_policy_rng.py
+++ b/tests/test_stateful_policy_rng.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+
+from app.ai.stateful_policy import StatefulPolicy
+from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
+from app.weapons.base import WeaponEffect, WorldView
+
+
+@dataclass
+class DummyView(WorldView):
+    me: EntityId
+    enemy: EntityId
+    pos_me: Vec2
+    pos_enemy: Vec2
+    vel_enemy: Vec2 = (0.0, 0.0)
+    projectiles: list[ProjectileInfo] = field(default_factory=list)
+
+    def get_enemy(self, owner: EntityId) -> EntityId | None:  # noqa: D401
+        return self.enemy
+
+    def get_position(self, eid: EntityId) -> Vec2:  # noqa: D401
+        return self.pos_me if eid == self.me else self.pos_enemy
+
+    def get_velocity(self, eid: EntityId) -> Vec2:  # noqa: D401
+        return (0.0, 0.0) if eid == self.me else self.vel_enemy
+
+    def get_health_ratio(self, eid: EntityId) -> float:  # noqa: D401
+        return 1.0
+
+    def deal_damage(self, eid: EntityId, damage: Damage, timestamp: float) -> None:  # noqa: D401
+        return None
+
+    def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:  # noqa: D401
+        return None
+
+    def spawn_effect(self, effect: WeaponEffect) -> None:  # noqa: D401
+        return None
+
+    def add_speed_bonus(self, eid: EntityId, bonus: float) -> None:  # noqa: D401
+        return None
+
+    def spawn_projectile(
+        self,
+        owner: EntityId,
+        position: Vec2,
+        velocity: Vec2,
+        radius: float,
+        damage: Damage,
+        knockback: float,
+        ttl: float,
+        sprite: object | None = None,
+        spin: float = 0.0,
+        trail_color: tuple[int, int, int] | None = None,
+        acceleration: float = 0.0,
+    ) -> WeaponEffect:  # noqa: D401
+        raise NotImplementedError
+
+    def iter_projectiles(self, excluding: EntityId | None = None) -> list[ProjectileInfo]:  # noqa: D401
+        return self.projectiles
+
+
+def _collect_faces(seed: int) -> list[Vec2]:
+    rng = random.Random(seed)
+    policy = StatefulPolicy("aggressive", rng=rng)
+    view = DummyView(EntityId(1), EntityId(2), (0.0, 0.0), (50.0, 0.0))
+    faces: list[Vec2] = []
+    for _ in range(3):
+        _, face, _, _ = policy.decide(EntityId(1), view, 600.0)
+        faces.append(face)
+    return faces
+
+
+def test_sequences_differ_with_seed() -> None:
+    assert _collect_faces(1) != _collect_faces(2)


### PR DESCRIPTION
## Summary
- randomize vertical facing offset in `StatefulPolicy.decide`
- document RNG influence on decision output
- add test ensuring different seeds yield different orientations

## Testing
- `uv run ruff check app/ai/stateful_policy.py tests/test_stateful_policy_rng.py`
- `uv run mypy app/ai/stateful_policy.py tests/test_stateful_policy_rng.py`
- `uv run pytest tests/test_stateful_policy.py tests/test_stateful_policy_rng.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5f83f25d0832a85b3f9fc8c6d17e0