### PR TITLE
refactor: use attribute access for velocity

### DIFF
--- a/app/weapons/bazooka.py
+++ b/app/weapons/bazooka.py
@@ -8,6 +8,7 @@ from app.core.types import Damage, EntityId, Vec2
 from app.render.sprites import load_sprite
 from app.world.entities import DEFAULT_BALL_RADIUS
 from app.world.projectiles import Projectile
+from pymunk import Vec2 as Vec2d
 
 from . import weapon_registry
 from .assets import load_weapon_sprite
@@ -70,7 +71,7 @@ class Bazooka(Weapon):
         enemy = view.get_enemy(owner)
         if enemy is not None:
             target = view.get_position(enemy)
-            enemy_velocity = view.get_velocity(enemy)
+            enemy_velocity = Vec2d(*view.get_velocity(enemy))
             origin = view.get_position(owner)
 
             dx, dy = target[0] - origin[0], target[1] - origin[1]
@@ -78,8 +79,8 @@ class Bazooka(Weapon):
 
             time_to_target = distance / self.speed if self.speed > 0 else 0.0
             predicted = (
-                target[0] + enemy_velocity[0] * time_to_target,
-                target[1] + enemy_velocity[1] * time_to_target,
+                target[0] + enemy_velocity.x * time_to_target,
+                target[1] + enemy_velocity.y * time_to_target,
             )
 
             dx, dy = predicted[0] - origin[0], predicted[1] - origin[1]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,4 +1,5 @@
 """Utility classes and helpers for tests."""
+
 from __future__ import annotations
 
 import pygame
@@ -30,8 +31,10 @@ class StubWorldView(WorldView):
     def deal_damage(self, eid: EntityId, damage: Damage, timestamp: float) -> None:
         self.ball.take_damage(damage)
 
-    def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:  # pragma: no cover - unused
-        self.ball.body.apply_impulse_at_local_point((vx, vy))
+    def apply_impulse(
+        self, eid: EntityId, vx: float, vy: float
+    ) -> None:  # pragma: no cover - unused
+        self.ball.body.apply_impulse_at_local_point((vx, vy))  # type: ignore[attr-defined]
 
     def add_speed_bonus(self, eid: EntityId, bonus: float) -> None:  # pragma: no cover - unused
         pass

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -9,6 +9,7 @@ from app.ai.policy import SimplePolicy, policy_for_weapon
 from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
 from app.weapons.base import WeaponEffect, WorldView
 from app.weapons.shuriken import Shuriken
+from pymunk import Vec2 as Vec2d
 
 
 @dataclass
@@ -21,7 +22,7 @@ class DummyView(WorldView):
     vel_enemy: Vec2 = (0.0, 0.0)
     health_me: float = 1.0
     health_enemy: float = 1.0
-    last_velocity: Vec2 | None = field(default=None, init=False)
+    last_velocity: Vec2d | None = field(default=None, init=False)
 
     def get_enemy(self, owner: EntityId) -> EntityId | None:  # noqa: D401
         return self.enemy
@@ -61,7 +62,7 @@ class DummyView(WorldView):
         trail_color: tuple[int, int, int] | None = None,
         acceleration: float = 0.0,
     ) -> WeaponEffect:  # noqa: D401
-        self.last_velocity = velocity
+        self.last_velocity = Vec2d(*velocity)
 
         class _Dummy(WeaponEffect):
             owner: EntityId = owner
@@ -186,7 +187,7 @@ def test_horizontal_alignment_has_vertical_component() -> None:
     assert parry is False
     weapon.trigger(me, view, face)
     assert view.last_velocity is not None
-    assert view.last_velocity[1] != 0.0
+    assert view.last_velocity.y != 0.0
 
 
 def test_aggressive_dodges_projectiles() -> None:

--- a/tests/unit/test_policy_angles.py
+++ b/tests/unit/test_policy_angles.py
@@ -6,6 +6,7 @@ from app.ai.policy import SimplePolicy
 from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
 from app.weapons.base import WeaponEffect, WorldView
 from app.weapons.shuriken import Shuriken
+from pymunk import Vec2 as Vec2d
 
 
 @dataclass
@@ -16,7 +17,7 @@ class DummyView(WorldView):
     pos_enemy: Vec2
     vel_me: Vec2 = (0.0, 0.0)
     vel_enemy: Vec2 = (0.0, 0.0)
-    last_velocity: Vec2 | None = field(default=None, init=False)
+    last_velocity: Vec2d | None = field(default=None, init=False)
 
     def get_enemy(self, owner: EntityId) -> EntityId | None:  # noqa: D401
         return self.enemy
@@ -56,7 +57,7 @@ class DummyView(WorldView):
         trail_color: tuple[int, int, int] | None = None,
         acceleration: float = 0.0,
     ) -> WeaponEffect:  # noqa: D401
-        self.last_velocity = velocity
+        self.last_velocity = Vec2d(*velocity)
 
         class _Dummy(WeaponEffect):
             owner: EntityId = owner
@@ -94,4 +95,4 @@ def test_policy_angle_has_vertical_component() -> None:
     weapon = Shuriken()
     weapon.trigger(me, view, face)
     assert view.last_velocity is not None
-    assert view.last_velocity[1] != 0.0
+    assert view.last_velocity.y != 0.0


### PR DESCRIPTION
## Summary
- refactor projectile and bazooka velocity handling to use x/y attributes
- adapt policy tests for attribute-style vectors

## Testing
- `uv run ruff check app/weapons/bazooka.py app/world/projectiles.py tests/test_policy.py tests/unit/test_policy_angles.py tests/helpers.py`
- `uv run mypy .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'imageio_ffmpeg')*
- `uv run pytest tests/test_policy.py tests/unit/test_policy_angles.py` *(fails: AttributeError: 'object' object has no attribute 'trigger')*


------
https://chatgpt.com/codex/tasks/task_e_68b5ffbb1b70832aa702a19b3e29e71f