### PR TITLE
feat: fire shuriken beyond range

### DIFF
--- a/app/ai/stateful_policy.py
+++ b/app/ai/stateful_policy.py
@@ -86,7 +86,9 @@ class StatefulPolicy(SimplePolicy):
         atk_range = _attack_range(projectile_speed, self.fire_range_factor, self.fire_range)
         out_of_range = self.range_type == "distant" and dist > atk_range
         projectile: ProjectileInfo | None = (
-            _nearest_projectile(me, view, my_pos) if out_of_range else None
+            _nearest_projectile(me, view, my_pos)
+            if out_of_range and not self.fire_out_of_range
+            else None
         )
 
         if projectile is not None:
@@ -163,7 +165,7 @@ class StatefulPolicy(SimplePolicy):
             accel = (direction[0] * 400.0, direction[1] * 400.0)
 
         if out_of_range:
-            fire = projectile is not None
+            fire = self.fire_out_of_range or projectile is not None
 
         if projectile is None and abs(dy) <= 1e-6:
             offset = self.vertical_offset + self.rng.uniform(-0.05, 0.05)

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -301,10 +301,18 @@ def test_distant_vs_distant_policy_is_kiter() -> None:
     assert policy.style == "kiter"
 
 
-def test_distant_policy_no_fire_without_projectile() -> None:
+def test_shuriken_policy_fires_when_enemy_far() -> None:
     view = DummyView(EntityId(1), EntityId(2), (0.0, 0.0), (1000.0, 0.0))
     policy = policy_for_weapon("shuriken", "katana")
     _, _, fire, parry = policy.decide(EntityId(1), view, 600.0)
+    assert fire is True
+    assert parry is False
+
+
+def test_bazooka_policy_no_fire_when_enemy_far() -> None:
+    view = DummyView(EntityId(1), EntityId(2), (0.0, 0.0), (1000.0, 0.0))
+    policy = policy_for_weapon("bazooka", "katana")
+    _, _, fire, parry = policy.decide(EntityId(1), view, 300.0)
     assert fire is False
     assert parry is False
 


### PR DESCRIPTION
## Summary
- allow shuriken to fire even when the target is beyond attack range
- expose a `fire_out_of_range` flag on combat policies and enable it for shuriken
- cover new behaviour with dedicated policy tests

## Testing
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68b81ed66bd4832aa09bd92320721be2