### PR TITLE
feat: deflect projectiles on defended hits

### DIFF
--- a/app/weapons/base.py
+++ b/app/weapons/base.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     import pygame
 
     from app.render.renderer import Renderer
+    from .parry import ParryEffect
 
 
 class WorldView(Protocol):
@@ -63,6 +64,12 @@ class WorldView(Protocol):
 
     def iter_projectiles(self, excluding: EntityId | None = None) -> Iterable[ProjectileInfo]:
         """Yield active projectiles, optionally skipping those owned by *excluding*."""
+
+    def get_weapon(self, eid: EntityId) -> Weapon:
+        """Return the weapon currently wielded by ``eid``."""
+
+    def get_parry(self, eid: EntityId) -> ParryEffect | None:
+        """Return the active parry effect for ``eid`` if present."""
 
 
 class WeaponEffect(Protocol):

--- a/app/world/physics.py
+++ b/app/world/physics.py
@@ -249,7 +249,7 @@ class PhysicsWorld:
         candidate: pymunk.Shape,
         view: WorldView,
     ) -> bool:
-        """Return ``True`` if a projectile hit a ball and was removed."""
+        """Return ``True`` if a projectile↔ball collision was handled."""
         ball = self._balls.get(candidate)
         if ball is None or not _shapes_hit(proj_shape, candidate):
             return False
@@ -257,6 +257,17 @@ class PhysicsWorld:
             # Skip self-collisions so a deflected projectile cannot immediately
             # hit its new owner.
             return False
+
+        weapon = view.get_weapon(ball.eid)
+        parry = view.get_parry(ball.eid)
+        if parry is not None:
+            parry.deflect_projectile(view, projectile, self._timestamp)
+            return True
+        reflector = getattr(weapon, "deflect_projectile", None)
+        if reflector is not None:
+            reflector(view, projectile, self._timestamp)
+            return True
+
         keep = projectile.on_hit(view, ball.eid, self._timestamp)
         if not keep:
             projectile.destroy()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,10 @@ class WorldView(Protocol):
 
     def iter_projectiles(self, excluding: EntityId | None = None) -> object: ...
 
+    def get_weapon(self, eid: EntityId) -> Weapon: ...
+
+    def get_parry(self, eid: EntityId) -> ParryEffect | None: ...
+
 
 class WeaponEffect(Protocol):
     owner: EntityId
@@ -71,8 +75,18 @@ class WeaponEffect(Protocol):
     def destroy(self) -> None: ...
 
 
+class Weapon(Protocol):
+    def step(self, dt: float) -> None: ...
+
+
+class ParryEffect(WeaponEffect, Protocol):
+    pass
+
+
 _weapons_base.WorldView = WorldView  # type: ignore[attr-defined]
 _weapons_base.WeaponEffect = WeaponEffect  # type: ignore[attr-defined]
+_weapons_base.Weapon = Weapon  # type: ignore[attr-defined]
+_weapons_base.ParryEffect = ParryEffect  # type: ignore[attr-defined]
 sys.modules.setdefault("app.weapons", types.ModuleType("app.weapons"))
 sys.modules["app.weapons.base"] = _weapons_base
 _shuriken_stub = types.ModuleType("app.weapons.shuriken")

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -12,6 +12,7 @@ from app.audio import BallAudio
 from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
 from app.game.controller import GameController, Player
 from app.weapons.base import Weapon, WeaponEffect, WorldView
+from app.weapons.parry import ParryEffect
 from app.world.entities import Ball
 from pymunk import Body
 
@@ -69,6 +70,12 @@ class StubWorldView(WorldView):
         self, excluding: EntityId | None = None
     ) -> list[ProjectileInfo]:  # pragma: no cover - unused
         return []
+
+    def get_weapon(self, eid: EntityId) -> Weapon:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    def get_parry(self, eid: EntityId) -> ParryEffect | None:  # pragma: no cover - unused
+        return None
 
 
 class DummyWorld:

--- a/tests/test_orbiting_rectangle.py
+++ b/tests/test_orbiting_rectangle.py
@@ -21,6 +21,12 @@ class DummyView:
     def get_enemy(self, owner: EntityId) -> EntityId | None:  # noqa: D401
         return self._enemy
 
+    def get_weapon(self, eid: EntityId) -> object:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    def get_parry(self, eid: EntityId) -> None:  # pragma: no cover - unused
+        return None
+
 
 class DummyProjectile:
     def __init__(self, velocity: Vec2) -> None:

