### PR TITLE
test: verify default weapons registered

### DIFF
--- a/tests/test_weapon_registry_defaults.py
+++ b/tests/test_weapon_registry_defaults.py
@@ -1,0 +1,36 @@
+"""Tests for default weapon registry entries."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+# Provide a minimal configuration module so that weapon modules importing the
+# physics engine do not require the optional pydantic dependency.
+config_stub = types.ModuleType("app.core.config")
+config_stub.settings = types.SimpleNamespace(  # type: ignore[attr-defined]
+    wall_thickness=10,
+    width=1080,
+    height=1920,
+)
+sys.modules.setdefault("app.core.config", config_stub)
+
+
+def test_weapon_registry_registers_default_weapons() -> None:
+    """Default weapons are registered on package import."""
+    for mod in [
+        "app.weapons",
+        "app.weapons.base",
+        "app.weapons.bazooka",
+        "app.weapons.katana",
+        "app.weapons.knife",
+        "app.weapons.shuriken",
+    ]:
+        sys.modules.pop(mod, None)
+
+    weapons = importlib.import_module("app.weapons")
+    names = weapons.weapon_registry.names()
+
+    expected = {"bazooka", "katana", "knife", "shuriken"}
+    assert expected <= set(names)


### PR DESCRIPTION
## Summary
- add a unit test ensuring bazooka, katana, knife, and shuriken are registered in the weapon registry

## Testing
- `uv run ruff check tests/test_weapon_registry_defaults.py`
- `uv run mypy tests/test_weapon_registry_defaults.py`
- `uv run pytest tests/test_weapon_registry_defaults.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b748d20bc4832ab5e4d02089d35ea1