### PR TITLE
feat: differentiate offensive and defensive dashes

### DIFF
--- a/app/ai/policy.py
+++ b/app/ai/policy.py
@@ -88,7 +88,7 @@ def _projectile_dodge(me: EntityId, view: WorldView, position: Vec2, direction: 
             continue
         cx = rx + vx * t
         cy = ry + vy * t
-        if cx * cx + cy * cy > 200.0 ** 2:
+        if cx * cx + cy * cy > 200.0**2:
             continue
         dist = math.hypot(cx, cy)
         if dist <= 1e-6:
@@ -119,6 +119,7 @@ class SimplePolicy:
     """Very small deterministic combat policy."""
 
     style: Literal["aggressive", "kiter", "evader"]
+    range_type: RangeType = "contact"
     vertical_offset: float = 0.1
     dodge_bias: float = 0.5
     dodge_smoothing: float = 0.5
@@ -207,7 +208,7 @@ class SimplePolicy:
                 continue
             hit_x = rx + vx * t
             hit_y = ry + vy * t
-            if hit_x * hit_x + hit_y * hit_y > 200.0 ** 2:
+            if hit_x * hit_x + hit_y * hit_y > 200.0**2:
                 continue
             return _projectile_dodge(me, view, position, (1.0, 0.0))
         return None
@@ -233,7 +234,10 @@ class SimplePolicy:
         )
         norm = math.hypot(*combined) or 1.0
         accel = (combined[0] / norm * 400.0, combined[1] / norm * 400.0)