--- a/tests/test_orbiting_sprite_collision.py
+++ b/tests/test_orbiting_sprite_collision.py
@@ -22,5 +22,6 @@ def test_orbiting_sprite_hits_enemy() -> None:
         speed=0.0,
     )
     controller.effects.append(blade)
-    controller._update_effects(0.0)
+    controller._step_effects()
+    controller._resolve_effect_hits(0.0)
     assert player_b.ball.health == 90.0

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -7,7 +7,8 @@ import pytest
 
 from app.ai.policy import SimplePolicy, policy_for_weapon
 from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
-from app.weapons.base import WeaponEffect, WorldView
+from app.weapons.base import Weapon, WeaponEffect, WorldView
+from app.weapons.parry import ParryEffect
 from app.weapons.shuriken import Shuriken
 from pymunk import Vec2 as Vec2d
 
@@ -23,6 +24,8 @@ class DummyView(WorldView):
     health_me: float = 1.0
     health_enemy: float = 1.0
     last_velocity: Vec2d | None = field(default=None, init=False)
+    weapons: dict[EntityId, Weapon] = field(default_factory=dict)
+    parries: dict[EntityId, ParryEffect] = field(default_factory=dict)
 
     def get_enemy(self, owner: EntityId) -> EntityId | None:  # noqa: D401
         return self.enemy
@@ -86,6 +89,12 @@ class DummyView(WorldView):
 
     def iter_projectiles(self, excluding: EntityId | None = None) -> list[ProjectileInfo]:  # noqa: D401
         return []
+
+    def get_weapon(self, eid: EntityId) -> Weapon:  # noqa: D401
+        return self.weapons[eid]
+
+    def get_parry(self, eid: EntityId) -> ParryEffect | None:  # noqa: D401
+        return self.parries.get(eid)
 
 
 def test_kiter_moves_away() -> None:

--- a/tests/test_policy_rng.py
+++ b/tests/test_policy_rng.py
@@ -5,7 +5,8 @@ from dataclasses import dataclass, field
 
 from app.ai.policy import SimplePolicy
 from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
-from app.weapons.base import WeaponEffect, WorldView
+from app.weapons.base import Weapon, WeaponEffect, WorldView
+from app.weapons.parry import ParryEffect
 
 
 @dataclass
@@ -17,6 +18,8 @@ class DummyView(WorldView):
     vel_me: Vec2 = (0.0, 0.0)
     vel_enemy: Vec2 = (0.0, 0.0)
     last_velocity: Vec2 | None = field(default=None, init=False)
+    weapons: dict[EntityId, Weapon] = field(default_factory=dict)
+    parries: dict[EntityId, ParryEffect] = field(default_factory=dict)
 
     def get_enemy(self, owner: EntityId) -> EntityId | None:  # noqa: D401
         return self.enemy
@@ -80,6 +83,12 @@ class DummyView(WorldView):
 
     def iter_projectiles(self, excluding: EntityId | None = None) -> list[ProjectileInfo]:  # noqa: D401
         return []
+
+    def get_weapon(self, eid: EntityId) -> Weapon:  # noqa: D401
+        return self.weapons[eid]
+
+    def get_parry(self, eid: EntityId) -> ParryEffect | None:  # noqa: D401
+        return self.parries.get(eid)
 
 
 def _collect_faces(seed: int) -> list[Vec2]:

--- a/tests/test_stateful_policy.py
+++ b/tests/test_stateful_policy.py
@@ -7,7 +7,8 @@ import pytest
 
 from app.ai.stateful_policy import Mode, State, StatefulPolicy, policy_for_weapon
 from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
-from app.weapons.base import WeaponEffect, WorldView
+from app.weapons.base import Weapon, WeaponEffect, WorldView
+from app.weapons.parry import ParryEffect
 
 
 @dataclass
@@ -20,6 +21,8 @@ class DummyView(WorldView):
     health_me: float = 1.0
     health_enemy: float = 1.0
     projectiles: list[ProjectileInfo] = field(default_factory=list)
+    weapons: dict[EntityId, Weapon] = field(default_factory=dict)
+    parries: dict[EntityId, ParryEffect] = field(default_factory=dict)
 
     def get_enemy(self, owner: EntityId) -> EntityId | None:  # noqa: D401
         return self.enemy
