### PR TITLE
test: verify ball reflection on arena walls

### DIFF
--- a/tests/unit/test_physics_substeps.py
+++ b/tests/unit/test_physics_substeps.py
@@ -1,5 +1,7 @@
 import pygame
+import pytest
 
+from app.core.config import settings
 from app.core.types import Damage, EntityId
 from app.world.entities import Ball
 from app.world.physics import PhysicsWorld
@@ -28,11 +30,46 @@ def test_substeps_high_speed_projectile_collision() -> None:
     assert ball.health < ball.stats.max_health
 
 
-def test_substeps_high_speed_ball_wall_collision() -> None:
-    """Balls moving at high speed still bounce on walls with substeps."""
+@pytest.mark.parametrize(
+    ("position", "velocity", "axis", "limit", "sign"),
+    [
+        ((50.0, settings.height * 0.5), (-200000.0, 0.0), "x", 20.0, 1),
+        (
+            (settings.width - 50.0, settings.height * 0.5),
+            (200000.0, 0.0),
+            "x",
+            settings.width - 20.0,
+            -1,
+        ),
+        ((settings.width * 0.5, 50.0), (0.0, -200000.0), "y", 20.0, 1),
+        (
+            (settings.width * 0.5, settings.height - 50.0),
+            (0.0, 200000.0),
+            "y",
+            settings.height - 20.0,
+            -1,
+        ),
+    ],
+)
+def test_substeps_high_speed_ball_wall_collision_all_sides(
+    position: tuple[float, float],
+    velocity: tuple[float, float],
+    axis: str,
+    limit: float,
+    sign: int,
+) -> None:
+    """Balls moving at high speed bounce off every wall with substeps."""
     pygame.init()
     world = PhysicsWorld()
-    ball = Ball.spawn(world, position=(50.0, 300.0), radius=20.0)
-    ball.body.velocity = (-200000.0, 0.0)
+    ball = Ball.spawn(world, position=position, radius=20.0)
+    ball.body.velocity = velocity
     world.step(1 / 60, substeps=4)
-    assert ball.body.position.x >= ball.shape.radius
+
+    pos_val = getattr(ball.body.position, axis)
+    vel_val = getattr(ball.body.velocity, axis)
+    if sign > 0:
+        assert pos_val >= limit
+        assert vel_val > 0
+    else:
+        assert pos_val <= limit
+        assert vel_val < 0


### PR DESCRIPTION
## Summary
- parametrize wall collision test to cover all four arena sides
- ensure velocity reverses and position remains inside after high-speed impact

## Testing
- `ruff check tests/unit/test_physics_substeps.py`
- `mypy tests/unit/test_physics_substeps.py`
- `pytest tests/unit/test_physics_substeps.py -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68b60d5a6a64832a879dd768ac8d701e