### PR TITLE
feat: add configurable AI transition delay

### DIFF
--- a/app/game/controller.py
+++ b/app/game/controller.py
@@ -205,7 +205,35 @@ class GameController:
         *,
         max_seconds: int = 120,
         display: bool = False,
+        ai_transition_seconds: int = 20,
     ) -> None:
+        """Initialise the controller.
+
+        Parameters
+        ----------
+        weapon_a, weapon_b:
+            Names of the weapons used by the two players.
+        players:
+            Active players taking part in the match.
+        world:
+            Physics world where the simulation occurs.
+        renderer:
+            Renderer used to draw frames.
+        hud:
+            Heads-up display renderer.
+        engine:
+            Audio engine responsible for playing sounds.
+        recorder:
+            Recorder receiving rendered frames.
+        intro_manager:
+            Manager for the intro sequence shown before the match.
+        max_seconds:
+            Maximum match duration.
+        display:
+            When ``True`` render to the screen instead of recording.
+        ai_transition_seconds:
+            Delay before switching to advanced AI behaviour.
+        """
         self.weapon_a = weapon_a
         self.weapon_b = weapon_b
         self.players = players
@@ -217,6 +245,7 @@ class GameController:
         self.intro_manager = intro_manager
         self.max_seconds = max_seconds
         self.display = display
+        self.ai_transition_seconds = ai_transition_seconds
 
         self.effects: list[WeaponEffect] = []
         self.view = _MatchView(players, self.effects, world, renderer, engine)

--- a/app/game/match.py
+++ b/app/game/match.py
@@ -37,11 +37,33 @@ def create_controller(
     renderer: Renderer | None = None,
     *,
     max_seconds: int = 120,
+    ai_transition_seconds: int = 20,
     display: bool = False,
     intro_config: IntroConfig | None = None,
     rng: random.Random | None = None,
 ) -> GameController:
-    """Construct a :class:`GameController` with default components."""
+    """Construct a :class:`GameController` with default components.
+
+    Parameters
+    ----------
+    weapon_a, weapon_b:
+        Names of the weapons used by the two players.
+    recorder:
+        Recorder responsible for writing frames to disk.
+    renderer:
+        Optional renderer. When ``None`` a new instance is created.
+    max_seconds:
+        Maximum duration of the match before raising :class:`MatchTimeout`.
+    ai_transition_seconds:
+        Delay before the AI switches to its advanced behaviour.
+    display:
+        Whether to render to the screen instead of recording frames.
+    intro_config:
+        Intro sequence configuration. Defaults to :class:`IntroConfig()`.
+    rng:
+        Random number generator controlling AI behaviour. When ``None``, a new
+        instance derived from a random seed is used.
+    """
     engine = get_default_engine()
     world = PhysicsWorld()
     renderer = renderer or Renderer(settings.width, settings.height, display=display)
@@ -91,6 +113,7 @@ def create_controller(
         recorder,
         intro,
         max_seconds=max_seconds,
+        ai_transition_seconds=ai_transition_seconds,
         display=display,
     )
 

--- a/config.yml
+++ b/config.yml
@@ -2,3 +2,4 @@ weapon_a: knife
 weapon_b: shuriken
 max_simulation_seconds: 120
 seed: 6666
+ai_transition_seconds: 20


### PR DESCRIPTION
## Summary
- add `ai_transition_seconds` default to config
- allow CLI `run` command to load and override AI transition delay
- propagate AI transition delay through match creation and controller

## Testing
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `uv sync --all-extras --dev` *(fails: Failed to download `sortedcontainers==2.4.0` due to network error)*

------
https://chatgpt.com/codex/tasks/task_e_68b69cdcce8c832a9099a573a099ecc4