@@ -63,6 +66,12 @@ class DummyView(WorldView):
 
     def iter_projectiles(self, excluding: EntityId | None = None) -> list[ProjectileInfo]:  # noqa: D401
         return self.projectiles
+
+    def get_weapon(self, eid: EntityId) -> Weapon:  # noqa: D401
+        return self.weapons[eid]
+
+    def get_parry(self, eid: EntityId) -> ParryEffect | None:  # noqa: D401
+        return self.parries.get(eid)
 
 
 def test_attack_then_dodge() -> None:

--- a/tests/test_stateful_policy_rng.py
+++ b/tests/test_stateful_policy_rng.py
@@ -5,7 +5,8 @@ from dataclasses import dataclass, field
 
 from app.ai.stateful_policy import StatefulPolicy
 from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
-from app.weapons.base import WeaponEffect, WorldView
+from app.weapons.base import Weapon, WeaponEffect, WorldView
+from app.weapons.parry import ParryEffect
 
 
 @dataclass
@@ -16,6 +17,8 @@ class DummyView(WorldView):
     pos_enemy: Vec2
     vel_enemy: Vec2 = (0.0, 0.0)
     projectiles: list[ProjectileInfo] = field(default_factory=list)
+    weapons: dict[EntityId, Weapon] = field(default_factory=dict)
+    parries: dict[EntityId, ParryEffect] = field(default_factory=dict)
 
     def get_enemy(self, owner: EntityId) -> EntityId | None:  # noqa: D401
         return self.enemy
@@ -59,6 +62,12 @@ class DummyView(WorldView):
 
     def iter_projectiles(self, excluding: EntityId | None = None) -> list[ProjectileInfo]:  # noqa: D401
         return self.projectiles
+
+    def get_weapon(self, eid: EntityId) -> Weapon:  # noqa: D401
+        return self.weapons[eid]
+
+    def get_parry(self, eid: EntityId) -> ParryEffect | None:  # noqa: D401
+        return self.parries.get(eid)
 
 
 def _collect_faces(seed: int) -> list[Vec2]:

--- a/tests/test_weapon_audio_integration.py
+++ b/tests/test_weapon_audio_integration.py
@@ -13,8 +13,9 @@ sys.modules.pop("pygame.sndarray", None)
 import pygame as _pygame  # noqa: F401, E402  - ensure real pygame is loaded
 
 from app.audio.weapons import WeaponAudio  # noqa: E402
-from app.core.types import Damage, EntityId, Vec2  # noqa: E402
-from app.weapons.base import WeaponEffect, WorldView  # noqa: E402
+from app.core.types import Damage, EntityId, ProjectileInfo, Vec2  # noqa: E402
+from app.weapons.base import Weapon, WeaponEffect, WorldView  # noqa: E402
+from app.weapons.parry import ParryEffect  # noqa: E402
 from app.weapons.bazooka import Bazooka  # noqa: E402
 from app.weapons.katana import Katana  # noqa: E402
 from app.weapons.knife import Knife  # noqa: E402
@@ -83,11 +84,35 @@ class ProjectileView:
         self.projectile = proj
         return proj
 
-    def deal_damage(self, eid: EntityId, damage: Damage, timestamp: float) -> None:  # noqa: D401
-        pass
+    def get_enemy(self, owner: EntityId) -> EntityId | None:  # pragma: no cover - unused
+        return None
 
-    def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:  # noqa: D401
-        pass
+    def get_velocity(self, eid: EntityId) -> Vec2:  # pragma: no cover - unused
+        return (0.0, 0.0)
+
+    def get_health_ratio(self, eid: EntityId) -> float:  # pragma: no cover - unused
+        return 1.0
+
+    def deal_damage(self, eid: EntityId, damage: Damage, timestamp: float) -> None:  # pragma: no cover - unused
+        return None
+
+    def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:  # pragma: no cover - unused
+        return None
+
+    def add_speed_bonus(self, eid: EntityId, bonus: float) -> None:  # pragma: no cover - unused
+        return None
+
+    def spawn_effect(self, effect: WeaponEffect) -> None:  # pragma: no cover - unused
+        return None
+
+    def iter_projectiles(self, excluding: EntityId | None = None) -> list[ProjectileInfo]:  # pragma: no cover - unused
+        return []
+
+    def get_weapon(self, eid: EntityId) -> Weapon:  # pragma: no cover - unused
+        return cast(Weapon, object())
+
+    def get_parry(self, eid: EntityId) -> ParryEffect | None:  # pragma: no cover - unused
+        return None
 
 
 def test_katana_audio_events() -> None:

