### PR TITLE
feat: vary dash cooldown by weapon range

### DIFF
--- a/app/game/controller.py
+++ b/app/game/controller.py
@@ -14,13 +14,13 @@ from app.ai.stateful_policy import StatefulPolicy
 from app.audio import AudioEngine, BallAudio
 from app.core.config import settings
 from app.core.types import Color, Damage, EntityId, ProjectileInfo, Vec2
-from app.game.dash import Dash
+from app.game.dash import RANGED_COOLDOWN_FACTOR, Dash
 from app.intro import IntroManager
 from app.render.hud import Hud
 from app.render.renderer import Renderer
 from app.video.recorder import RecorderProtocol
 from app.video.slowmo import append_slowmo_ending
-from app.weapons.base import Weapon, WeaponEffect, WorldView
+from app.weapons.base import RangeType, Weapon, WeaponEffect, WorldView
 from app.world.entities import Ball
 from app.world.physics import PhysicsWorld
 from app.world.projectiles import Projectile
@@ -43,6 +43,12 @@ class Player:
     audio: BallAudio
     dash: Dash = field(default_factory=Dash)
     alive: bool = True
+
+    def __post_init__(self) -> None:
+        """Adjust dash cooldown according to the weapon's range."""
+        range_type: RangeType = getattr(self.weapon, "range_type", "contact")
+        if range_type == "distant":
+            self.dash.cooldown *= RANGED_COOLDOWN_FACTOR
 
 
 class MatchTimeout(Exception):

--- a/app/game/dash.py
+++ b/app/game/dash.py
@@ -5,6 +5,9 @@ from dataclasses import dataclass, field
 
 from app.core.types import Damage, Vec2
 
+# Multiplier applied to the dash cooldown for distant weapons.
+RANGED_COOLDOWN_FACTOR: float = 2.0
+
 
 @dataclass(slots=True)
 class Dash:

--- a/docs/dash.md
+++ b/docs/dash.md
@@ -8,7 +8,7 @@ portée pendant un dash devient un **coup critique**.
 
 - **Vitesse** : `800` unités/s
 - **Durée** : `0,2` s
-- **Recharge** : `3` s
+- **Recharge** : `3` s pour les armes de contact, `6` s pour les armes à distance
 
 ## Orientation
 

--- a/tests/test_dash_cooldown_weapon.py
+++ b/tests/test_dash_cooldown_weapon.py
@@ -1,0 +1,32 @@
+"""Tests for dash cooldown configuration based on weapon range."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+from app.ai.stateful_policy import StatefulPolicy
+from app.audio import BallAudio
+from app.core.types import Damage, EntityId
+from app.game.controller import Player
+from app.game.dash import Dash
+from app.weapons.base import Weapon
+from app.world.entities import Ball
+
+
+def test_dash_cooldown_depends_on_weapon_range() -> None:
+    """Distant weapons impose a longer dash cooldown."""
+
+    ball = cast(Ball, SimpleNamespace())
+    policy = cast(StatefulPolicy, SimpleNamespace())
+    audio = cast(BallAudio, SimpleNamespace())
+
+    contact_weapon = Weapon("contact", 0.0, Damage(1.0), range_type="contact")
+    distant_weapon = Weapon("distant", 0.0, Damage(1.0), range_type="distant")
+
+    contact_player = Player(EntityId(1), ball, contact_weapon, policy, (0.0, 0.0), (0, 0, 0), audio)
+    distant_player = Player(EntityId(2), ball, distant_weapon, policy, (0.0, 0.0), (0, 0, 0), audio)
+
+    base = Dash().cooldown
+    assert contact_player.dash.cooldown == base
+    assert distant_player.dash.cooldown == base * 2.0


### PR DESCRIPTION
## Summary
- double dash cooldown for distant weapons
- adjust player initialization to apply ranged cooldown factor
- document dash cooldown differences and test range-based configuration

## Testing
- `uv run ruff check .`
- `uv run mypy .`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'imageio')*


------
https://chatgpt.com/codex/tasks/task_e_68b93abacb30832abc3756aea48648b0