### PR TITLE
refactor: freeze Damage dataclass

### DIFF
--- a/app/core/types.py
+++ b/app/core/types.py
@@ -15,7 +15,7 @@ class Stats:
     max_speed: float
 
 
-@dataclass(slots=True)
+@dataclass(frozen=True, slots=True)
 class Damage:
     """Represents raw damage dealt to an entity."""
 

--- a/tests/unit/test_damage.py
+++ b/tests/unit/test_damage.py
@@ -1,0 +1,16 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from app.core.types import Damage
+
+
+def test_damage_is_immutable() -> None:
+    damage = Damage(5.0)
+    with pytest.raises(FrozenInstanceError):
+        damage.amount = 10.0  # type: ignore[misc]
+
+
+def test_damage_value_preserved() -> None:
+    damage = Damage(12.5)
+    assert damage.amount == 12.5


### PR DESCRIPTION
## Summary
- freeze the `Damage` dataclass for immutability and slot-based memory layout
- add unit tests verifying `Damage` immutability and value preservation

## Testing
- `uv run ruff check app/core/types.py tests/unit/test_damage.py`
- `uv run mypy app/core/types.py tests/unit/test_damage.py`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68b6bebfee58832a96bebcbbda3eabb3