### PR TITLE
feat: enhance dash trail rendering

### DIFF
--- a/app/game/controller.py
+++ b/app/game/controller.py
@@ -27,6 +27,8 @@ from pymunk import Vec2 as Vec2d
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
+
+
 @dataclass(slots=True)
 class Player:
     eid: EntityId
@@ -371,7 +373,7 @@ class GameController:
                 float(p.ball.body.position.y),
             )
             radius = int(p.ball.shape.radius)
-            self.renderer.draw_ball(pos, radius, settings.ball_color, p.color)
+            self.renderer.draw_ball(pos, radius, settings.ball_color, p.color, p.dash.is_dashing)
             velocity = p.ball.body.velocity
             speed = sqrt(velocity.x * velocity.x + velocity.y * velocity.y)
             gaze = (velocity.x / speed, velocity.y / speed) if speed else p.face

--- a/app/render/renderer.py
+++ b/app/render/renderer.py
@@ -94,9 +94,7 @@ class Renderer:
             ).convert_alpha(),
         }
         self._scaled_ball_sprites: dict[tuple[Color, int], pygame.Surface] = {}
-        self._rotation_cache: dict[
-            tuple[pygame.Surface, int], pygame.Surface
-        ] = {}
+        self._rotation_cache: dict[tuple[pygame.Surface, int], pygame.Surface] = {}
 
     def clear(self) -> None:
         """Clear frame, update impacts and draw arena background."""
@@ -211,13 +209,41 @@ class Renderer:
         """
         self._hp_display = [hp_a, hp_b]
 
-    def draw_ball(self, pos: Vec2, radius: int, color: Color, team_color: Color) -> None:
+    def draw_ball(
+        self,
+        pos: Vec2,
+        radius: int,
+        color: Color,
+        team_color: Color,
+        is_dashing: bool = False,
+    ) -> None:
+        """Draw the ball and update its trail.
+
+        Parameters
+        ----------
+        pos:
+            Ball position in world coordinates.
+        radius:
+            Ball radius in pixels.
+        color:
+            Fill color of the ball body.
+        team_color:
+            Outline color identifying the team.
+        is_dashing:
+            Whether the owning player is currently dashing. When ``True`` the
+            trail effect is amplified by adding extra points.
+        """
         state = self._get_state(team_color)
         if state.prev_pos is not None:
             vx = pos[0] - state.prev_pos[0]
             vy = pos[1] - state.prev_pos[1]
             speed = (vx * vx + vy * vy) ** 0.5
-            state.trail.append((pos, min(255.0, speed * 10.0)))
+            alpha = min(255.0, speed * 10.0)
+            state.trail.append((pos, alpha))
+            if is_dashing:
+                # Add extra trail points to emphasize dash movement.
+                for _ in range(2):
+                    state.trail.append((pos, alpha))
         state.prev_pos = pos
         self._draw_trail(state, team_color, radius)
         sprite = self._ball_sprites.get(team_color)

--- a/tests/test_dash.py
+++ b/tests/test_dash.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import pytest
 
+from app.core.config import settings
 from app.core.types import Damage
 from app.game.dash import Dash
+from app.render.renderer import Renderer
 from app.world.entities import Ball
 from app.world.physics import PhysicsWorld
 
@@ -52,3 +54,22 @@ def test_dash_invulnerability_expires() -> None:
     if not (dash.is_dashing or later < dash.invulnerable_until):
         ball.take_damage(damage)
     assert ball.health == ball.stats.max_health - damage.amount
+
+
+def test_dash_trail_amplified() -> None:
+    renderer = Renderer(display=False)
+    team_color = settings.theme.team_a.primary
+    pos_a = (0.0, 0.0)
+    pos_b = (10.0, 0.0)
+    radius = 5
+
+    renderer.draw_ball(pos_a, radius, settings.ball_color, team_color)
+    renderer.draw_ball(pos_b, radius, settings.ball_color, team_color)
+    normal_len = len(renderer._get_state(team_color).trail)
+
+    renderer_dash = Renderer(display=False)
+    renderer_dash.draw_ball(pos_a, radius, settings.ball_color, team_color)
+    renderer_dash.draw_ball(pos_b, radius, settings.ball_color, team_color, is_dashing=True)
+    dash_len = len(renderer_dash._get_state(team_color).trail)
+
+    assert dash_len > normal_len


### PR DESCRIPTION
## Summary
- add `is_dashing` flag to `draw_ball` and boost trail when active
- propagate dash state in controller rendering loop
- test dash trail amplification

## Testing
- `uv run ruff check app/render/renderer.py app/game/controller.py tests/test_dash.py`
- `uv run mypy app/render/renderer.py app/game/controller.py tests/test_dash.py`
- `uv run pytest tests/test_dash.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `uv sync --all-extras --dev` *(fails: Failed to download `toml==0.10.2`)*

------
https://chatgpt.com/codex/tasks/task_e_68b696487610832a819bfaf3b5872f89