### PR TITLE
feat: add resonance hammer weapon with reflective wave

### DIFF
--- a/app/weapons/__init__.py
+++ b/app/weapons/__init__.py
@@ -33,5 +33,7 @@ with suppress(Exception):  # pragma: no cover
     from . import shuriken as _shuriken  # noqa: F401,E402
 with suppress(Exception):  # pragma: no cover
     from . import gravity_well as _gravity_well  # noqa: F401,E402
+with suppress(Exception):  # pragma: no cover
+    from . import resonance_hammer as _resonance_hammer  # noqa: F401,E402
 
 __all__ = ["Weapon", "weapon_registry"]

--- a/app/weapons/assets.py
+++ b/app/weapons/assets.py
@@ -40,3 +40,11 @@ def load_gravity_well_sprite() -> pygame.Surface:
         return load_weapon_sprite("gravity_well")
     except FileNotFoundError:
         return pygame.Surface((1, 1), pygame.SRCALPHA)
+
+
+def load_resonance_hammer_sprite() -> pygame.Surface:
+    """Load the resonance hammer sprite or return a placeholder surface."""
+    try:
+        return load_weapon_sprite("resonance_hammer")
+    except FileNotFoundError:
+        return pygame.Surface((1, 1), pygame.SRCALPHA)

--- a/app/weapons/resonance_hammer.py
+++ b/app/weapons/resonance_hammer.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+# ruff: noqa: E402
+
+"""Resonance Hammer weapon emitting a reflective shockwave.
+
+Assets for this weapon are not yet available; placeholder visuals are used
+until dedicated sprites and audio are integrated."""
+
+from app.core.types import Damage, EntityId, Vec2
+
+from . import weapon_registry
+from .assets import load_resonance_hammer_sprite
+from .base import RangeType, Weapon, WorldView
+from .effects import ResonanceWaveEffect
+
+
+class ResonanceHammer(Weapon):
+    """Heavy hammer emitting a resonant shockwave on impact."""
+
+    range_type: RangeType = "contact"
+
+    def __init__(self) -> None:
+        super().__init__(
+            name="resonance_hammer",
+            cooldown=2.0,
+            damage=Damage(12),
+            speed=120.0,
+            range_type=self.range_type,
+        )
+        self._sprite = load_resonance_hammer_sprite()
+
+    def _fire(self, owner: EntityId, view: WorldView, direction: Vec2) -> None:
+        origin = view.get_position(owner)
+        effect = ResonanceWaveEffect(
+            owner=owner,
+            position=origin,
+            max_radius=120.0,
+            speed=self.speed,
+            damage=self.damage,
+            amplification=2.0,
+        )
+        view.spawn_effect(effect)
+
+
+weapon_registry.register("resonance_hammer", ResonanceHammer)

--- a/docs/resonance_hammer.md
+++ b/docs/resonance_hammer.md
@@ -1,0 +1,10 @@
+# Resonance Hammer
+
+The **Resonance Hammer** unleashes a circular shockwave on impact. The wave expands
+from the wielder, rebounds at its maximum reach and returns with increased
+strength, striking anything it meets along the way. Each reflection multiplies
+the damage, rewarding precise timing and positioning.
+
+> **Note**
+> Sprite and audio assets will be integrated separately. The current
+> implementation uses placeholder visuals.

--- a/tests/weapons/test_resonance_hammer.py
+++ b/tests/weapons/test_resonance_hammer.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+# ruff: noqa: E402, I001
+
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+if "app" in sys.modules:
+    del sys.modules["app"]
+
+from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
+from app.weapons.base import WeaponEffect, WorldView
+from app.weapons.effects import ResonanceWaveEffect
+
+
+@dataclass
+class DummyView(WorldView):
+    positions: dict[EntityId, Vec2]
+    damage: dict[EntityId, float] = field(default_factory=dict)
+
+    def get_enemy(self, owner: EntityId) -> EntityId | None:  # pragma: no cover - unused
+        return None
+
+    def get_position(self, eid: EntityId) -> Vec2:
+        return self.positions[eid]
+
+    def get_velocity(self, eid: EntityId) -> Vec2:  # pragma: no cover - unused
+        return (0.0, 0.0)
+
+    def get_health_ratio(self, eid: EntityId) -> float:  # pragma: no cover - unused
+        return 1.0
+
+    def deal_damage(self, eid: EntityId, damage: Damage, timestamp: float) -> None:
+        self.damage[eid] = self.damage.get(eid, 0.0) + damage.amount
+
+    def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:  # pragma: no cover - unused
+        return None
+
+    def add_speed_bonus(self, eid: EntityId, bonus: float) -> None:  # pragma: no cover - unused
+        return None
+
+    def spawn_effect(self, effect: WeaponEffect) -> None:  # pragma: no cover - unused
+        return None
+
+    def spawn_projectile(self, *args: object, **kwargs: object) -> WeaponEffect:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    def iter_projectiles(self, excluding: EntityId | None = None) -> list[ProjectileInfo]:  # pragma: no cover - unused
+        return []
+
+
+def test_resonance_wave_reflects_and_amplifies() -> None:
+    owner = EntityId(1)
+    target = EntityId(2)
+    view = DummyView({owner: (0.0, 0.0), target: (5.0, 0.0)})
+    wave = ResonanceWaveEffect(
+        owner=owner,
+        position=(0.0, 0.0),
+        max_radius=10.0,
+        speed=10.0,
+        damage=Damage(10),
+        amplification=2.0,
+        thickness=1.0,
+    )
+
+    wave.step(0.5)  # expand to radius 5
+    assert wave.collides(view, view.get_position(target), 0.5) is True
+    wave.on_hit(view, target, timestamp=0.5)
+    assert view.damage[target] == 10.0
+
+    wave.step(0.5)  # reach max radius and reflect
+    assert wave.direction == -1
+
+    wave.step(0.5)  # contract back to radius 5
+    assert wave.collides(view, view.get_position(target), 0.5) is True
+    wave.on_hit(view, target, timestamp=1.5)
+    assert view.damage[target] == 30.0
+
+    assert wave.step(0.5) is False  # contract to zero and expire


### PR DESCRIPTION
## Summary
- add resonance hammer weapon spawning a reflective shockwave
- support resonance wave effect with damage amplification
- document resonance hammer mechanics and placeholder assets

## Testing
- `uv run ruff check app/weapons/resonance_hammer.py tests/weapons/test_resonance_hammer.py app/weapons/effects.py app/weapons/__init__.py app/weapons/assets.py`
- `uv run mypy app/weapons/resonance_hammer.py app/weapons/effects.py`
- `uv run python - <<'PY'
from pathlib import Path
import sys
ROOT = Path(__file__).resolve().parent
sys.path.insert(0, str(ROOT))
from tests.weapons.test_resonance_hammer import test_resonance_wave_reflects_and_amplifies

test_resonance_wave_reflects_and_amplifies()
print('resonance ok')
PY`
- `uv run python - <<'PY'
from pathlib import Path
import sys
ROOT = Path(__file__).resolve().parent
sys.path.insert(0, str(ROOT))
from tests.weapons.test_gravity_well import (
    test_gravity_well_attracts_target,
    test_gravity_well_lifetime,
    test_gravity_well_damage_over_time,
)

test_gravity_well_attracts_target()
test_gravity_well_lifetime()
test_gravity_well_damage_over_time()
print('gravity ok')
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b7518d8a48832abc060da4a4119dc8