--- a/tests/test_weapon_critical.py
+++ b/tests/test_weapon_critical.py
@@ -6,7 +6,8 @@ from types import SimpleNamespace
 from typing import Any
 
 from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
-from app.weapons.base import WeaponEffect, WorldView
+from app.weapons.base import Weapon, WeaponEffect, WorldView
+from app.weapons.parry import ParryEffect
 from app.weapons.effects import OrbitingSprite
 
 
@@ -15,6 +16,8 @@ class DummyView(WorldView):
     owner: EntityId
     target: EntityId
     last_damage: float = field(default=0.0, init=False)
+    weapons: dict[EntityId, Weapon] = field(default_factory=dict)
+    parries: dict[EntityId, ParryEffect] = field(default_factory=dict)
 
     def get_enemy(self, owner: EntityId) -> EntityId | None:  # noqa: D401
         return self.target if owner == self.owner else self.owner
@@ -45,6 +48,12 @@ class DummyView(WorldView):
 
     def iter_projectiles(self, excluding: EntityId | None = None) -> Iterable[ProjectileInfo]:  # noqa: D401
         return []
+
+    def get_weapon(self, eid: EntityId) -> Weapon:  # noqa: D401
+        return self.weapons[eid]
+
+    def get_parry(self, eid: EntityId) -> ParryEffect | None:  # noqa: D401
+        return self.parries.get(eid)
 
 
 def test_orbiting_sprite_deals_critical_damage_when_owner_is_fast() -> None:

--- a/tests/unit/test_katana_deflect.py
+++ b/tests/unit/test_katana_deflect.py
@@ -12,7 +12,8 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
 import pygame
 
 from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
-from app.weapons.base import WeaponEffect, WorldView
+from app.weapons.base import Weapon, WeaponEffect, WorldView
+from app.weapons.parry import ParryEffect
 from app.weapons.effects import OrbitingRectangle
 from app.world.entities import DEFAULT_BALL_RADIUS
 from app.world.physics import PhysicsWorld
@@ -25,6 +26,8 @@ class DummyView(WorldView):
 
     positions: dict[EntityId, Vec2]
     enemies: dict[EntityId, EntityId]
+    weapons: dict[EntityId, Weapon] = field(default_factory=dict)
+    parries: dict[EntityId, ParryEffect] = field(default_factory=dict)
     damage: dict[EntityId, float] = field(default_factory=dict)
 
     def get_enemy(self, owner: EntityId) -> EntityId | None:  # noqa: D401
@@ -69,6 +72,12 @@ class DummyView(WorldView):
 
     def iter_projectiles(self, excluding: EntityId | None = None) -> list[ProjectileInfo]:  # noqa: D401
         return []
+
+    def get_weapon(self, eid: EntityId) -> Weapon:  # noqa: D401
+        return self.weapons[eid]
+
+    def get_parry(self, eid: EntityId) -> ParryEffect | None:  # noqa: D401
+        return self.parries.get(eid)
 
 
 def _make_katana(owner: EntityId) -> OrbitingRectangle:

--- a/tests/unit/test_knife_deflect.py
+++ b/tests/unit/test_knife_deflect.py
@@ -1,19 +1,23 @@
 """Verify knife's deflection and contact mechanics."""
 
+# ruff: noqa: I001
+
 from __future__ import annotations
 
 import pathlib
 import sys
 from dataclasses import dataclass, field
-
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+from typing import cast
 
 import pygame
 
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
 from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
-from app.weapons.base import WeaponEffect, WorldView
+from app.weapons.base import Weapon, WeaponEffect, WorldView
 from app.weapons.effects import OrbitingRectangle
-from app.world.entities import DEFAULT_BALL_RADIUS
+from app.weapons.parry import ParryEffect
+from app.world.entities import Ball, DEFAULT_BALL_RADIUS
 from app.world.physics import PhysicsWorld
 from app.world.projectiles import Projectile
 
@@ -24,6 +28,8 @@ class DummyView(WorldView):
 
     positions: dict[EntityId, Vec2]
     enemies: dict[EntityId, EntityId]
+    weapons: dict[EntityId, Weapon] = field(default_factory=dict)
+    parries: dict[EntityId, ParryEffect] = field(default_factory=dict)
     damage: dict[EntityId, float] = field(default_factory=dict)
 
     def get_enemy(self, owner: EntityId) -> EntityId | None:  # noqa: D401
