### PR TITLE
feat: support configurable team sizes

### DIFF
--- a/app/config.json
+++ b/app/config.json
@@ -15,5 +15,7 @@
         "slow_factor": 0.5
     },
     "show_eyes": true,
-    "physics_substeps": 4
+    "physics_substeps": 4,
+    "team_a_count": 1,
+    "team_b_count": 1
 }

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -65,6 +65,8 @@ class Settings(BaseModel):  # type: ignore[misc]
     ball_color: Color = (220, 220, 220)
     show_eyes: bool = True  # Render eyes on balls when ``True``.
     physics_substeps: int = Field(default=4, ge=1)  # Physics integration substeps
+    team_a_count: int = Field(default=1, ge=1)  # Number of balls for team A
+    team_b_count: int = Field(default=1, ge=1)  # Number of balls for team B
 
     @property
     def width(self) -> int:

--- a/config.yml
+++ b/config.yml
@@ -5,3 +5,5 @@ seeds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
 # seed: 666
 ai_transition_seconds: 20
 debug: false
+team_a_count: 1
+team_b_count: 1

--- a/tests/test_match_team_counts.py
+++ b/tests/test_match_team_counts.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.core.config import settings
+from app.core.types import Damage, EntityId, Vec2
+from app.game.match import create_controller
+from app.video.recorder import NullRecorder
+from app.weapons import weapon_registry
+from app.weapons.base import Weapon, WorldView
+
+
+class _NoopWeapon(Weapon):
+    """Weapon that never fires."""
+
+    def __init__(self) -> None:
+        super().__init__(name="noop", cooldown=0.0, damage=Damage(0))
+
+    def _fire(self, owner: EntityId, view: WorldView, direction: Vec2) -> None:  # noqa: D401 - interface requirement
+        """No-op fire method."""
+
+
+def _noop_factory() -> Weapon:
+    return _NoopWeapon()
+
+
+_noop_factory.range_type = "contact"  # type: ignore[attr-defined]
+
+
+def test_create_controller_respects_team_counts(monkeypatch: Any) -> None:
+    """Players are spawned according to configured team sizes."""
+
+    monkeypatch.setattr(settings, "team_a_count", 2)
+    monkeypatch.setattr(settings, "team_b_count", 2)
+
+    weapon_registry.register("noop_test", _noop_factory)
+
+    controller = create_controller(
+        "noop_test",
+        "noop_test",
+        NullRecorder(),
+        renderer=None,
+        max_seconds=1,
+    )
+
+    try:
+        assert len(controller.players) == 4
+
+        step = settings.height / 3.0
+        expected_y = [step, step * 2]
+
+        for idx, player in enumerate(controller.players[:2]):
+            assert player.ball.body.position.x == pytest.approx(settings.width * 0.25)
+            assert player.ball.body.position.y == pytest.approx(expected_y[idx])
+
+        for idx, player in enumerate(controller.players[2:]):
+            assert player.ball.body.position.x == pytest.approx(settings.width * 0.75)
+            assert player.ball.body.position.y == pytest.approx(expected_y[idx])
+    finally:
+        weapon_registry._factories.pop("noop_test", None)
+


### PR DESCRIPTION
## Summary
- allow configuring independent team sizes via new `team_a_count` and `team_b_count` settings
- spawn multiple players per team spaced evenly across the field
- cover team player generation with a dedicated test

## Testing
- `ruff check app/game/match.py tests/test_match_team_counts.py app/core/config.py`
- `mypy app/game/match.py app/core/config.py tests/test_match_team_counts.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'imageio_ffmpeg')*

------
https://chatgpt.com/codex/tasks/task_e_68ba9aad1524832ab4e07984b6147b7b