### PR TITLE
refactor: use attribute access for velocities

### DIFF
--- a/app/game/controller.py
+++ b/app/game/controller.py
@@ -291,11 +291,10 @@ class GameController:
             if dash_dir is not None:
                 p.dash.start(dash_dir, now)
             p.dash.update(now)
-            vx = float(p.ball.body.velocity.x)
-            vy = float(p.ball.body.velocity.y)
+            velocity = p.ball.body.velocity
             p.ball.body.velocity = (
-                vx + accel[0] * settings.dt,
-                vy + accel[1] * settings.dt,
+                float(velocity.x) + accel[0] * settings.dt,
+                float(velocity.y) + accel[1] * settings.dt,
             )
             if p.dash.is_dashing:
                 p.ball.body.velocity = (
@@ -358,9 +357,9 @@ class GameController:
             )
             radius = int(p.ball.shape.radius)
             self.renderer.draw_ball(pos, radius, settings.ball_color, p.color)
-            vx, vy = p.ball.body.velocity
-            speed = sqrt(vx * vx + vy * vy)
-            gaze = (vx / speed, vy / speed) if speed else p.face
+            velocity = p.ball.body.velocity
+            speed = sqrt(velocity.x * velocity.x + velocity.y * velocity.y)
+            gaze = (velocity.x / speed, velocity.y / speed) if speed else p.face
             if settings.show_eyes:
                 self.renderer.draw_eyes(pos, gaze, radius, p.color)
         self.renderer.draw_impacts()

--- a/app/weapons/bazooka.py
+++ b/app/weapons/bazooka.py
@@ -38,8 +38,9 @@ class Bazooka(Weapon):
     def _fire(self, owner: EntityId, view: WorldView, direction: Vec2) -> None:  # noqa: D401
         self.audio.on_throw()
 
-        angle = math.atan2(direction[1], direction[0]) + math.pi / 2
-        velocity = (direction[0] * self.speed, direction[1] * self.speed)
+        dir_vec = Vec2d(*direction)
+        angle = math.atan2(dir_vec.y, dir_vec.x) + math.pi / 2
+        velocity = Vec2d(dir_vec.x * self.speed, dir_vec.y * self.speed)
         position = view.get_position(owner)
 
         proj = cast(
@@ -47,7 +48,7 @@ class Bazooka(Weapon):
             view.spawn_projectile(
                 owner,
                 position,
-                velocity,
+                (velocity.x, velocity.y),
                 radius=self.missile_radius,
                 damage=self.damage,
                 knockback=200.0,

--- a/app/world/projectiles.py
+++ b/app/world/projectiles.py
@@ -91,25 +91,23 @@ class Projectile(WeaponEffect):
     def step(self, dt: float) -> bool:
         """Advance state and return ``True`` while the projectile is alive."""
         self.ttl -= dt
-        vx = float(self.body.velocity.x)
-        vy = float(self.body.velocity.y)
-        if vx * self.last_velocity.x < 0 or vy * self.last_velocity.y < 0:
+        velocity = self.body.velocity
+        if velocity.x * self.last_velocity.x < 0 or velocity.y * self.last_velocity.y < 0:
             self.bounces += 1
-        self.last_velocity = Vec2d(vx, vy)
+        self.last_velocity = Vec2d(velocity.x, velocity.y)
         if self.acceleration != 0.0:
-            speed = sqrt(vx * vx + vy * vy)
+            speed = sqrt(velocity.x * velocity.x + velocity.y * velocity.y)
             if speed > 0.0:
                 new_speed = speed + self.acceleration * dt
                 scale = new_speed / speed
-                self.body.velocity = (vx * scale, vy * scale)
+                self.body.velocity = (velocity.x * scale, velocity.y * scale)
         if self.sprite is not None:
             if self.spin != 0.0:
                 self.angle = (self.angle + self.spin * dt) % (2 * pi)
             else:
-                vx = float(self.body.velocity.x)
-                vy = float(self.body.velocity.y)
-                if vx != 0.0 or vy != 0.0:
-                    self.angle = atan2(vy, vx) + pi / 2
+                velocity = self.body.velocity
+                if velocity.x != 0.0 or velocity.y != 0.0:
+                    self.angle = atan2(velocity.y, velocity.x) + pi / 2
         if self.trail_color is not None:
             pos = (float(self.body.position.x), float(self.body.position.y))
             self.trail.append(pos)

--- a/tests/test_dash.py
+++ b/tests/test_dash.py
@@ -30,9 +30,9 @@ def test_dash_velocity_and_invulnerability() -> None:
             dash.direction[0] * dash.speed,
             dash.direction[1] * dash.speed,
         )
-    vx, vy = ball.body.velocity
-    assert vx == pytest.approx(500.0)
-    assert vy == pytest.approx(0.0)
+    velocity = ball.body.velocity
+    assert velocity.x == pytest.approx(500.0)
+    assert velocity.y == pytest.approx(0.0)
     assert dash.invulnerable_until > 0.0
 
 


### PR DESCRIPTION
## Summary
- replace manual velocity component indexing with `x`/`y` attribute access
- adapt Bazooka and Projectile logic to use vector attributes
- update dash test to reference velocity attributes

## Testing
- `uv run ruff check app/game/controller.py app/weapons/bazooka.py app/world/projectiles.py tests/test_dash.py`
- `uv run mypy .`
- `uv run pytest` *(fails: No module named 'pydantic')*
- `uv sync --all-extras --dev` *(fails: Failed to download toml==0.10.2)*

------
https://chatgpt.com/codex/tasks/task_e_68b60207ab40832aa9f2459059196d21