### PR TITLE
feat: render projectiles with team aura

### DIFF
--- a/app/game/controller.py
+++ b/app/game/controller.py
@@ -97,6 +97,12 @@ class _MatchView(WorldView):
                 return float(ratio)
         raise KeyError(eid)
 
+    def get_team_color(self, eid: EntityId) -> Color:
+        for p in self.players:
+            if p.eid == eid:
+                return p.color
+        raise KeyError(eid)
+
     def deal_damage(self, eid: EntityId, damage: Damage, timestamp: float) -> None:
         """Apply ``damage`` to ``eid`` at ``timestamp``."""
         for p in self.players:

--- a/app/render/renderer.py
+++ b/app/render/renderer.py
@@ -305,8 +305,29 @@ class Renderer:
             pygame.draw.circle(self.surface, overlay, self._offset(pos), radius)
             state.hit_flash_timer = max(0.0, state.hit_flash_timer - settings.dt)
 
-    def draw_projectile(self, pos: Vec2, radius: int, color: Color) -> None:
+    def draw_projectile(
+        self,
+        pos: Vec2,
+        radius: int,
+        color: Color,
+        aura_color: Color | None = None,
+    ) -> None:
+        """Draw a projectile centered at ``pos``.
+
+        Parameters
+        ----------
+        pos:
+            Center position of the projectile in world coordinates.
+        radius:
+            Projectile radius in pixels.
+        color:
+            Fill color of the projectile.
+        aura_color:
+            Optional color for a concentric outline used to simulate a team aura.
+        """
         pygame.draw.circle(self.surface, color, self._offset(pos), radius)
+        if aura_color is not None:
+            pygame.draw.circle(self.surface, aura_color, self._offset(pos), radius + 2, width=2)
 
     def draw_eyes(self, pos: Vec2, gaze: Vec2, radius: int, team_color: Color) -> None:
         if not settings.show_eyes:

--- a/app/weapons/base.py
+++ b/app/weapons/base.py
@@ -33,6 +33,9 @@ class WorldView(Protocol):
     def get_health_ratio(self, eid: EntityId) -> float:
         """Return the current health ratio ``health / max_health`` of an entity."""
 
+    def get_team_color(self, eid: EntityId) -> Color:
+        """Return the color of the team owning ``eid``."""
+
     def deal_damage(self, eid: EntityId, damage: Damage, timestamp: float) -> None:
         """Apply ``damage`` to ``eid`` at the given ``timestamp``."""
 

--- a/app/world/projectiles.py
+++ b/app/world/projectiles.py
@@ -168,7 +168,10 @@ class Projectile(WeaponEffect):
         if self.sprite is not None:
             renderer.draw_sprite(self.sprite, pos, self.angle)
         else:
-            renderer.draw_projectile(pos, int(self.shape.radius), (255, 255, 0))
+            team_color: Color = view.get_team_color(self.owner)
+            renderer.draw_projectile(
+                pos, int(self.shape.radius), (255, 255, 0), aura_color=team_color
+            )
         if renderer.debug:
             renderer.draw_circle_outline(pos, float(self.shape.radius), (0, 255, 0))
 


### PR DESCRIPTION
## Summary
- expose team colors through `WorldView`
- render projectiles with optional aura color
- draw projectile auras using owners' team colors

## Testing
- `uv run ruff check app/weapons/base.py app/game/controller.py app/render/renderer.py app/world/projectiles.py`
- `uv run mypy app`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'imageio')*
- `uv run pip install imageio imageio-ffmpeg typer pygame` *(fails: Could not find a version that satisfies the requirement imageio)*

------
https://chatgpt.com/codex/tasks/task_e_68b94c0b109c832ab37a418ab5091094