### PR TITLE
fix: allow contact weapons to attack in defensive mode

### DIFF
--- a/app/ai/stateful_policy.py
+++ b/app/ai/stateful_policy.py
@@ -63,9 +63,9 @@ class StatefulPolicy(SimplePolicy):
         """Return acceleration, facing vector, fire and parry decisions.
 
         The behaviour switches from defensive to offensive at
-        ``transition_time``. In defensive mode the agent keeps its distance
-        using :meth:`_evader`. Once offensive, the original state machine is
-        employed.
+        ``transition_time``. For non-contact weapons defensive mode keeps
+        distance via :meth:`_evader`. Contact weapons always use the standard
+        attack logic and only dashes react to the tactical mode.
         """
 
         enemy = view.get_enemy(me)
@@ -82,6 +82,8 @@ class StatefulPolicy(SimplePolicy):
         cos_thresh = math.cos(math.radians(18))
 
         mode = Mode.DEFENSIVE if now < self.transition_time else Mode.OFFENSIVE
+        if self.range_type == "contact":
+            mode = Mode.OFFENSIVE
 
         if mode is Mode.DEFENSIVE:
             accel, fire = self._evader(


### PR DESCRIPTION
## Summary
- ensure contact weapons ignore defensive mode for standard attacks
- test that contact weapons attack normally before switching to offensive mode
- adjust policy tests for new mode handling

## Testing
- `uv run ruff check app/ai/stateful_policy.py tests/test_stateful_policy.py`
- `uv run ruff format app/ai/stateful_policy.py tests/test_stateful_policy.py`
- `uv run mypy app/ai/stateful_policy.py tests/test_stateful_policy.py`
- `uv run pytest tests/test_stateful_policy.py` *(fails: ImportError: cannot import name 'RangeType' from 'app.weapons.base')*


------
https://chatgpt.com/codex/tasks/task_e_68b6b4ddf224832aafa2bcdf00388562