### PR TITLE
feat: add image sanitizer

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -11,6 +11,7 @@ import typer
 from app.audio import reset_default_engine
 from app.audio.env import temporary_sdl_audio_driver
 from app.core.config import settings
+from app.core.images import sanitize_images as sanitize_directory_images
 from app.game.controller import MatchTimeout
 from app.game.match import create_controller
 from app.intro.config import IntroConfig, set_intro_weapons
@@ -158,6 +159,23 @@ def batch(
                 typer.echo(f"Saved video to {final_path}")
             finally:
                 reset_default_engine()
+
+
+@app.command("sanitize-images")  # type: ignore[misc]
+def sanitize_images_command(
+    directory: Annotated[
+        Path,
+        typer.Argument(
+            file_okay=False,
+            dir_okay=True,
+            exists=True,
+            help="Directory containing image assets",
+        ),
+    ] = Path("assets"),
+) -> None:
+    """Validate and repair image files in ``directory``."""
+    sanitized = sanitize_directory_images(directory)
+    typer.echo(f"Sanitized {len(sanitized)} image(s) in {directory}")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/app/core/images.py
+++ b/app/core/images.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from PIL import Image, ImageOps, UnidentifiedImageError
+
+SUPPORTED_IMAGE_SUFFIXES: tuple[str, ...] = (".png", ".jpg", ".jpeg")
+
+
+def sanitize_image(path: Path) -> None:
+    """Validate and repair an image file in-place.
+
+    The function ensures that the image at ``path`` can be loaded. If the
+    image contains orientation metadata, it is normalized using
+    :func:`ImageOps.exif_transpose`. The result is converted to ``RGBA`` and
+    written back to ``path``.
+
+    Parameters
+    ----------
+    path:
+        Path to the image file to sanitize.
+
+    Raises
+    ------
+    ValueError
+        If the file cannot be opened as an image.
+    """
+
+    try:
+        with Image.open(path) as img:
+            ImageOps.exif_transpose(img).convert("RGBA").save(path)
+    except (UnidentifiedImageError, OSError) as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Invalid image file: {path}") from exc
+
+
+def sanitize_images(directory: Path) -> list[Path]:
+    """Sanitize all image files in ``directory`` recursively.
+
+    Parameters
+    ----------
+    directory:
+        Root directory to scan for images. Only files with extensions defined
+        in :data:`SUPPORTED_IMAGE_SUFFIXES` are processed.
+
+    Returns
+    -------
+    list[pathlib.Path]
+        Paths of the images that were successfully sanitized.
+    """
+
+    sanitized: list[Path] = []
+    for path in directory.rglob("*"):
+        if path.suffix.lower() not in SUPPORTED_IMAGE_SUFFIXES:
+            continue
+        try:
+            sanitize_image(path)
+        except ValueError:
+            continue
+        sanitized.append(path)
+    return sanitized

--- a/tests/test_image_sanitizer.py
+++ b/tests/test_image_sanitizer.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from app.core.images import sanitize_image, sanitize_images
+
+
+def _create_image(path: Path, *, orientation: int | None = None) -> None:
+    image = Image.new("RGB", (2, 1), color=(255, 0, 0))
+    if orientation is not None:
+        exif = image.getexif()
+        exif[274] = orientation  # Orientation tag
+        image.save(path, exif=exif)
+    else:
+        image.save(path)
+
+
+def test_sanitize_image_transposes_and_converts(tmp_path: Path) -> None:
+    img_path = tmp_path / "test.png"
+    _create_image(img_path, orientation=3)
+
+    sanitize_image(img_path)
+
+    with Image.open(img_path) as img:
+        assert img.mode == "RGBA"
+        assert 274 not in img.getexif()
+
+
+def test_sanitize_image_raises_on_invalid_file(tmp_path: Path) -> None:
+    bad_path = tmp_path / "bad.png"
+    bad_path.write_text("not an image")
+
+    with pytest.raises(ValueError):
+        sanitize_image(bad_path)
+
+
+def test_sanitize_images_scans_directory(tmp_path: Path) -> None:
+    img1 = tmp_path / "a.png"
+    img2 = tmp_path / "b.jpg"
+    _create_image(img1)
+    _create_image(img2)
+
+    sanitized = sanitize_images(tmp_path)
+
+    assert set(sanitized) == {img1, img2}
+    for path in sanitized:
+        with Image.open(path) as img:
+            assert img.mode == "RGBA"


### PR DESCRIPTION
## Summary
- add utilities to validate and repair image files
- expose CLI command `sanitize-images`
- cover sanitization behaviour with tests

## Testing
- `make lint` *(fails: pymunk import sorting issues)*
- `uv run mypy app/core/images.py app/cli.py tests/test_image_sanitizer.py` *(fails: Body has no attribute apply_impulse_at_local_point)*
- `uv run pytest -q` *(fails: 37 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f9708b1c832aa873b370721158c5