@@ -68,6 +74,12 @@ class DummyView(WorldView):
 
     def iter_projectiles(self, excluding: EntityId | None = None) -> list[ProjectileInfo]:  # noqa: D401
         return []
+
+    def get_weapon(self, eid: EntityId) -> Weapon:  # noqa: D401
+        return self.weapons[eid]
+
+    def get_parry(self, eid: EntityId) -> ParryEffect | None:  # noqa: D401
+        return self.parries.get(eid)
 
 
 def _make_knife(owner: EntityId) -> OrbitingRectangle:
@@ -119,31 +131,34 @@ def test_knife_deflects_projectile() -> None:
     assert view.damage[enemy] == 5
 
 
-def test_knife_does_not_deflect_body_hit() -> None:
+def test_projectile_deflected_on_body_hit() -> None:
     pygame.init()
     world = PhysicsWorld()
-    owner = EntityId(1)
+    owner_ball = Ball.spawn(world, (0.0, 0.0))
+    owner = owner_ball.eid
     enemy = EntityId(2)
-    positions = {owner: (0.0, 0.0), enemy: (150.0, 0.0)}
-    enemies = {owner: enemy, enemy: owner}
-    view = DummyView(positions, enemies)
-    knife = _make_knife(owner)
     projectile = Projectile.spawn(
         world,
         owner=enemy,
         position=(0.0, 0.0),
-        velocity=(-100.0, 0.0),
+        velocity=(100.0, 0.0),
         radius=1.0,
         damage=Damage(5),
         knockback=0.0,
         ttl=1.0,
     )
-    projectile.ttl = 0.1
-    pos = (float(projectile.body.position.x), float(projectile.body.position.y))
-    assert not knife.collides(view, pos, float(projectile.shape.radius))
-
-    projectile.on_hit(view, owner, timestamp=0.0)
-    assert view.damage[owner] == 5
+    parry = ParryEffect(owner=owner, radius=80.0, duration=1.0)
+    positions = {owner: (0.0, 0.0), enemy: (150.0, 0.0)}
+    enemies = {owner: enemy, enemy: owner}
+    weapons = {
+        owner: cast(Weapon, object()),
+        enemy: cast(Weapon, object()),
+    }
+    view = DummyView(positions, enemies, weapons=weapons, parries={owner: parry})
+    world.set_context(view, 0.0)
+    world.step(0.1)
+    assert view.damage == {}
+    assert projectile.owner == owner
 
 
 def test_knife_hits_enemy_ball() -> None:

--- a/tests/unit/test_orbiting_sprite_cooldown.py
+++ b/tests/unit/test_orbiting_sprite_cooldown.py
@@ -4,7 +4,8 @@ from dataclasses import dataclass, field
 import pygame
 
 from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
-from app.weapons.base import WeaponEffect, WorldView
+from app.weapons.base import Weapon, WeaponEffect, WorldView
+from app.weapons.parry import ParryEffect
 from app.weapons.effects import OrbitingSprite
 
 
@@ -12,6 +13,8 @@ from app.weapons.effects import OrbitingSprite
 class DummyView(WorldView):
     positions: dict[EntityId, Vec2]
     enemies: dict[EntityId, EntityId]
+    weapons: dict[EntityId, Weapon] = field(default_factory=dict)
+    parries: dict[EntityId, ParryEffect] = field(default_factory=dict)
     damage: dict[EntityId, float] = field(default_factory=dict)
 
     def get_enemy(self, owner: EntityId) -> EntityId | None:
@@ -56,6 +59,12 @@ class DummyView(WorldView):
 
     def iter_projectiles(self, excluding: EntityId | None = None) -> list[ProjectileInfo]:
         return []
+
+    def get_weapon(self, eid: EntityId) -> Weapon:
+        return self.weapons[eid]
+
+    def get_parry(self, eid: EntityId) -> ParryEffect | None:
+        return self.parries.get(eid)
 
 
 def test_orbiting_sprite_requires_half_turn_between_hits() -> None:

--- a/tests/unit/test_orbiting_sprite_knockback.py
+++ b/tests/unit/test_orbiting_sprite_knockback.py
@@ -3,7 +3,8 @@ from dataclasses import dataclass, field
 import pygame
 
 from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
