### PR TITLE
fix: handle high-speed ball collisions

### DIFF
--- a/tests/unit/test_ball_high_speed_collision.py
+++ b/tests/unit/test_ball_high_speed_collision.py
@@ -1,0 +1,17 @@
+import pygame
+
+from app.world.entities import Ball
+from app.world.physics import PhysicsWorld
+
+
+def test_high_speed_balls_collide() -> None:
+    pygame.init()
+    world = PhysicsWorld()
+    left = Ball.spawn(world, position=(100.0, 300.0), radius=20.0)
+    right = Ball.spawn(world, position=(700.0, 300.0), radius=20.0)
+    left.body.velocity = (200000.0, 0.0)
+    right.body.velocity = (-200000.0, 0.0)
+    world.step(1 / 60)
+    assert left.body.position.x < right.body.position.x
+    assert left.body.velocity.x < 0
+    assert right.body.velocity.x > 0

--- a/tests/unit/test_parry_owner.py
+++ b/tests/unit/test_parry_owner.py
@@ -90,6 +90,7 @@ def test_deflected_projectile_cannot_hit_new_owner() -> None:
 
     projectile.body.position = owner_ball.body.position
 
-    world._process_collisions()
+    world._index.rebuild()
+    world._process_projectile_collisions()
 
     assert view.damage == {}

--- a/tests/world/test_spatial_index.py
+++ b/tests/world/test_spatial_index.py
@@ -51,7 +51,8 @@ def _build_world(count: int) -> PhysicsWorld:
 
 def _run_once(world: PhysicsWorld) -> float:
     start = perf_counter()
-    world._process_collisions()  # noqa: SLF001 - internal benchmark
+    world._index.rebuild()  # noqa: SLF001 - internal benchmark
+    world._process_projectile_collisions()  # noqa: SLF001 - internal benchmark
     return perf_counter() - start
 
 


### PR DESCRIPTION
## Summary
- resolve ball-on-ball overlaps to prevent tunneling
- add regression test for fast moving balls
- update internal collision helpers for new API

## Testing
- `uv run ruff check app/world/physics.py tests/unit/test_parry_owner.py tests/world/test_spatial_index.py tests/unit/test_ball_high_speed_collision.py`
- `uv run mypy app/world/physics.py tests/unit/test_parry_owner.py tests/world/test_spatial_index.py tests/unit/test_ball_high_speed_collision.py`
- `uv run pytest` *(fails: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b695961eac832a8c42a7f40cbf4fa2