### PR TITLE
feat: add explicit error for unknown weapons

### DIFF
--- a/tests/test_unknown_weapon_error.py
+++ b/tests/test_unknown_weapon_error.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pytest
+
+from app.core.registry import UnknownWeaponError
+from app.weapons import weapon_registry
+
+
+def test_unknown_weapon_error_lists_available() -> None:
+    """Unknown weapons provide a helpful error message."""
+    available = weapon_registry.names()
+    missing = "laser"
+    with pytest.raises(UnknownWeaponError) as exc:
+        weapon_registry.create(missing)
+    message = str(exc.value)
+    assert missing in message
+    for name in available:
+        assert name in message


### PR DESCRIPTION
## Summary
- add `UnknownWeaponError` and raise when weapon name is not registered
- surface helpful weapon suggestions in controller creation and CLI commands
- cover unknown weapon handling with new tests

## Testing
- `uv run ruff check .`
- `uv run ruff format app/cli.py app/core/registry.py app/game/match.py tests/test_cli_run.py tests/test_unknown_weapon_error.py`
- `uv run mypy .`
- `uv run pytest` *(fails: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68b7368e511c832a9852c41a5b75b2cf