### PR TITLE
fix: lazy weapon registry import for CLI commands

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -18,7 +18,6 @@ from app.game.match import create_controller
 from app.intro.config import IntroConfig, set_intro_weapons
 from app.render.renderer import Renderer
 from app.video.recorder import NullRecorder, Recorder, RecorderProtocol
-from app.weapons import weapon_registry
 
 app = typer.Typer(help="Génération de vidéos satisfaction (TikTok).")
 
@@ -164,6 +163,9 @@ def run(
         )
 
     with temporary_sdl_audio_driver(driver):
+        from app.weapons import weapon_registry
+
+        weapon_registry.names()
         if display:
             renderer = Renderer(settings.width, settings.height, display=True)
             recorder = NullRecorder()
@@ -226,9 +228,11 @@ def batch(
 ) -> None:
     """Generate multiple match videos with varied seeds and weapons."""
     out_dir.mkdir(parents=True, exist_ok=True)
-    names = weapon_registry.names()
 
     with temporary_sdl_audio_driver("dummy"):
+        from app.weapons import weapon_registry
+
+        names = weapon_registry.names()
         for _ in range(count):
             seed = random.randint(0, 1_000_000)
             weapon_a, weapon_b = random.sample(names, k=2)

--- a/tests/test_cli_lazy_weapon_import.py
+++ b/tests/test_cli_lazy_weapon_import.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("typer")
+pytest.importorskip("pydantic")
+from typer.testing import CliRunner
+
+import app.cli as cli_module
+from app.cli import app
+
+
+class DummyRenderer:
+    def __init__(self, width: int, height: int, display: bool = False) -> None:
+        self.width = width
+        self.height = height
+        self.display = display
+
+    def close(self) -> None:  # pragma: no cover - interface compatibility
+        pass
+
+
+def _clear_weapon_modules() -> None:
+    for name in list(sys.modules):
+        if name.startswith("app.weapons"):
+            sys.modules.pop(name)
+
+
+def test_run_without_preimport(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_weapon_modules()
+
+    class DummyRecorder:
+        def __init__(self, width: int, height: int, fps: int, path: Path) -> None:  # noqa: ARG002
+            self.path: Path | None = None
+
+        def add_frame(self, _frame: object) -> None:  # pragma: no cover - interface compatibility
+            pass
+
+        def close(
+            self, _audio: object | None = None, rate: int = 48_000
+        ) -> None:  # pragma: no cover - interface compatibility
+            pass
+
+    def fake_create_controller(*_args: object, **_kwargs: object) -> object:
+        class Controller:
+            def run(self) -> str:
+                return "winner"
+
+        return Controller()
+
+    monkeypatch.setattr(cli_module, "Recorder", DummyRecorder)
+    monkeypatch.setattr(cli_module, "Renderer", DummyRenderer)
+    monkeypatch.setattr(cli_module, "create_controller", fake_create_controller)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            app,
+            ["run", "--seed", "1", "--weapon-a", "katana", "--weapon-b", "shuriken"],
+        )
+    assert result.exit_code == 0
+
+
+def test_batch_without_preimport(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_weapon_modules()
+
+    class DummyRecorder:
+        def __init__(self, width: int, height: int, fps: int, path: Path) -> None:  # noqa: ARG002
+            self.path = path
+
+        def add_frame(self, _frame: object) -> None:  # pragma: no cover - interface compatibility
+            pass
+
+        def close(
+            self, _audio: object | None = None, rate: int = 48_000
+        ) -> None:  # pragma: no cover - interface compatibility
+            pass
+
+    def fake_create_controller(
+        _weapon_a: str,
+        _weapon_b: str,
+        recorder: DummyRecorder,
+        _renderer: DummyRenderer,
+        **_kwargs: object,
+    ) -> object:
+        class Controller:
+            def run(self) -> str:
+                if recorder.path is not None:
+                    recorder.path.write_bytes(b"data")
+                return "winner"
+
+        return Controller()
+
+    monkeypatch.setattr(cli_module, "Recorder", DummyRecorder)
+    monkeypatch.setattr(cli_module, "Renderer", DummyRenderer)
+    monkeypatch.setattr(cli_module, "create_controller", fake_create_controller)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(app, ["batch", "--count", "1"])
+    assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- import weapons registry inside run and batch commands only after setting a temporary SDL audio driver
- add tests verifying CLI commands work without pre-importing weapon registry

## Testing
- `uv run ruff check app/cli.py tests/test_cli_lazy_weapon_import.py`
- `uv run mypy app/cli.py tests/test_cli_lazy_weapon_import.py`
- `uv run pytest` *(fails: tests raise missing dependency errors)*
- `uv run pytest tests/test_cli_lazy_weapon_import.py` *(skipped: typer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b74453b908832a8725cad57b194aec