### PR TITLE
test: verify ai transition timing and weapon ranges

### DIFF
--- a/app/ai/policy.py
+++ b/app/ai/policy.py
@@ -333,7 +333,9 @@ def policy_for_weapon(
     enemy_range: RangeType = range_type_for(enemy_weapon_name)
 
     if my_range == "distant":
-        style = "evader" if enemy_range == "contact" else "kiter"
+        style: Literal["evader", "kiter"] = (
+            "evader" if enemy_range == "contact" else "kiter"
+        )
         fire_factor = 0.0 if style == "evader" else float("inf")
         return SimplePolicy(style, fire_range_factor=fire_factor, rng=rng)
 

--- a/app/ai/stateful_policy.py
+++ b/app/ai/stateful_policy.py
@@ -246,7 +246,9 @@ def policy_for_weapon(
     enemy_range: RangeType = range_type_for(enemy_weapon_name)
 
     if my_range == "distant":
-        style = "evader" if enemy_range == "contact" else "kiter"
+        style: Literal["evader", "kiter"] = (
+            "evader" if enemy_range == "contact" else "kiter"
+        )
         fire_factor = 0.0 if style == "evader" else float("inf")
         return StatefulPolicy(
             style,

--- a/app/weapons/utils.py
+++ b/app/weapons/utils.py
@@ -21,6 +21,6 @@ def range_type_for(name: str) -> RangeType:
     """
 
     factory = weapon_registry.factory(name)
-    range_type: RangeType = getattr(factory, "range_type", "contact")  # type: ignore[assignment]
+    range_type: RangeType = getattr(factory, "range_type", "contact")
     return range_type
 


### PR DESCRIPTION
## Summary
- ensure CLI forwards `ai_transition_seconds` and defaults when omitted
- cover stateful policy mode switch via `transition_time`
- check `policy_for_weapon` style for contact/distant combinations
- tighten literal typing for policy factories

## Testing
- `uv run ruff check app/weapons/utils.py app/ai/policy.py app/ai/stateful_policy.py tests/test_cli_config_yaml.py tests/test_stateful_policy.py`
- `uv run mypy tests/test_cli_config_yaml.py tests/test_stateful_policy.py`
- `uv run pytest tests/test_cli_config_yaml.py tests/test_stateful_policy.py -q` *(fails: No module named 'typer')*


------
https://chatgpt.com/codex/tasks/task_e_68b6aca0e354832aad6abb2d2dd03eef