### PR TITLE
feat: add default simulation config

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,4 @@
+weapon_a: katana
+weapon_b: shuriken
+max_simulation_seconds: 120
+seed: 6666

--- a/tests/test_simulation_config.py
+++ b/tests/test_simulation_config.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _parse_simple_yaml(path: Path) -> dict[str, str]:
+    """Return key-value pairs from a simple YAML file."""
+    data: dict[str, str] = {}
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, value = line.split(":", 1)
+        data[key.strip()] = value.strip()
+    return data
+
+
+def test_simulation_config_defaults() -> None:
+    config = _parse_simple_yaml(Path("config.yml"))
+    assert config["weapon_a"] == "katana"
+    assert config["weapon_b"] == "shuriken"
+    assert int(config["seed"]) == 6666
+    assert int(config["max_simulation_seconds"]) == 120


### PR DESCRIPTION
## Summary
- add `config.yml` with default weapons, seed, and simulation duration
- test configuration defaults with simple YAML parser

## Testing
- `uv run pre-commit run --files config.yml tests/test_simulation_config.py` *(fails: pre-commit not installed)*
- `make lint`
- `uv run ruff check tests/test_simulation_config.py`
- `uv run mypy tests/test_simulation_config.py`
- `make test` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68b692735c74832a84d2455173ee5950