### PR TITLE
refactor: use deque for projectile trail

### DIFF
--- a/app/world/projectiles.py
+++ b/app/world/projectiles.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from collections import deque
 from dataclasses import dataclass, field
+from itertools import pairwise
 from math import atan2, pi, sqrt
 from typing import TYPE_CHECKING, cast
 
@@ -37,7 +39,7 @@ class Projectile(WeaponEffect):
     spin: float = 0.0
     audio: WeaponAudio | None = None
     trail_color: Color | None = None
-    trail: list[Vec2] = field(default_factory=list)
+    trail: deque[Vec2] = field(default_factory=lambda: deque(maxlen=8))
     trail_width: int = 2
     acceleration: float = 0.0
     bounces: int = 0
@@ -111,8 +113,6 @@ class Projectile(WeaponEffect):
         if self.trail_color is not None:
             pos = (float(self.body.position.x), float(self.body.position.y))
             self.trail.append(pos)
-            if len(self.trail) > 8:
-                self.trail.pop(0)
         return self.ttl > 0 or self.bounces < 2
 
     def collides(self, view: WorldView, position: Vec2, radius: float) -> bool:
@@ -158,7 +158,7 @@ class Projectile(WeaponEffect):
         pos = (float(self.body.position.x), float(self.body.position.y))
         if self.trail_color is not None and len(self.trail) > 1:
             denom = len(self.trail) - 1
-            for i, (a, b) in enumerate(zip(self.trail, self.trail[1:], strict=False)):
+            for i, (a, b) in enumerate(pairwise(self.trail)):
                 t = (i + 1) / denom
                 color = cast(Color, tuple(int(c * t) for c in self.trail_color))
                 renderer.draw_line(a, b, color, self.trail_width)

--- a/tests/world/test_projectile_trail.py
+++ b/tests/world/test_projectile_trail.py
@@ -1,0 +1,51 @@
+from collections import deque
+
+import pygame
+
+from app.core.types import Damage, EntityId, Vec2
+from app.world.physics import PhysicsWorld
+from app.world.projectiles import Projectile
+
+
+class RecordingDeque(deque[Vec2]):
+    """Deque that records ``pop`` and ``popleft`` calls."""
+
+    def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - simple init
+        super().__init__(*args, **kwargs)
+        self.pop_calls = 0
+        self.popleft_calls = 0
+
+    def pop(self) -> Vec2:  # type: ignore[override]
+        self.pop_calls += 1
+        return super().pop()
+
+    def popleft(self) -> Vec2:  # type: ignore[override]
+        self.popleft_calls += 1
+        return super().popleft()
+
+
+def test_trail_is_bounded_without_manual_shifting() -> None:
+    pygame.init()
+    world = PhysicsWorld()
+    projectile = Projectile.spawn(
+        world,
+        owner=EntityId(1),
+        position=(0.0, 0.0),
+        velocity=(0.0, 0.0),
+        radius=1.0,
+        damage=Damage(1),
+        knockback=0.0,
+        ttl=1.0,
+        trail_color=(255, 255, 255),
+    )
+    recording_trail: RecordingDeque = RecordingDeque(maxlen=8)
+    projectile.trail = recording_trail
+    for i in range(10):
+        projectile.body.position = (float(i), 0.0)
+        projectile.step(0.0)
+    assert len(projectile.trail) == 8
+    assert list(projectile.trail)[0] == (2.0, 0.0)
+    assert list(projectile.trail)[-1] == (9.0, 0.0)
+    assert recording_trail.pop_calls == 0
+    assert recording_trail.popleft_calls == 0
+


### PR DESCRIPTION
## Summary
- replace projectile trail list with bounded deque
- draw trail using deque pairwise iteration
- test trail bounding and absence of manual shifting

## Testing
- `uv run --extra dev pre-commit run --files app/world/projectiles.py tests/world/test_projectile_trail.py` *(fails: Failed to download `pip-api==0.0.34`)*
- `uv run --extra dev ruff app/world/projectiles.py tests/world/test_projectile_trail.py` *(fails: Failed to download `pip-requirements-parser==32.0.1`)*
- `uv run --extra dev mypy app/world/projectiles.py tests/world/test_projectile_trail.py` *(fails: Failed to download `pyparsing==3.2.3`)*
- `uv run --extra dev pytest tests/world/test_projectile_trail.py` *(fails: Failed to download `mypy==1.17.1`)*

------
https://chatgpt.com/codex/tasks/task_e_68b607237878832a80e0040396399eb8