### PR TITLE
fix: align stateful shuriken policy with ranged behavior

### DIFF
--- a/app/ai/stateful_policy.py
+++ b/app/ai/stateful_policy.py
@@ -327,11 +327,13 @@ def policy_for_weapon(
     if my_range == "distant":
         style: Literal["evader", "kiter"] = "evader" if enemy_range == "contact" else "kiter"
         fire_factor = 0.0 if style == "evader" else float("inf")
+        fire_out = weapon_name == "shuriken"
         return StatefulPolicy(
             style,
             range_type=my_range,
             transition_time=transition_time,
             fire_range_factor=fire_factor,
+            fire_out_of_range=fire_out,
             rng=rng,
         )
 

--- a/tests/test_stateful_policy.py
+++ b/tests/test_stateful_policy.py
@@ -212,6 +212,22 @@ def test_policy_for_weapon_range_combinations(
     assert policy.fire_range_factor == expected_factor
 
 
+def test_shuriken_stateful_policy_fires_when_enemy_far() -> None:
+    view = DummyView(EntityId(1), EntityId(2), (0.0, 0.0), (1000.0, 0.0))
+    policy = policy_for_weapon("shuriken", "katana", transition_time=0.0)
+    _, _, fire, parry = policy.decide(EntityId(1), view, 0.0, 600.0)
+    assert fire is True
+    assert parry is False
+
+
+def test_bazooka_stateful_policy_no_fire_when_enemy_far() -> None:
+    view = DummyView(EntityId(1), EntityId(2), (0.0, 0.0), (1000.0, 0.0))
+    policy = policy_for_weapon("bazooka", "katana", transition_time=0.0)
+    _, _, fire, parry = policy.decide(EntityId(1), view, 0.0, 300.0)
+    assert fire is False
+    assert parry is False
+
+
 def test_stateful_evader_moves_toward_offscreen_enemy() -> None:
     me = EntityId(1)
     enemy = EntityId(2)


### PR DESCRIPTION
## Summary
- ensure stateful shuriken users fire when out of range
- cover ranged firing behavior for stateful policies in tests

## Testing
- `uv run ruff check .` *(fails: import block is un-sorted or un-formatted)*
- `uv run ruff check app/ai/stateful_policy.py tests/test_stateful_policy.py`
- `uv run mypy .`
- `uv run pytest` *(fails: Interrupted: 55 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b832b0fcac832ab9fde883fd257c9a