### PR TITLE
feat: apply 80% opacity to simulation HUD

### DIFF
--- a/app/render/hud.py
+++ b/app/render/hud.py
@@ -166,9 +166,11 @@ class Hud:
 
         layout_a, layout_b, logo_rect, vs_rect = self.compute_layout(surface, labels)
 
+        hud_surface = pygame.Surface(surface.get_size(), pygame.SRCALPHA)
+
         # Left bar (team A)
         left_rect = pygame.Rect(margin, 120, bar_width, bar_height)
-        pygame.draw.rect(surface, self.theme.hp_empty, left_rect)
+        pygame.draw.rect(hud_surface, self.theme.hp_empty, left_rect)
         width_a = int(bar_width * self.current_hp_a)
         if width_a > 0:
             filled_rect = pygame.Rect(left_rect.x, left_rect.y, width_a, bar_height)
@@ -177,15 +179,15 @@ class Hud:
                 if self.current_hp_a < self.LOW_HP_THRESHOLD
                 else self.theme.team_a.hp_gradient
             )
-            draw_diagonal_gradient(surface, filled_rect, colors_a)
+            draw_diagonal_gradient(hud_surface, filled_rect, colors_a)
         label_a = self.bar_font.render(labels[0], True, (255, 255, 255))
-        surface.blit(label_a, layout_a)
+        hud_surface.blit(label_a, layout_a)
 
         # Right bar (team B)
         right_rect = pygame.Rect(
             surface.get_width() - margin - bar_width, 120, bar_width, bar_height
         )
-        pygame.draw.rect(surface, self.theme.hp_empty, right_rect)
+        pygame.draw.rect(hud_surface, self.theme.hp_empty, right_rect)
         width_b = int(bar_width * self.current_hp_b)
         if width_b > 0:
             filled_rect = pygame.Rect(
@@ -196,12 +198,15 @@ class Hud:
                 if self.current_hp_b < self.LOW_HP_THRESHOLD
                 else tuple(reversed(self.theme.team_b.hp_gradient))
             )
-            draw_diagonal_gradient(surface, filled_rect, colors_b)
+            draw_diagonal_gradient(hud_surface, filled_rect, colors_b)
         label_b = self.bar_font.render(labels[1], True, (255, 255, 255))
-        surface.blit(label_b, layout_b)
+        hud_surface.blit(label_b, layout_b)
 
         scaled_vs = pygame.transform.smoothscale(self.vs_image, vs_rect.size)
-        surface.blit(scaled_vs, vs_rect)
+        hud_surface.blit(scaled_vs, vs_rect)
+
+        hud_surface.set_alpha(int(255 * 0.8))  # 80% opacity
+        surface.blit(hud_surface, (0, 0))
 
         return layout_a, layout_b, logo_rect, vs_rect
 

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -7,6 +7,15 @@ from app.core.config import settings
 from app.render.hud import Hud
 from app.render.renderer import Renderer
 
+ALPHA = int(255 * 0.8)
+
+
+def _blend(color: tuple[int, int, int], background: tuple[int, int, int]) -> tuple[int, int, int]:
+    r = (color[0] * ALPHA + background[0] * (255 - ALPHA)) // 255
+    g = (color[1] * ALPHA + background[1] * (255 - ALPHA)) // 255
+    b = (color[2] * ALPHA + background[2] * (255 - ALPHA)) // 255
+    return r, g, b
+
 
 def test_hud_draws_without_errors() -> None:
     renderer = Renderer(100, 200)
@@ -32,9 +41,10 @@ def test_hp_bar_background_color() -> None:
     y = 120 + bar_height // 2
     width_a = int(bar_width * hud.current_hp_a)
     left_empty_x = 40 + width_a + 1
-    assert renderer.surface.get_at((left_empty_x, y))[:3] == empty
+    expected = _blend(empty, renderer.background)
+    assert renderer.surface.get_at((left_empty_x, y))[:3] == expected
     right_rect_start = renderer.surface.get_width() - 40 - bar_width
-    assert renderer.surface.get_at((right_rect_start + 1, y))[:3] == empty
+    assert renderer.surface.get_at((right_rect_start + 1, y))[:3] == expected
 
 
 def test_hp_bar_low_hp_color() -> None:
@@ -47,9 +57,10 @@ def test_hp_bar_low_hp_color() -> None:
     bar_height = int(renderer.surface.get_height() * Hud.BAR_HEIGHT_RATIO)
     x = 40 + bar_width // 10
     y = 120 + bar_height // 2
-    assert renderer.surface.get_at((x, y))[:3] == settings.theme.hp_warning
+    warning_blend = _blend(settings.theme.hp_warning, renderer.background)
+    assert renderer.surface.get_at((x, y))[:3] == warning_blend
     right_x = renderer.surface.get_width() - 40 - bar_width + bar_width // 2
-    assert renderer.surface.get_at((right_x, y))[:3] != settings.theme.hp_warning
+    assert renderer.surface.get_at((right_x, y))[:3] != warning_blend
 
 
 def test_hp_bars_scale_with_surface(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- render HP bars, labels, and VS logo on a temporary surface with 80% opacity
- adjust HUD tests for blended colors against the background

## Testing
- `ruff check app/render/hud.py tests/test_hud.py`
- `mypy app/render/hud.py tests/test_hud.py`
- `pytest tests/test_hud.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy pygame` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b936df5718832aa2dbbd9b952c64a7