### PR TITLE
Raise KeyError for missing impulse target

### DIFF
--- a/app/game/controller.py
+++ b/app/game/controller.py
@@ -110,10 +110,25 @@ class _MatchView(WorldView):
                 return
 
     def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:
+        """Apply a physics impulse to ``eid``'s body.
+
+        Parameters
+        ----------
+        eid:
+            Identifier of the target entity.
+        vx, vy:
+            Components of the impulse vector.
+
+        Raises
+        ------
+        KeyError
+            If no player with ``eid`` exists.
+        """
         for p in self.players:
             if p.eid == eid:
-                p.ball.body.apply_impulse_at_local_point((vx, vy))  # type: ignore[attr-defined]
+                p.ball.body.apply_impulse_at_local_point((vx, vy))
                 return
+        raise KeyError(eid)
 
     def add_speed_bonus(self, eid: EntityId, bonus: float) -> None:
         for p in self.players:

--- a/app/weapons/base.py
+++ b/app/weapons/base.py
@@ -31,7 +31,13 @@ class WorldView(Protocol):
         """Apply ``damage`` to ``eid`` at the given ``timestamp``."""
 
     def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:
-        """Apply an impulse to the entity's body."""
+        """Apply an impulse to the entity's body.
+
+        Raises
+        ------
+        KeyError
+            If ``eid`` does not reference a known entity.
+        """
 
     def add_speed_bonus(self, eid: EntityId, bonus: float) -> None:
         """Increase ``eid``'s maximum speed by ``bonus`` units."""

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -34,7 +34,7 @@ class StubWorldView(WorldView):
     def apply_impulse(
         self, eid: EntityId, vx: float, vy: float
     ) -> None:  # pragma: no cover - unused
-        self.ball.body.apply_impulse_at_local_point((vx, vy))  # type: ignore[attr-defined]
+        self.ball.body.apply_impulse_at_local_point((vx, vy))
 
     def add_speed_bonus(self, eid: EntityId, bonus: float) -> None:  # pragma: no cover - unused
         pass

--- a/tests/test_match_apply_impulse.py
+++ b/tests/test_match_apply_impulse.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from app.core.types import EntityId
+from app.game.match import Player, _MatchView
+from app.world.entities import Ball
+from app.world.physics import PhysicsWorld
+
+
+def test_apply_impulse_raises_for_unknown_entity() -> None:
+    world = PhysicsWorld()
+    ball = Ball.spawn(world, (0.0, 0.0))
+    player = Player(
+        eid=ball.eid,
+        ball=ball,
+        weapon=cast(Any, object()),
+        policy=cast(Any, object()),
+        face=(1.0, 0.0),
+        color=(255, 255, 255),
+        audio=cast(Any, object()),
+    )
+    view = _MatchView([player], [], world, cast(Any, object()), cast(Any, object()))
+
+    with pytest.raises(KeyError):
+        view.apply_impulse(EntityId(ball.eid.value + 1), 1.0, 0.0)


### PR DESCRIPTION
## Summary
- raise `KeyError` when applying an impulse to an unknown entity
- document new error behavior in `WorldView.apply_impulse`
- add unit test covering missing entity scenario

## Testing
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68b611587488832aab598878ef9dc666