### PR TITLE
fix: stop all idle weapon sounds after death

### DIFF
--- a/app/game/controller.py
+++ b/app/game/controller.py
@@ -106,7 +106,7 @@ class _MatchView(WorldView):
                     for other in self.players:
                         weapon_audio = getattr(other.weapon, "audio", None)
                         if weapon_audio is not None:
-                            weapon_audio.stop_idle(timestamp)
+                            weapon_audio.stop_idle(timestamp, disable=True)
                 self.renderer.trigger_blink(p.color, int(damage.amount))
                 self.renderer.trigger_hit_flash(p.color)
                 return
@@ -498,7 +498,7 @@ class GameController:
         for p in self.players:
             weapon_audio = getattr(p.weapon, "audio", None)
             if weapon_audio is not None:
-                weapon_audio.stop_idle(self.death_ts)
+                weapon_audio.stop_idle(self.death_ts, disable=True)
         for p in self.players:
             p.ball.body.velocity = (0.0, 0.0)
         hp_a = max(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -127,7 +127,7 @@ class DummyBallAudio:
     def on_explode(self, _timestamp: float | None = None) -> None:  # pragma: no cover - stub
         return None
 
-    def stop_idle(self, _timestamp: float | None = None) -> None:  # pragma: no cover - stub
+    def stop_idle(self, _timestamp: float | None = None, *, disable: bool = False) -> None:  # pragma: no cover - stub
         return None
 
 

--- a/tests/test_dash_sound.py
+++ b/tests/test_dash_sound.py
@@ -65,7 +65,7 @@ class DummyBallAudio:
     def on_explode(self, _timestamp: float | None = None) -> None:  # pragma: no cover - stub
         return
 
-    def stop_idle(self, _timestamp: float | None = None) -> None:  # pragma: no cover - stub
+    def stop_idle(self, _timestamp: float | None = None, *, disable: bool = False) -> None:  # pragma: no cover - stub
         return
 
 

--- a/tests/test_idle_sounds_stop_on_death.py
+++ b/tests/test_idle_sounds_stop_on_death.py
@@ -22,10 +22,10 @@ class SpyWeaponAudio(WeaponAudio):
         super().__init__(*args, **kwargs)
         self.stopped_at: float | None = None
 
-    def stop_idle(self, timestamp: float | None = None) -> None:
+    def stop_idle(self, timestamp: float | None = None, *, disable: bool = False) -> None:
         if self._idle_thread and self._idle_thread.is_alive() and self.stopped_at is None:
             self.stopped_at = timestamp
-        super().stop_idle(timestamp)
+        super().stop_idle(timestamp, disable=disable)
 
 
 class KillerWeapon(Weapon):
@@ -87,6 +87,11 @@ def test_idle_sounds_stop_on_death() -> None:
     assert audio_a.stopped_at == pytest.approx(0.5)
     assert audio_b.stopped_at == pytest.approx(0.5)
     assert audio_a.stopped_at == audio_b.stopped_at
+
+    audio_a.start_idle(timestamp=1.0)
+    audio_b.start_idle(timestamp=1.0)
+    assert audio_a._idle_thread is None
+    assert audio_b._idle_thread is None
 
     weapon_registry._factories.pop("killer_test")
     weapon_registry._factories.pop("passive_test")

--- a/tests/test_match_logging.py
+++ b/tests/test_match_logging.py
@@ -71,7 +71,7 @@ class DummyBallAudio:
     def on_explode(self, _timestamp: float | None = None) -> None:  # pragma: no cover - stub
         return
 
-    def stop_idle(self, _timestamp: float | None = None) -> None:  # pragma: no cover - stub
+    def stop_idle(self, _timestamp: float | None = None, *, disable: bool = False) -> None:  # pragma: no cover - stub
         return
 
 

--- a/tests/test_update_players_velocity.py
+++ b/tests/test_update_players_velocity.py
@@ -70,7 +70,7 @@ class DummyBallAudio:
     def on_explode(self, _timestamp: float | None = None) -> None:  # pragma: no cover - stub
         return
 
-    def stop_idle(self, _timestamp: float | None = None) -> None:  # pragma: no cover - stub
+    def stop_idle(self, _timestamp: float | None = None, *, disable: bool = False) -> None:  # pragma: no cover - stub
         return
 
 

--- a/tests/weapons/test_bazooka_effect_respawn.py
+++ b/tests/weapons/test_bazooka_effect_respawn.py
@@ -53,7 +53,7 @@ class _WeaponAudio:
     def start_idle(self) -> None:  # pragma: no cover - unused
         return None
 
-    def stop_idle(self, timestamp: float | None = None) -> None:  # pragma: no cover - unused
+    def stop_idle(self, timestamp: float | None = None, *, disable: bool = False) -> None:  # pragma: no cover - unused
         return None
 
 


### PR DESCRIPTION
## Summary
- ensure weapon idle audio cannot restart after death via disable flag
- stop idle sounds for all players when a ball dies
- test that idle loops stay disabled after death

## Testing
- `ruff check app tests`
- `mypy app tests`
- `pytest` *(fails: ModuleNotFoundError: imageio, pygame; dependency installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68b85de7f578832aa27799ae36400cb5