### PR TITLE
fix: prevent shared Damage instances in Dash

### DIFF
--- a/app/game/dash.py
+++ b/app/game/dash.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from app.core.types import Damage, Vec2
 
@@ -19,7 +19,7 @@ class Dash:
     is_dashing: bool = False
     cooldown_end: float = 0.0
     invulnerable_until: float = 0.0
-    damage: Damage = Damage(5.0)
+    damage: Damage = field(default_factory=lambda: Damage(5.0))
     knockback: float = 400.0
     has_hit: bool = False
     _direction: Vec2 = (0.0, 0.0)

--- a/tests/test_dash.py
+++ b/tests/test_dash.py
@@ -10,6 +10,14 @@ from app.world.entities import Ball
 from app.world.physics import PhysicsWorld
 
 
+def test_dash_unique_damage_instance() -> None:
+    dash_a = Dash()
+    dash_b = Dash()
+    assert dash_a.damage.amount == 5.0
+    assert dash_b.damage.amount == 5.0
+    assert dash_a.damage is not dash_b.damage
+
+
 def test_dash_cooldown_respected() -> None:
     dash = Dash(cooldown=1.0, duration=0.1)
     assert dash.can_dash(0.0)


### PR DESCRIPTION
## Summary
- avoid shared state by using default factory for `Dash.damage`
- test that `Dash` instances own distinct `Damage`

## Testing
- `uv run ruff check app/game/dash.py tests/test_dash.py`
- `uv run mypy app/game/dash.py tests/test_dash.py`
- `uv run pytest` *(fails: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68b6bbb5e51c832a803da7dbcf6b7805