### PR TITLE
feat: track projectile destruction state

### DIFF
--- a/app/world/physics.py
+++ b/app/world/physics.py
@@ -219,7 +219,7 @@ class PhysicsWorld:
             other_proj is None
             or candidate in processed
             or candidate is proj_shape
-            or getattr(other_proj, "destroyed", False)
+            or other_proj.destroyed
             or not _shapes_hit(proj_shape, candidate)
         ):
             return False
@@ -289,7 +289,7 @@ class PhysicsWorld:
         processed: set[pymunk.Shape] = set()
 
         for proj_shape, projectile in list(self._projectiles.items()):
-            if getattr(projectile, "destroyed", False):
+            if projectile.destroyed:
                 continue
 
             for candidate in self._index.query(proj_shape):

--- a/app/world/projectiles.py
+++ b/app/world/projectiles.py
@@ -45,6 +45,7 @@ class Projectile(WeaponEffect):
     acceleration: float = 0.0
     bounces: int = 0
     last_velocity: Vec2d = field(default_factory=lambda: Vec2d(0.0, 0.0))
+    destroyed: bool = False
 
     @classmethod
     def spawn(
@@ -172,5 +173,6 @@ class Projectile(WeaponEffect):
             renderer.draw_circle_outline(pos, float(self.shape.radius), (0, 255, 0))
 
     def destroy(self) -> None:
+        self.destroyed = True
         self.world.unregister_projectile(self)
         self.world.space.remove(self.body, self.shape)


### PR DESCRIPTION
## Summary
- add `destroyed` flag to projectiles and set during `destroy()`
- rely on `destroyed` attribute to skip removed projectiles during collision processing

## Testing
- `make lint` *(fails: Import block is un-sorted or un-formatted)*
- `uv run ruff check app/world/projectiles.py app/world/physics.py`
- `uv run mypy app/world/projectiles.py app/world/physics.py`
- `make test` *(fails: pytest: error: unrecognized arguments: --cov=.)*
- `uv run pytest` *(fails: 56 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b835bb3330832ab6e38b69bf9dda9c