### PR TITLE
feat: add local impulse application

### DIFF
--- a/pymunk/__init__.py
+++ b/pymunk/__init__.py
@@ -106,6 +106,22 @@ class Body:
         x, y = value
         self._velocity = Vec2(float(x), float(y))
 
+    def apply_impulse_at_local_point(self, impulse: Iterable[float]) -> None:
+        """Add an instantaneous velocity change in local coordinates.
+
+        Parameters
+        ----------
+        impulse:
+            Two-component impulse vector. The stub treats this vector as a
+            direct change in velocity and ignores mass or rotational effects,
+            mirroring :meth:`pymunk.Body.apply_impulse_at_local_point`.
+        """
+        vx, vy = impulse
+        self._velocity = Vec2(
+            self._velocity.x + float(vx),
+            self._velocity.y + float(vy),
+        )
+
 
 class Shape:
     """Base collision shape."""

--- a/tests/unit/test_pymunk_apply_impulse.py
+++ b/tests/unit/test_pymunk_apply_impulse.py
@@ -1,0 +1,9 @@
+import pymunk
+
+
+def test_apply_impulse_at_local_point_updates_velocity() -> None:
+    body = pymunk.Body(1.0, 1.0)
+    body.velocity = (1.0, 2.0)
+    body.apply_impulse_at_local_point((3.0, -4.0))
+    assert body.velocity.x == 4.0
+    assert body.velocity.y == -2.0


### PR DESCRIPTION
## Summary
- implement `Body.apply_impulse_at_local_point` in pymunk stub
- test that local impulses adjust body velocity

## Testing
- `uv run ruff check pymunk/__init__.py tests/unit/test_pymunk_apply_impulse.py`
- `uv run mypy pymunk/__init__.py tests/unit/test_pymunk_apply_impulse.py`
- `uv run pytest` *(fails: 42 errors during collection)*
- `uv run pytest tests/unit/test_pymunk_apply_impulse.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6103370e4832aa86b2a8e9cbb2443