### PR TITLE
fix: warn on optional weapon import errors

### DIFF
--- a/app/weapons/__init__.py
+++ b/app/weapons/__init__.py
@@ -13,6 +13,9 @@ All modules importing this package will automatically discover registered
 weapons.
 """
 
+from __future__ import annotations
+
+import importlib
 import logging
 
 from app.core.registry import Registry
@@ -24,34 +27,19 @@ weapon_registry: Registry[Weapon] = Registry()
 # Import weapon modules to register them
 logger = logging.getLogger(__name__)
 
-try:
-    from . import bazooka as _bazooka  # noqa: F401,E402
-except Exception as exc:  # pragma: no cover - optional weapons may have extra deps
-    logger.warning("Failed to import optional weapon module 'bazooka': %s", exc)
+_OPTIONAL_MODULES: list[str] = [
+    "bazooka",
+    "katana",
+    "knife",
+    "shuriken",
+    "gravity_well",
+    "resonance_hammer",
+]
 
-try:
-    from . import katana as _katana  # noqa: F401,E402
-except Exception as exc:  # pragma: no cover
-    logger.warning("Failed to import optional weapon module 'katana': %s", exc)
-
-try:
-    from . import knife as _knife  # noqa: F401,E402
-except Exception as exc:  # pragma: no cover
-    logger.warning("Failed to import optional weapon module 'knife': %s", exc)
-
-try:
-    from . import shuriken as _shuriken  # noqa: F401,E402
-except Exception as exc:  # pragma: no cover
-    logger.warning("Failed to import optional weapon module 'shuriken': %s", exc)
-
-try:
-    from . import gravity_well as _gravity_well  # noqa: F401,E402
-except Exception as exc:  # pragma: no cover
-    logger.warning("Failed to import optional weapon module 'gravity_well': %s", exc)
-
-try:
-    from . import resonance_hammer as _resonance_hammer  # noqa: F401,E402
-except Exception as exc:  # pragma: no cover
-    logger.warning("Failed to import optional weapon module 'resonance_hammer': %s", exc)
+for _module in _OPTIONAL_MODULES:
+    try:
+        importlib.import_module(f"{__name__}.{_module}")
+    except Exception as exc:  # pragma: no cover - optional weapons may have extra deps
+        logger.warning("Failed to import optional weapon module '%s': %s", _module, exc)
 
 __all__ = ["Weapon", "weapon_registry"]

--- a/tests/test_weapon_import_warning.py
+++ b/tests/test_weapon_import_warning.py
@@ -1,0 +1,49 @@
+"""Tests that failed weapon imports surface warnings."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+import types
+
+import pytest
+
+
+def _clear_weapon_modules() -> None:
+    """Remove weapon modules from :data:`sys.modules` for a clean import."""
+    for name in list(sys.modules):
+        if name.startswith("app.weapons"):
+            sys.modules.pop(name)
+
+
+def test_failed_import_logs_warning(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Import failures should emit a warning with module and error details."""
+
+    # Provide minimal configuration to satisfy optional dependencies.
+    config_stub = types.ModuleType("app.core.config")
+    config_stub.settings = types.SimpleNamespace(  # type: ignore[attr-defined]
+        wall_thickness=10,
+        width=1080,
+        height=1920,
+    )
+    sys.modules.setdefault("app.core.config", config_stub)
+
+    _clear_weapon_modules()
+
+    real_import_module = importlib.import_module
+
+    def failing_import(name: str, package: str | None = None) -> types.ModuleType:
+        if name == "app.weapons.katana":
+            raise RuntimeError("boom")
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(importlib, "import_module", failing_import)
+
+    with caplog.at_level(logging.WARNING):
+        importlib.import_module("app.weapons")
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("Failed to import optional weapon module 'katana': boom" in msg for msg in messages)


### PR DESCRIPTION
## Summary
- handle optional weapon imports with explicit try/except and warning logs
- add regression test ensuring warnings are emitted when imports fail

## Testing
- `uv run ruff format app/weapons/__init__.py tests/test_weapon_import_warning.py`
- `uv run ruff check app/weapons/__init__.py tests/test_weapon_import_warning.py`
- `uv run mypy app/weapons/__init__.py tests/test_weapon_import_warning.py`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'imageio_ffmpeg', 'pydantic', 'pygame', 'typer')*
- `uv run pytest tests/test_weapon_import_warning.py`
- `uv run pip-audit` *(fails: No such file or directory)*
- `uv run bandit -r app` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b75a314bbc832abdd5bb24c1201f75