### PR TITLE
test: add blade deflection tests

### DIFF
--- a/tests/test_weapons.py
+++ b/tests/test_weapons.py
@@ -1,3 +1,8 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
 from app.weapons.bazooka import Bazooka
 from app.weapons.katana import Katana
 from app.weapons.knife import Knife
@@ -13,17 +18,29 @@ def test_shuriken_sprite_and_radius() -> None:
     assert shuriken._radius == DEFAULT_BALL_RADIUS / 3
 
 
-def test_katana_sprite_height() -> None:
+def test_katana_blade_dimensions() -> None:
     katana = Katana()
-    expected_height = int(DEFAULT_BALL_RADIUS * 3)
+    expected_height = DEFAULT_BALL_RADIUS * 3.0
+    expected_width = DEFAULT_BALL_RADIUS / 4.0
+    expected_offset = DEFAULT_BALL_RADIUS + expected_height / 2 + 1.0
     _, height = katana._sprite.get_size()
-    assert height == expected_height
+    assert height == int(expected_height)
+    assert katana._blade_height == expected_height
+    assert katana._blade_width == expected_width
+    assert katana._blade_offset == expected_offset
 
 
-def test_knife_sprite_loaded() -> None:
+def test_knife_blade_dimensions() -> None:
     knife = Knife()
+    expected_height = DEFAULT_BALL_RADIUS * 2.0
+    expected_width = DEFAULT_BALL_RADIUS / 4.0
+    expected_offset = DEFAULT_BALL_RADIUS + expected_height / 2 + 1.0
     width, height = knife._sprite.get_size()
-    assert width > 0 and height > 0
+    assert height == int(expected_height)
+    assert width > 0
+    assert knife._blade_height == expected_height
+    assert knife._blade_width == expected_width
+    assert knife._blade_offset == expected_offset
 
 
 def test_bazooka_missile_radius() -> None:

--- a/tests/unit/test_knife_deflect.py
+++ b/tests/unit/test_knife_deflect.py
@@ -1,8 +1,7 @@
-"""Verify katana's deflection and contact mechanics."""
+"""Verify knife's deflection and contact mechanics."""
 
 from __future__ import annotations
 
-import math
 import pathlib
 import sys
 from dataclasses import dataclass, field
@@ -21,7 +20,7 @@ from app.world.projectiles import Projectile
 
 @dataclass
 class DummyView(WorldView):
-    """Minimal :class:`WorldView` for katana tests."""
+    """Minimal :class:`WorldView` used for knife tests."""
 
     positions: dict[EntityId, Vec2]
     enemies: dict[EntityId, EntityId]
@@ -71,8 +70,8 @@ class DummyView(WorldView):
         return []
 
 
-def _make_katana(owner: EntityId) -> OrbitingRectangle:
-    height = DEFAULT_BALL_RADIUS * 3.0
+def _make_knife(owner: EntityId) -> OrbitingRectangle:
+    height = DEFAULT_BALL_RADIUS * 2.0
     width = DEFAULT_BALL_RADIUS / 4.0
     offset = DEFAULT_BALL_RADIUS + height / 2 + 1.0
     return OrbitingRectangle(
@@ -86,7 +85,7 @@ def _make_katana(owner: EntityId) -> OrbitingRectangle:
     )
 
 
-def test_katana_deflects_projectile() -> None:
+def test_knife_deflects_projectile() -> None:
     pygame.init()
     world = PhysicsWorld()
     owner = EntityId(1)
@@ -94,11 +93,11 @@ def test_katana_deflects_projectile() -> None:
     positions = {owner: (0.0, 0.0), enemy: (150.0, 0.0)}
     enemies = {owner: enemy, enemy: owner}
     view = DummyView(positions, enemies)
-    katana = _make_katana(owner)
+    knife = _make_knife(owner)
     projectile = Projectile.spawn(
         world,
         owner=enemy,
-        position=(katana.offset, 0.0),
+        position=(knife.offset, 0.0),
         velocity=(-100.0, 0.0),
         radius=1.0,
         damage=Damage(5),
@@ -107,9 +106,9 @@ def test_katana_deflects_projectile() -> None:
     )
     projectile.ttl = 0.1
     pos = (float(projectile.body.position.x), float(projectile.body.position.y))
-    assert katana.collides(view, pos, float(projectile.shape.radius))
+    assert knife.collides(view, pos, float(projectile.shape.radius))
 
