### PR TITLE
feat: support Vec2 indexing

### DIFF
--- a/pymunk/__init__.py
+++ b/pymunk/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Minimal stub of the :mod:`pymunk` API used in tests.
 
 This stub provides lightweight implementations of the classes required by
@@ -8,10 +6,12 @@ features exercised by the repository's tests.  The real Pymunk package
 should be used for any production code.
 """
 
-# mypy: ignore-errors
+from __future__ import annotations
 
+from collections.abc import Iterable, Iterator, Sequence
+
+# mypy: ignore-errors
 from dataclasses import dataclass
-from typing import Iterable, Iterator, Sequence
 
 
 @dataclass(slots=True)
@@ -50,6 +50,25 @@ class Vec2:
     def __iter__(self) -> Iterator[float]:
         yield self.x
         yield self.y
+
+    def __getitem__(self, index: int) -> float:
+        """Return a coordinate by ``index``.
+
+        Parameters
+        ----------
+        index:
+            ``0`` for ``x`` and ``1`` for ``y``.
+
+        Raises
+        ------
+        IndexError
+            If ``index`` is not ``0`` or ``1``.
+        """
+        if index == 0:
+            return self.x
+        if index == 1:
+            return self.y
+        raise IndexError("Vec2 index out of range")
 
     def normalized(self) -> Vec2:
         norm = (self.x * self.x + self.y * self.y) ** 0.5 or 1.0

--- a/tests/test_vec2.py
+++ b/tests/test_vec2.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pytest
+
+from pymunk import Vec2
+
+
+def test_vec2_index_access() -> None:
+    vec = Vec2(1.5, -2.0)
+    assert vec[0] == 1.5
+    assert vec[1] == -2.0
+
+
+@pytest.mark.parametrize("index", [-1, 2])
+def test_vec2_index_error(index: int) -> None:
+    vec = Vec2(0.0, 0.0)
+    with pytest.raises(IndexError):
+        _ = vec[index]


### PR DESCRIPTION
## Summary
- allow Vec2 to be indexed like a sequence
- add tests validating Vec2 index access and error handling

## Testing
- `uv run ruff check pymunk/__init__.py tests/test_vec2.py`
- `uv run mypy pymunk/__init__.py tests/test_vec2.py`
- `uv run pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `uv run pytest tests/test_vec2.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5fa673490832a82554a0ded8b05db