### PR TITLE
feat: play versus sound at intro start

### DIFF
--- a/app/intro/intro_manager.py
+++ b/app/intro/intro_manager.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:  # pragma: no cover - hints only
     from app.audio import AudioEngine
 
 
+VERSUS_SOUND: str = "assets/versus.ogg"
 FIGHT_SOUND: str = "assets/fight.ogg"
 WEAPON_PULSE_AMPLITUDE: float = 0.05
 
@@ -70,10 +71,7 @@ class IntroManager:
         self._timeline: Timeline | None = None
         self._elapsed = 0.0
         self._duration = (
-            self.config.logo_in
-            + self.config.weapons_in
-            + self.config.hold
-            + self.config.fade_out
+            self.config.logo_in + self.config.weapons_in + self.config.hold + self.config.fade_out
         )
         self._targets: tuple[pygame.Rect, pygame.Rect, pygame.Rect] | None = None
 
@@ -99,6 +97,12 @@ class IntroManager:
         self._state_index = 0
         self._elapsed = 0.0
         self._targets = None
+        engine = self._engine
+        if engine is None:
+            from app.audio import get_default_engine
+
+            engine = get_default_engine()
+        engine.play_variation(VERSUS_SOUND, timestamp=0.0)
         self._renderer.reset()
         self._timeline = Timeline()
         self._timeline.add(Animation(0.0, 1.0, self.config.logo_in))

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -8,6 +8,7 @@ Ce document décrit l'architecture de l'animation d'introduction avant chaque ma
 - Machine à états gérant les phases : `LOGO_IN`, `WEAPONS_IN`, `HOLD`, `FADE_OUT`, `DONE`.
 - Méthodes `start`, `update(dt, events)`, `draw(surface, labels)` et `is_finished` orchestrent la séquence.
 - Permet de passer l'intro via la touche de saut (Échap par défaut) quand `allow_skip=True`.
+- Joue `versus.ogg` au lancement et `fight.ogg` lors du passage à la phase `FADE_OUT`.
 
 ## IntroRenderer
 

--- a/tests/unit/test_intro_manager.py
+++ b/tests/unit/test_intro_manager.py
@@ -91,11 +91,14 @@ def test_intro_manager_fight_sound() -> None:
     manager.start()
     for _ in range(3):
         manager.update(0.1)
-    assert len(stub.played) == 1
-    path, timestamp = stub.played[0]
-    assert path.endswith("fight.ogg")
+    assert len(stub.played) == 2
+    start_path, start_ts = stub.played[0]
+    assert start_path.endswith("versus.ogg")
+    assert start_ts == pytest.approx(0.0)
+    fight_path, fight_ts = stub.played[1]
+    assert fight_path.endswith("fight.ogg")
     expected = config.logo_in + config.weapons_in + config.hold
-    assert timestamp == pytest.approx(expected)
+    assert fight_ts == pytest.approx(expected)
 
 
 def test_start_resets_renderer() -> None:


### PR DESCRIPTION
## Summary
- play versus sound when intro begins
- document intro audio sequence
- validate both versus and fight cues in intro tests

## Testing
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68b6e60022fc832a92247b04002ba238