### PR TITLE
feat: render sprites for melee weapons

### DIFF
--- a/app/weapons/effects.py
+++ b/app/weapons/effects.py
@@ -186,6 +186,7 @@ class OrbitingRectangle(WeaponEffect):
     knockback: float = 0.0
     audio: WeaponAudio | None = None
     hit_times: dict[EntityId, float] = field(default_factory=dict)
+    sprite: pygame.Surface | None = None
 
     def __post_init__(self) -> None:
         if self.offset <= DEFAULT_BALL_RADIUS:
@@ -253,8 +254,10 @@ class OrbitingRectangle(WeaponEffect):
             projectile.audio.on_touch(timestamp)
 
     def draw(self, renderer: Renderer, view: WorldView) -> None:  # noqa: D401
+        center = self._center(view)
+        if self.sprite is not None:
+            renderer.draw_sprite(self.sprite, center, self.angle)
         if renderer.debug:
-            center = self._center(view)
             c, s = math.cos(self.angle), math.sin(self.angle)
             tc, ts = -s, c
             hw, hh = self.width / 2, self.height / 2

--- a/app/weapons/katana.py
+++ b/app/weapons/katana.py
@@ -50,6 +50,7 @@ class Katana(Weapon):
                 speed=self.speed,
                 knockback=220.0,
                 audio=self.audio,
+                sprite=self._sprite,
             )
             view.spawn_effect(effect)
             self.audio.start_idle()

--- a/app/weapons/knife.py
+++ b/app/weapons/knife.py
@@ -52,6 +52,7 @@ class Knife(Weapon):
                 speed=self.speed,
                 knockback=120.0,
                 audio=self.audio,
+                sprite=self._sprite,
             )
             view.spawn_effect(effect)
             self.audio.start_idle()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,28 @@ sys.modules.setdefault("app.render.renderer", _renderer_stub)
 
 sys.modules.setdefault("numpy", types.ModuleType("numpy"))
 
+# Provide a minimal pydantic stub so configuration modules can be imported.
+_pydantic_stub = types.ModuleType("pydantic")
+
+
+class _BaseModel:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    @classmethod
+    def model_validate(cls, data: dict[str, object]) -> _BaseModel:
+        return cls(**data)
+
+
+def _field(default: object, **_kwargs: object) -> object:  # pragma: no cover - simple stub
+    return default
+
+
+_pydantic_stub.BaseModel = _BaseModel  # type: ignore[attr-defined]
+_pydantic_stub.Field = _field  # type: ignore[attr-defined]
+sys.modules.setdefault("pydantic", _pydantic_stub)
+
 
 class WorldView(Protocol):
     def get_enemy(self, owner: EntityId) -> EntityId | None: ...

--- a/tests/test_orbiting_rectangle.py
+++ b/tests/test_orbiting_rectangle.py
@@ -25,6 +25,9 @@ class DummyView:
     def get_weapon(self, eid: EntityId) -> object:  # pragma: no cover - unused
         raise NotImplementedError
 
+    def get_velocity(self, eid: EntityId) -> Vec2:  # pragma: no cover - unused
+        return (0.0, 0.0)
+
     def deal_damage(self, eid: EntityId, damage: Damage, timestamp: float) -> None:
         self.damage[eid] = self.damage.get(eid, 0.0) + damage.amount
 

