### PR TITLE
fix: limit orbiting hits to half-turn

### DIFF
--- a/tests/unit/test_orbiting_sprite_cooldown.py
+++ b/tests/unit/test_orbiting_sprite_cooldown.py
@@ -1,3 +1,4 @@
+import math
 from dataclasses import dataclass, field
 
 import pygame
@@ -57,7 +58,7 @@ class DummyView(WorldView):
         return []
 
 
-def test_orbiting_sprite_respects_cooldown() -> None:
+def test_orbiting_sprite_requires_half_turn_between_hits() -> None:
     pygame.init()
     owner = EntityId(1)
     target = EntityId(2)
@@ -77,9 +78,10 @@ def test_orbiting_sprite_respects_cooldown() -> None:
     effect.on_hit(view, target, timestamp=0.0)
     assert view.damage[target] == 5
 
+    effect.angle = 0.1
     effect.on_hit(view, target, timestamp=0.1)
     assert view.damage[target] == 5
 
-    effect.step(0.5)
-    effect.on_hit(view, target, timestamp=0.6)
+    effect.angle = math.pi
+    effect.on_hit(view, target, timestamp=0.2)
     assert view.damage[target] == 10


### PR DESCRIPTION
## Summary
- drop time-based cooldown for orbiting weapons
- allow re-hits only after half a rotation
- update orbiting sprite test for angle-based hits

## Testing
- `uv run ruff check app/weapons/effects.py tests/unit/test_orbiting_sprite_cooldown.py`
- `uv run mypy app/weapons/effects.py tests/unit/test_orbiting_sprite_cooldown.py`
- `uv run pytest --cov=.` *(fails: unrecognized arguments)*
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `uv sync --all-extras --dev` *(fails: Failed to download `defusedxml==0.7.1`)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b49669ac832aaa7c2ebf4a3aa1a7