### PR TITLE
fix: bind dash_direction to parent class

### DIFF
--- a/app/ai/stateful_policy.py
+++ b/app/ai/stateful_policy.py
@@ -170,7 +170,7 @@ class StatefulPolicy(SimplePolicy):
         """
 
         if self.range_type != "contact":
-            return super().dash_direction(me, view, now, can_dash)
+            return super(StatefulPolicy, self).dash_direction(me, view, now, can_dash)  # noqa: UP008
         if not can_dash(now):
             return None
 
@@ -190,7 +190,7 @@ class StatefulPolicy(SimplePolicy):
             return direction
 
         # Defensive mode --------------------------------------------------
-        super_dir = super().dash_direction(me, view, now, can_dash)
+        super_dir = super(StatefulPolicy, self).dash_direction(me, view, now, can_dash)  # noqa: UP008
         projectile_threat = super_dir is not None
         if dist > 150.0 and not projectile_threat:
             return None


### PR DESCRIPTION
## Summary
- explicitly bind `dash_direction` calls to `SimplePolicy` in `StatefulPolicy`

## Testing
- `make lint`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68b6cf58e998832ab6ae89a37e77981b