### PR TITLE
fix: avoid deflecting contact weapon body hits

### DIFF
--- a/app/world/physics.py
+++ b/app/world/physics.py
@@ -263,10 +263,11 @@ class PhysicsWorld:
         if parry is not None:
             parry.deflect_projectile(view, projectile, self._timestamp)
             return True
-        reflector = getattr(weapon, "deflect_projectile", None)
-        if reflector is not None:
-            reflector(view, projectile, self._timestamp)
-            return True
+        if getattr(weapon, "range_type", "contact") != "contact":
+            reflector = getattr(weapon, "deflect_projectile", None)
+            if reflector is not None:
+                reflector(view, projectile, self._timestamp)
+                return True
 
         keep = projectile.on_hit(view, ball.eid, self._timestamp)
         if not keep:

--- a/tests/world/test_contact_weapon_deflection.py
+++ b/tests/world/test_contact_weapon_deflection.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import cast
+
+import pygame
+
+from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
+from app.weapons.base import Weapon, WeaponEffect, WorldView
+from app.weapons.effects import OrbitingRectangle
+from app.weapons.parry import ParryEffect
+from app.world.entities import DEFAULT_BALL_RADIUS, Ball
+from app.world.physics import PhysicsWorld
+from app.world.projectiles import Projectile
+
+
+@dataclass
+class DummyView(WorldView):
+    """Minimal ``WorldView`` implementation for projectile tests."""
+
+    positions: dict[EntityId, Vec2]
+    weapons: dict[EntityId, Weapon]
+    damage: dict[EntityId, float] = field(default_factory=dict)
+
+    def get_enemy(self, owner: EntityId) -> EntityId | None:  # noqa: D401
+        return None
+
+    def get_position(self, eid: EntityId) -> Vec2:  # noqa: D401
+        return self.positions[eid]
+
+    def get_velocity(self, eid: EntityId) -> Vec2:  # noqa: D401
+        return (0.0, 0.0)
+
+    def get_health_ratio(self, eid: EntityId) -> float:  # noqa: D401
+        return 1.0
+
+    def deal_damage(self, eid: EntityId, damage: Damage, timestamp: float) -> None:  # noqa: D401
+        self.damage[eid] = self.damage.get(eid, 0.0) + damage.amount
+
+    def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:  # noqa: D401
+        return None
+
+    def spawn_effect(self, effect: WeaponEffect) -> None:  # noqa: D401
+        return None
+
+    def add_speed_bonus(self, eid: EntityId, bonus: float) -> None:  # noqa: D401
+        return None
+
+    def spawn_projectile(
+        self,
+        owner: EntityId,
+        position: Vec2,
+        velocity: Vec2,
+        radius: float,
+        damage: Damage,
+        knockback: float,
+        ttl: float,
+        sprite: pygame.Surface | None = None,
+        spin: float = 0.0,
+        trail_color: tuple[int, int, int] | None = None,
+        acceleration: float = 0.0,
+    ) -> WeaponEffect:  # noqa: D401
+        raise NotImplementedError
+
+    def iter_projectiles(self, excluding: EntityId | None = None) -> list[ProjectileInfo]:  # noqa: D401
+        return []
+
+    def get_weapon(self, eid: EntityId) -> Weapon:  # noqa: D401
+        return self.weapons[eid]
+
+    def get_parry(self, eid: EntityId) -> ParryEffect | None:  # noqa: D401
+        return None
+
+
+class DummyContactWeapon:
+    """Contact weapon stub tracking deflection calls."""
+
+    range_type = "contact"
+
+    def __init__(self) -> None:
+        self.deflected = False
+
+    def deflect_projectile(self, view: WorldView, projectile: Projectile, timestamp: float) -> None:  # noqa: D401
+        self.deflected = True
+
+
+def test_contact_weapon_body_hit_applies_damage() -> None:
+    pygame.init()
+    world = PhysicsWorld()
+    owner_ball = Ball.spawn(world, (0.0, 0.0))
+    owner = owner_ball.eid
+    enemy = EntityId(2)
+    weapon = DummyContactWeapon()
+    positions = {owner: (0.0, 0.0), enemy: (100.0, 0.0)}
+    view = DummyView(positions, {owner: cast(Weapon, weapon), enemy: cast(Weapon, object())})
+    projectile = Projectile.spawn(
+        world,
+        owner=enemy,
+        position=(0.0, 0.0),
+        velocity=(0.0, 0.0),
+        radius=1.0,
+        damage=Damage(5),
+        knockback=0.0,
+        ttl=1.0,
+    )
+    world.set_context(view, 0.0)
+    world.step(0.1)
+    assert view.damage[owner] == 5
+    assert weapon.deflected is False
+    assert projectile.owner == enemy
+
+
+def test_contact_weapon_hitbox_collision_deflects_projectile() -> None:
+    pygame.init()
+    world = PhysicsWorld()
+    owner = EntityId(1)
+    enemy = EntityId(2)
+    positions = {owner: (0.0, 0.0), enemy: (100.0, 0.0)}
+    weapon = DummyContactWeapon()
+    view = DummyView(positions, {owner: cast(Weapon, weapon), enemy: cast(Weapon, object())})
+    effect = OrbitingRectangle(
+        owner=owner,
+        damage=Damage(5),
+        width=DEFAULT_BALL_RADIUS / 4.0,
+        height=DEFAULT_BALL_RADIUS * 2.0,
+        offset=DEFAULT_BALL_RADIUS * 2.0,
+        angle=0.0,
+        speed=0.0,
+    )
+    projectile = Projectile.spawn(
+        world,
+        owner=enemy,
+        position=(effect.offset, 0.0),
+        velocity=(-100.0, 0.0),
+        radius=1.0,
+        damage=Damage(5),
+        knockback=0.0,
+        ttl=1.0,
+    )
+    pos = (float(projectile.body.position.x), float(projectile.body.position.y))
+    assert effect.collides(view, pos, float(projectile.shape.radius))
+    effect.deflect_projectile(view, projectile, timestamp=0.0)
+    assert projectile.owner == owner
+    assert view.damage == {}


### PR DESCRIPTION
## Summary
- ensure contact weapons don't deflect projectiles that hit the player's body
- test contact weapons for body damage and weapon-hitbox deflection

## Testing
- `uv run ruff check app/world/physics.py tests/world/test_contact_weapon_deflection.py`
- `uv run mypy app/world/physics.py tests/world/test_contact_weapon_deflection.py`
- `uv run pytest tests/world/test_contact_weapon_deflection.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68b832ba728c832a8b73dba10651594d