-from app.weapons.base import WeaponEffect, WorldView
+from app.weapons.base import Weapon, WeaponEffect, WorldView
+from app.weapons.parry import ParryEffect
 from app.weapons.effects import OrbitingSprite
 
 
@@ -11,6 +12,8 @@ from app.weapons.effects import OrbitingSprite
 class DummyView(WorldView):
     positions: dict[EntityId, Vec2]
     impulses: dict[EntityId, Vec2] = field(default_factory=dict)
+    weapons: dict[EntityId, Weapon] = field(default_factory=dict)
+    parries: dict[EntityId, ParryEffect] = field(default_factory=dict)
 
     def get_enemy(self, owner: EntityId) -> EntityId | None:
         return None
@@ -54,6 +57,12 @@ class DummyView(WorldView):
 
     def iter_projectiles(self, excluding: EntityId | None = None) -> list[ProjectileInfo]:
         return []
+
+    def get_weapon(self, eid: EntityId) -> Weapon:
+        return self.weapons[eid]
+
+    def get_parry(self, eid: EntityId) -> ParryEffect | None:
+        return self.parries.get(eid)
 
 
 def test_orbiting_sprite_applies_knockback() -> None:

--- a/tests/unit/test_parry_owner.py
+++ b/tests/unit/test_parry_owner.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 import pygame
 
 from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
-from app.weapons.base import WeaponEffect, WorldView
+from app.weapons.base import Weapon, WeaponEffect, WorldView
 from app.weapons.parry import ParryEffect
 from app.world.entities import Ball
 from app.world.physics import PhysicsWorld
@@ -14,6 +14,8 @@ from app.world.projectiles import Projectile
 class DummyView(WorldView):
     positions: dict[EntityId, Vec2]
     enemies: dict[EntityId, EntityId]
+    weapons: dict[EntityId, Weapon] = field(default_factory=dict)
+    parries: dict[EntityId, ParryEffect] = field(default_factory=dict)
     damage: dict[EntityId, float] = field(default_factory=dict)
 
     def get_enemy(self, owner: EntityId) -> EntityId | None:
@@ -58,6 +60,12 @@ class DummyView(WorldView):
 
     def iter_projectiles(self, excluding: EntityId | None = None) -> list[ProjectileInfo]:  # noqa: D401
         return []
+
+    def get_weapon(self, eid: EntityId) -> Weapon:  # noqa: D401
+        return self.weapons[eid]
+
+    def get_parry(self, eid: EntityId) -> ParryEffect | None:  # noqa: D401
+        return self.parries.get(eid)
 
 
 def test_deflected_projectile_cannot_hit_new_owner() -> None:

--- a/tests/unit/test_policy_angles.py
+++ b/tests/unit/test_policy_angles.py
@@ -4,7 +4,8 @@ from dataclasses import dataclass, field
 
 from app.ai.policy import SimplePolicy
 from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
-from app.weapons.base import WeaponEffect, WorldView
+from app.weapons.base import Weapon, WeaponEffect, WorldView
+from app.weapons.parry import ParryEffect
 from app.weapons.shuriken import Shuriken
 from pymunk import Vec2 as Vec2d
 
@@ -17,6 +18,8 @@ class DummyView(WorldView):
     pos_enemy: Vec2
     vel_me: Vec2 = (0.0, 0.0)
     vel_enemy: Vec2 = (0.0, 0.0)
+    weapons: dict[EntityId, Weapon] = field(default_factory=dict)
+    parries: dict[EntityId, ParryEffect] = field(default_factory=dict)
     last_velocity: Vec2d | None = field(default=None, init=False)
 
     def get_enemy(self, owner: EntityId) -> EntityId | None:  # noqa: D401
@@ -81,6 +84,12 @@ class DummyView(WorldView):
 
     def iter_projectiles(self, excluding: EntityId | None = None) -> list[ProjectileInfo]:  # noqa: D401
         return []
+
+    def get_weapon(self, eid: EntityId) -> Weapon:  # noqa: D401
+        return self.weapons[eid]
+
+    def get_parry(self, eid: EntityId) -> ParryEffect | None:  # noqa: D401
+        return self.parries.get(eid)
 
 
 def test_policy_angle_has_vertical_component() -> None:

--- a/tests/unit/test_projectile_collision_cooldown.py
+++ b/tests/unit/test_projectile_collision_cooldown.py
@@ -5,7 +5,8 @@ from dataclasses import dataclass, field
 import pygame
 
 from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