-    katana.deflect_projectile(view, projectile, timestamp=0.0)
+    knife.deflect_projectile(view, projectile, timestamp=0.0)
 
     assert projectile.owner == owner
     assert projectile.body.velocity.x == 100.0
@@ -120,7 +119,7 @@ def test_katana_deflects_projectile() -> None:
     assert view.damage[enemy] == 5
 
 
-def test_katana_does_not_deflect_body_hit() -> None:
+def test_knife_does_not_deflect_body_hit() -> None:
     pygame.init()
     world = PhysicsWorld()
     owner = EntityId(1)
@@ -128,7 +127,7 @@ def test_katana_does_not_deflect_body_hit() -> None:
     positions = {owner: (0.0, 0.0), enemy: (150.0, 0.0)}
     enemies = {owner: enemy, enemy: owner}
     view = DummyView(positions, enemies)
-    katana = _make_katana(owner)
+    knife = _make_knife(owner)
     projectile = Projectile.spawn(
         world,
         owner=enemy,
@@ -141,23 +140,23 @@ def test_katana_does_not_deflect_body_hit() -> None:
     )
     projectile.ttl = 0.1
     pos = (float(projectile.body.position.x), float(projectile.body.position.y))
-    assert not katana.collides(view, pos, float(projectile.shape.radius))
+    assert not knife.collides(view, pos, float(projectile.shape.radius))
 
     projectile.on_hit(view, owner, timestamp=0.0)
     assert view.damage[owner] == 5
 
 
-def test_katana_hits_enemy_ball() -> None:
+def test_knife_hits_enemy_ball() -> None:
     pygame.init()
     owner = EntityId(1)
     enemy = EntityId(2)
-    height = DEFAULT_BALL_RADIUS * 3.0
+    height = DEFAULT_BALL_RADIUS * 2.0
     width = DEFAULT_BALL_RADIUS / 4.0
     offset = DEFAULT_BALL_RADIUS + height / 2 + 1.0
     positions = {owner: (0.0, 0.0), enemy: (offset, 0.0)}
     enemies = {owner: enemy, enemy: owner}
     view = DummyView(positions, enemies)
-    katana = OrbitingRectangle(
+    knife = OrbitingRectangle(
         owner=owner,
         damage=Damage(5),
         width=width,
@@ -166,37 +165,9 @@ def test_katana_hits_enemy_ball() -> None:
         angle=0.0,
         speed=0.0,
     )
-    assert katana.collides(view, positions[enemy], DEFAULT_BALL_RADIUS)
+    assert knife.collides(view, positions[enemy], DEFAULT_BALL_RADIUS)
 
-    katana.on_hit(view, enemy, timestamp=0.0)
+    knife.on_hit(view, enemy, timestamp=0.0)
 
     assert view.damage[enemy] == 5
 
-
-def test_katana_deflect_respects_angle() -> None:
-    pygame.init()
-    world = PhysicsWorld()
-    owner = EntityId(1)
-    enemy = EntityId(2)
-    positions = {owner: (0.0, 0.0), enemy: (0.0, 150.0)}
-    enemies = {owner: enemy, enemy: owner}
-    view = DummyView(positions, enemies)
-    katana = _make_katana(owner)
-    projectile = Projectile.spawn(
-        world,
-        owner=enemy,
-        position=(0.0, katana.offset),
-        velocity=(0.0, -100.0),
-        radius=1.0,
-        damage=Damage(5),
-        knockback=0.0,
-        ttl=1.0,
-    )
-    pos = (float(projectile.body.position.x), float(projectile.body.position.y))
-    assert not katana.collides(view, pos, float(projectile.shape.radius))
-
-    katana.angle = math.pi / 2
-    assert katana.collides(view, pos, float(projectile.shape.radius))
-
-    katana.deflect_projectile(view, projectile, timestamp=0.0)
-    assert projectile.owner == owner


### PR DESCRIPTION
## Summary
- verify katana parry reflects projectiles and respects rotation
- add knife deflection coverage
- assert katana and knife blade dimensions

## Testing
- `ruff check tests/unit/test_katana_deflect.py tests/unit/test_knife_deflect.py tests/test_weapons.py`
- `mypy tests/unit/test_katana_deflect.py tests/unit/test_knife_deflect.py tests/test_weapons.py`
- `uv run pytest tests/unit/test_katana_deflect.py tests/unit/test_knife_deflect.py tests/test_weapons.py` *(fails: No module named 'app.weapons.effects'; 'app.weapons' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68b823a55730832a946ccc3fa2592a69