### PR TITLE
feat: render aura glow using halo utility

### DIFF
--- a/tests/render/test_rotation_cache.py
+++ b/tests/render/test_rotation_cache.py
@@ -9,7 +9,9 @@ import pytest
 
 
 @pytest.fixture()
-def renderer_stub(monkeypatch: pytest.MonkeyPatch) -> tuple[Any, type, list[int], list[tuple[Any, int, int]]]:
+def renderer_stub(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[Any, type, list[int], list[tuple[tuple[float, float], int, Any]]]:
     class PygameStub(types.ModuleType):
         SRCALPHA: int
         init: Callable[[], None]
@@ -43,16 +45,13 @@ def renderer_stub(monkeypatch: pytest.MonkeyPatch) -> tuple[Any, type, list[int]
     pygame_stub.image = types.SimpleNamespace(load=lambda path: Surface((32, 32)))
 
     rotation_calls: list[int] = []
-    circle_calls: list[tuple[Any, int, int]] = []
+    glow_calls: list[tuple[tuple[float, float], int, Any]] = []
 
     def rotozoom(surface: Surface, angle: float, scale: float) -> Surface:
         rotation_calls.append(int(angle))
         return Surface((surface._width, surface._height))
 
-    def circle(_surface: Surface, color: Any, _center: Any, radius: int, width: int = 0) -> None:
-        circle_calls.append((color, radius, width))
-
-    pygame_stub.draw = types.SimpleNamespace(circle=circle, line=lambda *a, **k: None)
+    pygame_stub.draw = types.SimpleNamespace(circle=lambda *a, **k: None, line=lambda *a, **k: None)
     pygame_stub.transform = types.SimpleNamespace(
         rotozoom=rotozoom, smoothscale=lambda s, size: Surface(size)
     )
@@ -81,11 +80,20 @@ def renderer_stub(monkeypatch: pytest.MonkeyPatch) -> tuple[Any, type, list[int]
 
     from app.render.renderer import Renderer
 
+    def fake_draw_glow(
+        _surface: Any, center: tuple[float, float], radius: int, color: Any
+    ) -> None:
+        glow_calls.append((center, radius, color))
+
+    monkeypatch.setattr("app.render.renderer.draw_glow", fake_draw_glow)
+
     renderer = Renderer(200, 200)
-    return renderer, Surface, rotation_calls, circle_calls
+    return renderer, Surface, rotation_calls, glow_calls
 
 
-def test_sprite_rotation_cached(renderer_stub: tuple[Any, type, list[int], list[tuple[Any, int, int]]]) -> None:
+def test_sprite_rotation_cached(
+    renderer_stub: tuple[Any, type, list[int], list[tuple[tuple[float, float], int, Any]]]
+) -> None:
     renderer, Surface, rotation_calls, _ = renderer_stub
     sprite = Surface((32, 32))
     renderer.draw_sprite(sprite, (0.0, 0.0), 0.1)
@@ -95,9 +103,19 @@ def test_sprite_rotation_cached(renderer_stub: tuple[Any, type, list[int], list[
     assert rotation_calls == [355, 330]
 
 
-def test_draw_sprite_with_aura(renderer_stub: tuple[Any, type, list[int], list[tuple[Any, int, int]]]) -> None:
-    renderer, Surface, _rotation_calls, circle_calls = renderer_stub
+def test_draw_sprite_with_aura(
+    renderer_stub: tuple[Any, type, list[int], list[tuple[tuple[float, float], int, Any]]]
+) -> None:
+    renderer, Surface, _rotation_calls, glow_calls = renderer_stub
     sprite = Surface((32, 32))
     renderer.draw_sprite(sprite, (0.0, 0.0), 0.0, aura_color=(1, 2, 3), aura_radius=5)
-    assert circle_calls == [((1, 2, 3), 7, 2)]
+    assert glow_calls == [((0.0, 0.0), 7, (1, 2, 3))]
+
+
+def test_draw_projectile_with_aura(
+    renderer_stub: tuple[Any, type, list[int], list[tuple[tuple[float, float], int, Any]]]
+) -> None:
+    renderer, _Surface, _rotation_calls, glow_calls = renderer_stub
+    renderer.draw_projectile((1.0, 2.0), 5, (255, 255, 0), aura_color=(1, 2, 3))
+    assert glow_calls == [((1.0, 2.0), 7, (1, 2, 3))]
 

--- a/tests/world/test_projectile_aura.py
+++ b/tests/world/test_projectile_aura.py
@@ -11,7 +11,7 @@ from app.weapons.base import WorldView
 
 class DummyRenderer:
     def __init__(self) -> None:  # pragma: no cover - simple init
-        self.calls: list[tuple[tuple[int, int, int] | None, int | None]] = []
+        self.calls: list[tuple[tuple[float, float], int, tuple[int, int, int]]] = []
         self.debug = False
 
     def draw_sprite(
@@ -22,7 +22,8 @@ class DummyRenderer:
         aura_color: tuple[int, int, int] | None = None,
         aura_radius: int | None = None,
     ) -> None:
-        self.calls.append((aura_color, aura_radius))
+        if aura_color is not None and aura_radius is not None:
+            self.calls.append((pos, aura_radius + 2, aura_color))
 
 
 class DummyView:
@@ -46,4 +47,4 @@ def test_projectile_sprite_has_aura() -> None:
     renderer = DummyRenderer()
     view = DummyView()
     projectile.draw(cast(Renderer, renderer), cast(WorldView, view))
-    assert renderer.calls == [((1, 2, 3), 5)]
+    assert renderer.calls == [((0.0, 0.0), 7, (1, 2, 3))]


### PR DESCRIPTION
## Summary
- add `draw_glow` helper to render a soft halo with shadow and semi-transparent blits
- use glow effect for sprite and projectile auras
- extend tests to assert glow rendering for projectiles and sprites

## Testing
- `uv run pytest tests/world/test_projectile_aura.py tests/render/test_rotation_cache.py`
- `uv run pre-commit run --files app/render/renderer.py tests/render/test_rotation_cache.py tests/world/test_projectile_aura.py` *(fails: Failed to spawn: `pre-commit`)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d762c290832aa8612df83f5c5087