--- a/tests/weapons/test_melee_sprite_effect.py
+++ b/tests/weapons/test_melee_sprite_effect.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass, field
+from typing import cast
+
+import pygame
+
+from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
+
+
+class _Surface:
+    def get_width(self) -> int:  # pragma: no cover - simple stub
+        return 10
+
+    def get_height(self) -> int:  # pragma: no cover - simple stub
+        return 10
+
+    def get_size(self) -> tuple[int, int]:  # pragma: no cover - simple stub
+        return (self.get_width(), self.get_height())
+
+
+pygame.Surface = _Surface
+pygame.transform = types.SimpleNamespace(rotate=lambda surf, angle: surf)
+pygame.mixer = types.SimpleNamespace(init=lambda **kwargs: None)
+
+
+assets_mod = types.ModuleType("app.weapons.assets")
+
+
+def _load_weapon_sprite(name: str, max_dim: float | None = None) -> pygame.Surface:
+    return _Surface()
+
+
+assets_mod.load_weapon_sprite = _load_weapon_sprite  # type: ignore[attr-defined]
+sys.modules.setdefault("app.weapons.assets", assets_mod)
+
+
+audio_mod = types.ModuleType("app.audio.weapons")
+
+
+class _WeaponAudio:
+    def __init__(self, *args: object, **kwargs: object) -> None:  # noqa: D401
+        return None
+
+    def start_idle(self) -> None:  # noqa: D401
+        return None
+
+    def on_touch(self, timestamp: float) -> None:  # noqa: D401
+        return None
+
+
+audio_mod.WeaponAudio = _WeaponAudio  # type: ignore[attr-defined]
+sys.modules.setdefault("app.audio.weapons", audio_mod)
+
+from app.weapons.base import Weapon, WeaponEffect, WorldView  # noqa: E402
+from app.weapons.katana import Katana  # noqa: E402
+from app.weapons.knife import Knife  # noqa: E402
+
+
+@dataclass(slots=True)
+class DummyView(WorldView):
+    positions: dict[EntityId, Vec2]
+    effects: list[WeaponEffect] = field(default_factory=list)
+    speed_bonus: dict[EntityId, float] = field(default_factory=dict)
+
+    def get_position(self, eid: EntityId) -> Vec2:  # noqa: D401
+        return self.positions[eid]
+
+    def get_velocity(self, eid: EntityId) -> Vec2:  # pragma: no cover - unused
+        return (0.0, 0.0)
+
+    def get_health_ratio(self, eid: EntityId) -> float:  # pragma: no cover - unused
+        return 1.0
+
+    def deal_damage(self, eid: EntityId, damage: Damage, timestamp: float) -> None:  # noqa: D401
+        return None
+
+    def apply_impulse(self, eid: EntityId, vx: float, vy: float) -> None:  # noqa: D401
+        return None
+
+    def add_speed_bonus(self, eid: EntityId, bonus: float) -> None:  # noqa: D401
+        self.speed_bonus[eid] = self.speed_bonus.get(eid, 0.0) + bonus
+
+    def spawn_effect(self, effect: WeaponEffect) -> None:  # noqa: D401
+        self.effects.append(effect)
+
+    def spawn_projectile(
+        self, *args: object, **kwargs: object
+    ) -> WeaponEffect:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    def iter_projectiles(
+        self, excluding: EntityId | None = None
+    ) -> list[ProjectileInfo]:  # pragma: no cover - unused
+        return []
+
+    def get_weapon(self, eid: EntityId) -> Weapon:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    def get_enemy(self, owner: EntityId) -> EntityId | None:  # pragma: no cover - unused
+        return None
+
+
+def _assert_weapon_spawns_sprite(weapon: Knife | Katana) -> None:
+    owner = EntityId(1)
+    view = DummyView({owner: (0.0, 0.0)})
+    weapon.update(owner, cast(WorldView, view), dt=0.016)
+    assert view.effects, "Weapon did not spawn any effect"
+    effect = view.effects[0]
+    sprite = getattr(effect, "sprite", None)
+    assert isinstance(sprite, pygame.Surface)
+
+
+def test_knife_spawns_sprite_effect() -> None:
+    _assert_weapon_spawns_sprite(Knife())
+
+
+def test_katana_spawns_sprite_effect() -> None:
+    _assert_weapon_spawns_sprite(Katana())


### PR DESCRIPTION
## Summary
- allow OrbitingRectangle to render an optional sprite
- pass knife and katana sprites to their orbiting effects
- add tests validating melee weapons spawn sprite effects

## Testing
- `uv run ruff check app/weapons/effects.py app/weapons/knife.py app/weapons/katana.py tests/conftest.py tests/test_orbiting_rectangle.py tests/weapons/test_melee_sprite_effect.py`
- `uv run mypy app/weapons/effects.py app/weapons/knife.py app/weapons/katana.py tests/conftest.py tests/test_orbiting_rectangle.py tests/weapons/test_melee_sprite_effect.py`
- `uv run pytest tests/weapons/test_melee_sprite_effect.py tests/test_orbiting_rectangle.py`

------
https://chatgpt.com/codex/tasks/task_e_68b855f8aa70832ab0a857d9e1f465ea