### PR TITLE
feat: add owner aura to projectiles

### DIFF
--- a/app/render/renderer.py
+++ b/app/render/renderer.py
@@ -169,8 +169,15 @@ class Renderer:
         """Draw a circle outline centered at ``pos`` with ``radius`` pixels."""
         pygame.draw.circle(self.surface, color, self._offset(pos), int(radius), width)
 
-    def draw_sprite(self, sprite: pygame.Surface, pos: Vec2, angle: float) -> None:
-        """Render a rotated sprite centered at *pos*.
+    def draw_sprite(
+        self,
+        sprite: pygame.Surface,
+        pos: Vec2,
+        angle: float,
+        aura_color: Color | None = None,
+        aura_radius: int | None = None,
+    ) -> None:
+        """Render a rotated sprite centered at ``pos`` with an optional aura.
 
         Parameters
         ----------
@@ -180,6 +187,10 @@ class Renderer:
             Center position in world coordinates.
         angle:
             Rotation angle in radians.
+        aura_color:
+            Optional color for a concentric outline used to simulate a team aura.
+        aura_radius:
+            Radius of the aura circle in pixels. Required when ``aura_color`` is provided.
         """
         degrees = math.degrees(-angle)
         quantized = int(round(degrees / _ROTATION_STEP_DEGREES) * _ROTATION_STEP_DEGREES)
@@ -191,6 +202,10 @@ class Renderer:
             self._rotation_cache[key] = rotated
         rect = rotated.get_rect(center=self._offset(pos))
         self.surface.blit(rotated, rect)
+        if aura_color is not None and aura_radius is not None:
+            pygame.draw.circle(
+                self.surface, aura_color, self._offset(pos), aura_radius + 2, width=2
+            )
 
     def add_impact(self, pos: Vec2, duration: float = 0.08) -> None:
         """Register an impact at ``pos`` lasting ``duration`` seconds.

--- a/app/world/projectiles.py
+++ b/app/world/projectiles.py
@@ -165,10 +165,16 @@ class Projectile(WeaponEffect):
                 t = (i + 1) / denom
                 color = cast(Color, tuple(int(c * t) for c in self.trail_color))
                 renderer.draw_line(a, b, color, self.trail_width)
+        team_color: Color = view.get_team_color(self.owner)
         if self.sprite is not None:
-            renderer.draw_sprite(self.sprite, pos, self.angle)
+            renderer.draw_sprite(
+                self.sprite,
+                pos,
+                self.angle,
+                aura_color=team_color,
+                aura_radius=int(self.shape.radius),
+            )
         else:
-            team_color: Color = view.get_team_color(self.owner)
             renderer.draw_projectile(
                 pos, int(self.shape.radius), (255, 255, 0), aura_color=team_color
             )

--- a/tests/world/test_projectile_aura.py
+++ b/tests/world/test_projectile_aura.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import cast
+
+from app.core.types import Damage, EntityId
+from app.world.physics import PhysicsWorld
+from app.world.projectiles import Projectile
+from app.render.renderer import Renderer
+from app.weapons.base import WorldView
+
+
+class DummyRenderer:
+    def __init__(self) -> None:  # pragma: no cover - simple init
+        self.calls: list[tuple[tuple[int, int, int] | None, int | None]] = []
+        self.debug = False
+
+    def draw_sprite(
+        self,
+        sprite: object,
+        pos: tuple[float, float],
+        angle: float,
+        aura_color: tuple[int, int, int] | None = None,
+        aura_radius: int | None = None,
+    ) -> None:
+        self.calls.append((aura_color, aura_radius))
+
+
+class DummyView:
+    def get_team_color(self, owner: EntityId) -> tuple[int, int, int]:
+        return (1, 2, 3)
+
+
+def test_projectile_sprite_has_aura() -> None:
+    world = PhysicsWorld()
+    projectile = Projectile.spawn(
+        world,
+        owner=EntityId(1),
+        position=(0.0, 0.0),
+        velocity=(0.0, 0.0),
+        radius=5.0,
+        damage=Damage(1),
+        knockback=0.0,
+        ttl=1.0,
+        sprite=object(),
+    )
+    renderer = DummyRenderer()
+    view = DummyView()
+    projectile.draw(cast(Renderer, renderer), cast(WorldView, view))
+    assert renderer.calls == [((1, 2, 3), 5)]


### PR DESCRIPTION
## Summary
- render projectile sprites with an aura in their owner's color
- support optional aura rendering in the sprite renderer
- test sprite aura drawing and projectile aura assignment

## Testing
- `uv run ruff check app/world/projectiles.py app/render/renderer.py tests/render/test_rotation_cache.py tests/world/test_projectile_aura.py`
- `uv run mypy app/world/projectiles.py app/render/renderer.py tests/render/test_rotation_cache.py tests/world/test_projectile_aura.py`
- `uv run pytest` *(fails: 37 errors during collection)*
- `uv run pytest tests/render/test_rotation_cache.py tests/world/test_projectile_aura.py`


------
https://chatgpt.com/codex/tasks/task_e_68b95384d808832a8c23564f9bd768a3