-from app.weapons.base import WeaponEffect, WorldView
+from app.weapons.base import Weapon, WeaponEffect, WorldView
+from app.weapons.parry import ParryEffect
 from app.world.physics import PhysicsWorld
 from app.world.projectiles import Projectile
 
@@ -15,6 +16,8 @@ class DummyView(WorldView):
     positions: dict[EntityId, Vec2]
     velocities: dict[EntityId, Vec2]
     enemies: dict[EntityId, EntityId]
+    weapons: dict[EntityId, Weapon] = field(default_factory=dict)
+    parries: dict[EntityId, ParryEffect] = field(default_factory=dict)
     damage: dict[EntityId, float] = field(default_factory=dict)
 
     def get_enemy(self, owner: EntityId) -> EntityId | None:
@@ -59,6 +62,12 @@ class DummyView(WorldView):
 
     def iter_projectiles(self, excluding: EntityId | None = None) -> list[ProjectileInfo]:
         return []
+
+    def get_weapon(self, eid: EntityId) -> Weapon:
+        return self.weapons[eid]
+
+    def get_parry(self, eid: EntityId) -> ParryEffect | None:
+        return self.parries.get(eid)
 
 
 def test_projectile_collision_cooldown() -> None:

--- a/tests/unit/test_projectile_exchange.py
+++ b/tests/unit/test_projectile_exchange.py
@@ -5,7 +5,8 @@ import pygame
 
 from app.audio.weapons import WeaponAudio
 from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
-from app.weapons.base import WeaponEffect, WorldView
+from app.weapons.base import Weapon, WeaponEffect, WorldView
+from app.weapons.parry import ParryEffect
 from app.world.physics import PhysicsWorld
 from app.world.projectiles import Projectile
 
@@ -15,6 +16,8 @@ class DummyView(WorldView):
     positions: dict[EntityId, Vec2]
     velocities: dict[EntityId, Vec2]
     enemies: dict[EntityId, EntityId]
+    weapons: dict[EntityId, Weapon] = field(default_factory=dict)
+    parries: dict[EntityId, ParryEffect] = field(default_factory=dict)
     damage: dict[EntityId, float] = field(default_factory=dict)
 
     def get_enemy(self, owner: EntityId) -> EntityId | None:
@@ -59,6 +62,12 @@ class DummyView(WorldView):
 
     def iter_projectiles(self, excluding: EntityId | None = None) -> list[ProjectileInfo]:
         return []
+
+    def get_weapon(self, eid: EntityId) -> Weapon:
+        return self.weapons[eid]
+
+    def get_parry(self, eid: EntityId) -> ParryEffect | None:
+        return self.parries.get(eid)
 
 
 class StubAudio:

--- a/tests/unit/test_weapons.py
+++ b/tests/unit/test_weapons.py
@@ -13,6 +13,7 @@ from app.render.renderer import Renderer
 from app.video.recorder import NullRecorder
 from app.weapons import weapon_registry
 from app.weapons.base import Weapon, WeaponEffect, WorldView
+from app.weapons.parry import ParryEffect
 from app.weapons.bazooka import Bazooka
 from app.weapons.katana import Katana
 from app.weapons.knife import Knife
@@ -28,6 +29,8 @@ class DummyView(WorldView):
     speed_bonus: dict[EntityId, float] = field(default_factory=dict)
     effects: list[WeaponEffect] = field(default_factory=list)
     projectiles: list[dict[str, object]] = field(default_factory=list)
+    weapons: dict[EntityId, Weapon] = field(default_factory=dict)
+    parries: dict[EntityId, ParryEffect] = field(default_factory=dict)
 
     def get_enemy(self, owner: EntityId) -> EntityId | None:  # noqa: D401
         return self.enemy
@@ -103,6 +106,12 @@ class DummyView(WorldView):
     def add_speed_bonus(self, eid: EntityId, bonus: float) -> None:  # noqa: D401
         self.speed_bonus[eid] = self.speed_bonus.get(eid, 0.0) + bonus
 
+    def get_weapon(self, eid: EntityId) -> Weapon:  # noqa: D401
+        return self.weapons[eid]
+
+    def get_parry(self, eid: EntityId) -> ParryEffect | None:  # noqa: D401
+        return self.parries.get(eid)
+
 
 def test_weapon_speed_attribute() -> None:
     """Weapons expose their projectile speed on the base class."""
