### PR TITLE
feat: randomize dodge behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Image de prévisualisation à venir.
 - 🎨 **Rendu vertical 1080×1920** optimisé pour TikTok.
 - 🎥 **Export vidéo automatique** en `.mp4` via [imageio-ffmpeg](https://imageio.readthedocs.io/).
 - 🖥️ **Mode affichage** sans enregistrement grâce à l'option `--display`.
-- 🔄 **Reproductibilité totale** grâce aux seeds (mêmes combats → mêmes résultats).
+ - 🔄 **Reproductibilité totale** grâce aux seeds (mêmes combats → mêmes résultats).
+ - 🛡️ **Esquives dépendantes de la seed** : chaque seed produit un biais d'évitement unique mais reproductible.
 - 🧩 **Architecture plug-in** : ajout d'armes, IA ou effets visuels sans toucher au moteur.
 - 🔊 **Effets sonores** intégrés dans la piste audio.
 - 📦 **Batch mode** : génération de **N vidéos** en une seule commande.

--- a/tests/test_stateful_policy_rng.py
+++ b/tests/test_stateful_policy_rng.py
@@ -74,3 +74,22 @@ def _collect_faces(seed: int) -> list[Vec2]:
 
 def test_sequences_differ_with_seed() -> None:
     assert _collect_faces(1) != _collect_faces(2)
+
+
+def _collect_dodges(seed: int) -> list[Vec2]:
+    rng = random.Random(seed)
+    policy = StatefulPolicy("aggressive", rng=rng)
+    me = EntityId(1)
+    enemy = EntityId(2)
+    projectile = ProjectileInfo(owner=enemy, position=(50.0, 0.0), velocity=(-80.0, 0.0))
+    view = DummyView(me, enemy, (0.0, 0.0), (100.0, 0.0), projectiles=[projectile])
+    accels: list[Vec2] = []
+    for _ in range(3):
+        accel, _, _, _ = policy.decide(me, view, 600.0)
+        accels.append(accel)
+    return accels
+
+
+def test_dodge_sequence_depends_on_seed() -> None:
+    assert _collect_dodges(1) != _collect_dodges(2)
+    assert _collect_dodges(3) == _collect_dodges(3)


### PR DESCRIPTION
## Summary
- bias dodging with smoothed projectile avoidance and RNG-dependent bias
- document seed impact on dodge behavior
- verify dodge variability and determinism with seed-based tests

## Testing
- `uv run ruff check app/ai/stateful_policy.py tests/test_stateful_policy_rng.py`
- `uv run mypy app/ai/stateful_policy.py tests/test_stateful_policy_rng.py`
- `uv run pytest tests/test_stateful_policy_rng.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5f8f473f4832aa41bf2a818bbcce6