### PR TITLE
feat: add projectile targeting for ranged AI

### DIFF
--- a/tests/test_stateful_policy.py
+++ b/tests/test_stateful_policy.py
@@ -201,3 +201,12 @@ def test_policy_for_weapon_range_combinations(
     policy = policy_for_weapon(weapon, enemy, transition_time=0.0)
     assert policy.style == expected_style
     assert policy.fire_range_factor == expected_factor
+
+
+def test_stateful_evader_moves_toward_offscreen_enemy() -> None:
+    me = EntityId(1)
+    enemy = EntityId(2)
+    view = DummyView(me, enemy, (0.0, 0.0), (2000.0, 0.0))
+    policy = StatefulPolicy("evader", transition_time=0.0, range_type="distant")
+    accel, _, _, _ = policy.decide(me, view, 0.0, 600.0)
+    assert accel[0] > 0


### PR DESCRIPTION
## Summary
- improve ranged policy logic to chase distant enemies and lead shots on projectiles
- cover new behaviour with AI unit tests

## Testing
- `uv run ruff check app/ai/policy.py app/ai/stateful_policy.py tests/test_policy.py tests/test_stateful_policy.py`
- `uv run mypy app/ai/policy.py app/ai/stateful_policy.py tests/test_policy.py tests/test_stateful_policy.py`
- `uv run pytest tests/test_policy.py tests/test_stateful_policy.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68b6d5141f28832abe3cd5624e690064