-        fire = dist <= self.fire_range and direction[0] * face[0] + direction[1] * face[1] >= cos_thresh
+        fire = (
+            dist <= self.fire_range
+            and direction[0] * face[0] + direction[1] * face[1] >= cos_thresh
+        )
         return accel, fire
 
     def _evader(
@@ -333,10 +337,13 @@ def policy_for_weapon(
     enemy_range: RangeType = range_type_for(enemy_weapon_name)
 
     if my_range == "distant":
-        style: Literal["evader", "kiter"] = (
-            "evader" if enemy_range == "contact" else "kiter"
-        )
+        style: Literal["evader", "kiter"] = "evader" if enemy_range == "contact" else "kiter"
         fire_factor = 0.0 if style == "evader" else float("inf")
-        return SimplePolicy(style, fire_range_factor=fire_factor, rng=rng)
+        return SimplePolicy(
+            style,
+            range_type=my_range,
+            fire_range_factor=fire_factor,
+            rng=rng,
+        )
 
-    return SimplePolicy("aggressive", rng=rng)
+    return SimplePolicy("aggressive", range_type=my_range, rng=rng)

--- a/app/game/controller.py
+++ b/app/game/controller.py
@@ -360,6 +360,30 @@ class GameController:
             elif fire:
                 p.weapon.trigger(p.eid, self.view, face)
             p.ball.cap_speed()
+            self._resolve_dash_collision(p, now)
+
+    def _resolve_dash_collision(self, p: Player, now: float) -> None:
+        """Resolve dash impacts between ``p`` and opponents."""
+        if not p.dash.is_dashing or p.dash.has_hit:
+            return
+        pa = p.ball.body.position
+        for other in self.players:
+            if other.eid == p.eid or not other.alive:
+                continue
+            pb = other.ball.body.position
+            radii = float(p.ball.shape.radius + other.ball.shape.radius)
+            dx = pb.x - pa.x
+            dy = pb.y - pa.y
+            if dx * dx + dy * dy > radii * radii:
+                continue
+            self.view.apply_impulse(
+                other.eid,
+                p.dash.direction[0] * p.dash.knockback,
+                p.dash.direction[1] * p.dash.knockback,
+            )
+            self.view.deal_damage(other.eid, p.dash.damage, now)
+            p.dash.has_hit = True
+            return
 
     def _update_effects(self, current_time: float) -> None:
         """Advance active effects and resolve collisions."""

--- a/app/game/dash.py
+++ b/app/game/dash.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 
-from app.core.types import Vec2
+from app.core.types import Damage, Vec2
 
 INVULNERABILITY_BUFFER = 1.0 / 60.0
 """Extra time in seconds after dash end before collisions resume."""
@@ -19,6 +19,9 @@ class Dash:
     is_dashing: bool = False
     cooldown_end: float = 0.0
     invulnerable_until: float = 0.0
+    damage: Damage = Damage(5.0)
+    knockback: float = 400.0
+    has_hit: bool = False
     _direction: Vec2 = (0.0, 0.0)
     _dash_end: float = 0.0
 
@@ -38,6 +41,7 @@ class Dash:
         self._dash_end = now + self.duration
         self.cooldown_end = now + self.cooldown
         self.invulnerable_until = self._dash_end + INVULNERABILITY_BUFFER
+        self.has_hit = False
 
     def update(self, now: float) -> None:
         """Advance the dash state based on ``now``."""

--- a/tests/test_dash_collision.py
+++ b/tests/test_dash_collision.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+from app.ai.stateful_policy import StatefulPolicy
+from app.audio import BallAudio
+from app.core.types import Damage, EntityId
+from app.game.controller import GameController, Player
+from app.weapons.base import Weapon
+from app.world.entities import Ball
+from pymunk import Body
+
+
+class DummyWorld:
+    def set_projectile_removed_callback(self, _cb: Any) -> None:
+        return
+
+    def set_context(self, _view: object, _timestamp: float) -> None:  # pragma: no cover - stub
+        return
+
+    def step(self, _dt: float, _substeps: int) -> None:  # pragma: no cover - stub
+        return
+
+
+class DummyWeapon:
+    speed: float = 0.0
+
+    def step(self, _dt: float) -> None:  # pragma: no cover - stub
+        return
+
+    def update(
+        self, _owner: EntityId, _view: object, _dt: float
+    ) -> None:  # pragma: no cover - stub
+        return
+
+    def parry(self, _owner: EntityId, _view: object) -> None:  # pragma: no cover - stub
+        return
+
+    def trigger(
+        self, _owner: EntityId, _view: object, _direction: tuple[float, float]
+    ) -> None:  # pragma: no cover - stub
+        return
+
+
+class DummyPolicy:
+    def decide(
+        self, _eid: EntityId, _view: object, _speed: float
+    ) -> tuple[tuple[float, float], tuple[float, float], bool, bool]:
+        return (0.0, 0.0), (1.0, 0.0), False, False
+
+    def dash_direction(self, _eid: EntityId, _view: object, _now: float, _can_dash: Any) -> None:
+        return None
+
+
+class DummyBallAudio:
+    def on_hit(self, _timestamp: float | None = None) -> None:  # pragma: no cover - stub
+        return
+
+    def on_explode(self, _timestamp: float | None = None) -> None:  # pragma: no cover - stub
+        return
+
+    def stop_idle(self, _timestamp: float | None = None) -> None:  # pragma: no cover - stub
+        return
+
+
+class DummyBall:
+    def __init__(self, x: float) -> None:
+        self.body = Body(1.0, 0.0)
+        self.body.position = (x, 0.0)
+        self.body.velocity = (0.0, 0.0)
+        self.shape = SimpleNamespace(radius=40.0)
+        self.stats = SimpleNamespace(max_speed=100.0)
+        self.health = 100.0
+
+    def cap_speed(self) -> None:  # pragma: no cover - stub
+        return
+
+    def take_damage(self, damage: Damage) -> bool:
+        self.health -= damage.amount
+        return self.health <= 0
+
+
+def _make_player(eid: int, x: float) -> Player:
+    ball = cast(Ball, DummyBall(x))
+    weapon = cast(Weapon, DummyWeapon())
+    policy = cast(StatefulPolicy, DummyPolicy())
+    audio = cast(BallAudio, DummyBallAudio())
+    return Player(EntityId(eid), ball, weapon, policy, (1.0, 0.0), (0, 0, 0), audio)
+
+
+def test_dash_collision_deals_damage_and_knockback() -> None:
+    player_a = _make_player(1, 0.0)
+    player_b = _make_player(2, 70.0)
+    world = DummyWorld()
+    renderer = cast(object, SimpleNamespace())
+    hud = cast(object, SimpleNamespace())
+    engine = SimpleNamespace(play_variation=lambda *a, **k: None)
+    recorder = cast(
+        object, SimpleNamespace(add_frame=lambda *_a: None, close=lambda *_a, **_k: None)
+    )
+    intro = cast(object, SimpleNamespace())
+
+    controller = GameController(
+        "a",
+        "b",
+        [player_a, player_b],
+        cast(Any, world),
+        cast(Any, renderer),
+        cast(Any, hud),
+        cast(Any, engine),
+        cast(Any, recorder),
+        cast(Any, intro),
+    )
+
+    player_a.dash.start((1.0, 0.0), 0.0)
+
+    controller._update_players(0.0)
+
+    assert player_b.ball.health == 95.0
+    assert player_b.ball.body.velocity.x > 0.0
+    assert player_a.dash.has_hit

--- a/tests/test_stateful_policy.py
+++ b/tests/test_stateful_policy.py
@@ -140,6 +140,27 @@ def test_transition_time_switches_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     assert called.get("mode") is Mode.OFFENSIVE
 
 
+def test_contact_dash_offensive_in_attack_mode() -> None:
+    me = EntityId(1)
+    enemy = EntityId(2)
+    view = DummyView(me, enemy, (0.0, 0.0), (100.0, 0.0))
+    policy = StatefulPolicy("aggressive", transition_time=0.0, range_type="contact")
+    direction = policy.dash_direction(me, view, 0.0, lambda _now: True)
+    assert direction is not None
+    assert direction[0] > 0
+
+
+def test_contact_dash_defensive_in_defense_mode() -> None:
+    me = EntityId(1)
+    enemy = EntityId(2)
+    projectile = ProjectileInfo(owner=enemy, position=(50.0, 0.0), velocity=(-80.0, 0.0))
+    view = DummyView(me, enemy, (0.0, 0.0), (100.0, 0.0), projectiles=[projectile])
+    policy = StatefulPolicy("aggressive", transition_time=1.0, range_type="contact")
+    direction = policy.dash_direction(me, view, 0.0, lambda _now: True)
+    assert direction is not None
+    assert direction[0] < 0
+
+
 @pytest.mark.parametrize(
     ("weapon", "enemy", "expected_style", "expected_factor"),
     [


### PR DESCRIPTION
## Summary
- track weapon range in policies
- add offensive/defensive dash logic for contact weapons
- apply damage and knockback on dash collisions
- test dash orientation and collision effects

## Testing
- `uv run ruff check app/ai/policy.py app/ai/stateful_policy.py app/game/controller.py app/game/dash.py tests/test_stateful_policy.py tests/test_dash_collision.py`
- `uv run mypy app/ai/policy.py app/ai/stateful_policy.py app/game/controller.py app/game/dash.py tests/test_stateful_policy.py tests/test_dash_collision.py`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68b6b069b7ac832a88b314fb7edc1137