@@ -172,6 +181,8 @@ class _OrientView(WorldView):
     enemy_pos: Vec2
     effects: list[WeaponEffect] = field(default_factory=list)
     projectile: object | None = None
+    weapons: dict[EntityId, Weapon] = field(default_factory=dict)
+    parries: dict[EntityId, ParryEffect] = field(default_factory=dict)
 
     def get_enemy(self, owner: EntityId) -> EntityId | None:  # noqa: D401
         return self.enemy
@@ -236,6 +247,12 @@ class _OrientView(WorldView):
 
     def add_speed_bonus(self, eid: EntityId, bonus: float) -> None:  # noqa: D401
         return None
+
+    def get_weapon(self, eid: EntityId) -> Weapon:  # noqa: D401
+        return self.weapons[eid]
+
+    def get_parry(self, eid: EntityId) -> ParryEffect | None:  # noqa: D401
+        return self.parries.get(eid)
 
 
 def test_bazooka_sprite_and_projectile_orientation() -> None:

--- a/tests/weapons/test_gravity_well.py
+++ b/tests/weapons/test_gravity_well.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
-from app.weapons.base import WeaponEffect, WorldView
+from app.weapons.base import Weapon, WeaponEffect, WorldView
+from app.weapons.parry import ParryEffect
 from app.weapons.effects import GravityWellEffect
 
 
@@ -12,6 +13,8 @@ class DummyView(WorldView):
     positions: dict[EntityId, Vec2]
     impulses: dict[EntityId, Vec2] = field(default_factory=dict)
     damage: dict[EntityId, float] = field(default_factory=dict)
+    weapons: dict[EntityId, Weapon] = field(default_factory=dict)
+    parries: dict[EntityId, ParryEffect] = field(default_factory=dict)
 
     def get_enemy(self, owner: EntityId) -> EntityId | None:  # pragma: no cover - unused
         return None
@@ -42,6 +45,12 @@ class DummyView(WorldView):
 
     def iter_projectiles(self, excluding: EntityId | None = None) -> list[ProjectileInfo]:  # pragma: no cover - unused
         return []
+
+    def get_weapon(self, eid: EntityId) -> Weapon:  # pragma: no cover - unused
+        return self.weapons[eid]
+
+    def get_parry(self, eid: EntityId) -> ParryEffect | None:  # pragma: no cover - unused
+        return self.parries.get(eid)
 
 
 def test_gravity_well_attracts_target() -> None:

--- a/tests/weapons/test_resonance_hammer.py
+++ b/tests/weapons/test_resonance_hammer.py
@@ -13,7 +13,8 @@ if "app" in sys.modules:
     del sys.modules["app"]
 
 from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
-from app.weapons.base import WeaponEffect, WorldView
+from app.weapons.base import Weapon, WeaponEffect, WorldView
+from app.weapons.parry import ParryEffect
 from app.weapons.effects import ResonanceWaveEffect
 
 
@@ -21,6 +22,8 @@ from app.weapons.effects import ResonanceWaveEffect
 class DummyView(WorldView):
     positions: dict[EntityId, Vec2]
     damage: dict[EntityId, float] = field(default_factory=dict)
+    weapons: dict[EntityId, Weapon] = field(default_factory=dict)
+    parries: dict[EntityId, ParryEffect] = field(default_factory=dict)
 
     def get_enemy(self, owner: EntityId) -> EntityId | None:  # pragma: no cover - unused
         return None
@@ -51,6 +54,12 @@ class DummyView(WorldView):
 
     def iter_projectiles(self, excluding: EntityId | None = None) -> list[ProjectileInfo]:  # pragma: no cover - unused
         return []
+
+    def get_weapon(self, eid: EntityId) -> Weapon:  # pragma: no cover - unused
+        return self.weapons[eid]
+
+    def get_parry(self, eid: EntityId) -> ParryEffect | None:  # pragma: no cover - unused
+        return self.parries.get(eid)
 
 
 def test_resonance_wave_reflects_and_amplifies() -> None:


### PR DESCRIPTION
## Summary
- expose player weapons and active parry effects through the world view
- deflect projectiles in physics when a ball is protected
- simulate defensive effects before physics collisions
- replace body-hit knife test with parry deflection scenario

## Testing
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'imageio_ffmpeg')*


------
https://chatgpt.com/codex/tasks/task_e_68b8298a30fc832a8ffe29eb421e7367