### PR TITLE
refactor: log optional weapon import failures

### DIFF
--- a/app/weapons/__init__.py
+++ b/app/weapons/__init__.py
@@ -13,7 +13,7 @@ All modules importing this package will automatically discover registered
 weapons.
 """
 
-from contextlib import suppress
+import logging
 
 from app.core.registry import Registry
 
@@ -22,16 +22,31 @@ from .base import Weapon
 weapon_registry: Registry[Weapon] = Registry()
 
 # Import weapon modules to register them
+logger = logging.getLogger(__name__)
 
-with suppress(Exception):  # pragma: no cover - optional weapons may have extra deps
+try:
     from . import bazooka as _bazooka  # noqa: F401,E402
-with suppress(Exception):  # pragma: no cover
+except Exception as exc:  # pragma: no cover - optional weapons may have extra deps
+    logger.warning("Failed to import optional weapon module 'bazooka': %s", exc)
+
+try:
     from . import katana as _katana  # noqa: F401,E402
-with suppress(Exception):  # pragma: no cover
+except Exception as exc:  # pragma: no cover
+    logger.warning("Failed to import optional weapon module 'katana': %s", exc)
+
+try:
     from . import knife as _knife  # noqa: F401,E402
-with suppress(Exception):  # pragma: no cover
+except Exception as exc:  # pragma: no cover
+    logger.warning("Failed to import optional weapon module 'knife': %s", exc)
+
+try:
     from . import shuriken as _shuriken  # noqa: F401,E402
-with suppress(Exception):  # pragma: no cover
+except Exception as exc:  # pragma: no cover
+    logger.warning("Failed to import optional weapon module 'shuriken': %s", exc)
+
+try:
     from . import gravity_well as _gravity_well  # noqa: F401,E402
+except Exception as exc:  # pragma: no cover
+    logger.warning("Failed to import optional weapon module 'gravity_well': %s", exc)
 
 __all__ = ["Weapon", "weapon_registry"]


### PR DESCRIPTION
## Summary
- replace suppress blocks with explicit try/except and logging for optional weapon modules

## Testing
- `ruff check app/weapons/__init__.py`
- `mypy app/weapons/__init__.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic', etc.)*
- `uv run pre-commit run --files app/weapons/__init__.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b754883d78832abbf11d1694c8039b