### PR TITLE
feat: add team-aware enemy filtering

### DIFF
--- a/app/core/types.py
+++ b/app/core/types.py
@@ -39,3 +39,4 @@ class ProjectileInfo:
 
 
 WeaponFactory = NewType("WeaponFactory", object)
+TeamId = NewType("TeamId", int)

--- a/app/game/match.py
+++ b/app/game/match.py
@@ -7,7 +7,7 @@ from app.ai.stateful_policy import policy_for_weapon
 from app.audio import AudioEngine, BallAudio, get_default_engine
 from app.core.config import settings
 from app.core.registry import UnknownWeaponError
-from app.core.types import Color
+from app.core.types import Color, TeamId
 from app.game.controller import (
     GameController,
     MatchTimeout,  # noqa: F401 - re-exported
@@ -41,6 +41,7 @@ def _spawn_team(
     enemy_weapon_name: str,
     face: tuple[float, float],
     color: Color,
+    team: TeamId,
     engine: AudioEngine,
     ai_transition_seconds: int,
     rng: random.Random,
@@ -66,6 +67,7 @@ def _spawn_team(
             ),
             face,
             color,
+            team,
             BallAudio(engine=engine),
         )
         players.append(player)
@@ -133,6 +135,7 @@ def create_controller(
             enemy_weapon_name=weapon_b,
             face=(1.0, 0.0),
             color=settings.theme.team_a.primary,
+            team=TeamId(0),
             engine=engine,
             ai_transition_seconds=ai_transition_seconds,
             rng=rng,
@@ -147,6 +150,7 @@ def create_controller(
             enemy_weapon_name=weapon_a,
             face=(-1.0, 0.0),
             color=settings.theme.team_b.primary,
+            team=TeamId(1),
             engine=engine,
             ai_transition_seconds=ai_transition_seconds,
             rng=rng,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -9,7 +9,7 @@ import pygame
 
 from app.ai.stateful_policy import StatefulPolicy
 from app.audio import BallAudio
-from app.core.types import Damage, EntityId, ProjectileInfo, Vec2
+from app.core.types import Damage, EntityId, ProjectileInfo, TeamId, Vec2
 from app.game.controller import GameController, Player
 from app.weapons.base import Weapon, WeaponEffect, WorldView
 from app.world.entities import Ball
@@ -150,14 +150,23 @@ class DummyBall:
         return self.health <= 0
 
 
-def make_player(eid: int, x: float) -> Player:
+def make_player(eid: int, x: float, team: int = 0) -> Player:
     """Return a :class:`Player` positioned at ``x`` with inert weapon."""
 
     ball = cast(Ball, DummyBall(x))
     weapon = cast(Weapon, DummyWeapon())
     policy = cast(StatefulPolicy, DummyPolicy())
     audio = cast(BallAudio, DummyBallAudio())
-    return Player(EntityId(eid), ball, weapon, policy, (1.0, 0.0), (0, 0, 0), audio)
+    return Player(
+        EntityId(eid),
+        ball,
+        weapon,
+        policy,
+        (1.0, 0.0),
+        (0, 0, 0),
+        TeamId(team),
+        audio,
+    )
 
 
 def make_controller(player_a: Player, player_b: Player) -> GameController:

--- a/tests/test_ball_death_sound.py
+++ b/tests/test_ball_death_sound.py
@@ -19,7 +19,7 @@ np_stub = cast(Any, types.ModuleType("numpy"))
 sys.modules.setdefault("numpy", np_stub)
 
 from app.audio import BallAudio  # noqa: E402
-from app.core.types import Damage  # noqa: E402
+from app.core.types import Damage, TeamId  # noqa: E402
 from app.game.match import Player, _MatchView  # noqa: E402
 from app.world.entities import Ball  # noqa: E402
 from app.world.physics import PhysicsWorld  # noqa: E402
@@ -69,7 +69,7 @@ def test_deal_damage_triggers_explosion_sound_on_death() -> None:
     dummy_engine = DummyEngine()
     engine = cast("AudioEngine", dummy_engine)
     audio = BallAudio(engine=engine)
-    player = Player(ball.eid, ball, weapon, policy, (1.0, 0.0), (255, 255, 255), audio)
+    player = Player(ball.eid, ball, weapon, policy, (1.0, 0.0), (255, 255, 255), TeamId(0), audio)
     renderer = cast("Renderer", DummyRenderer())
     view = _MatchView([player], [], world, renderer, engine)
 

--- a/tests/test_ball_hit_sound.py
+++ b/tests/test_ball_hit_sound.py
@@ -19,7 +19,7 @@ np_stub = cast(Any, types.ModuleType("numpy"))
 sys.modules.setdefault("numpy", np_stub)
 
 from app.audio import BallAudio  # noqa: E402
-from app.core.types import Damage  # noqa: E402
+from app.core.types import Damage, TeamId  # noqa: E402
 from app.game.match import Player, _MatchView  # noqa: E402
 from app.world.entities import Ball  # noqa: E402
 from app.world.physics import PhysicsWorld  # noqa: E402
@@ -69,7 +69,7 @@ def test_deal_damage_triggers_hit_sound(monkeypatch: Any) -> None:
     dummy_engine = DummyEngine()
     engine = cast("AudioEngine", dummy_engine)
     audio = BallAudio(engine=engine)
-    player = Player(ball.eid, ball, weapon, policy, (1.0, 0.0), (255, 255, 255), audio)
+    player = Player(ball.eid, ball, weapon, policy, (1.0, 0.0), (255, 255, 255), TeamId(0), audio)
     renderer = cast("Renderer", DummyRenderer())
     view = _MatchView([player], [], world, renderer, engine)
 

--- a/tests/test_dash_collision.py
+++ b/tests/test_dash_collision.py
@@ -5,8 +5,8 @@ from tests.helpers import make_controller, make_player
 
 
 def test_dash_collision_deals_damage_and_knockback() -> None:
-    player_a = make_player(1, 0.0)
-    player_b = make_player(2, 70.0)
+    player_a = make_player(1, 0.0, team=0)
+    player_b = make_player(2, 70.0, team=1)
     controller = make_controller(player_a, player_b)
     player_a.dash.start((1.0, 0.0), 0.0)
     controller._update_players(0.0)
@@ -17,8 +17,8 @@ def test_dash_collision_deals_damage_and_knockback() -> None:
 
 
 def test_dash_damage_scales_with_speed() -> None:
-    player_a = make_player(1, 0.0)
-    player_b = make_player(2, 70.0)
+    player_a = make_player(1, 0.0, team=0)
+    player_b = make_player(2, 70.0, team=1)
     controller = make_controller(player_a, player_b)
     player_a.dash.start((1.0, 0.0), 0.0)
     player_a.ball.body.velocity = (player_a.dash.speed / 2.0, 0.0)
@@ -27,8 +27,8 @@ def test_dash_damage_scales_with_speed() -> None:
 
 
 def test_dashing_player_can_be_damaged() -> None:
-    player_a = make_player(1, 0.0)
-    player_b = make_player(2, 200.0)
+    player_a = make_player(1, 0.0, team=0)
+    player_b = make_player(2, 200.0, team=1)
     controller = make_controller(player_a, player_b)
     player_a.dash.start((1.0, 0.0), 0.0)
     controller.view.deal_damage(player_a.eid, Damage(10.0), 0.0)

--- a/tests/test_dash_cooldown_weapon.py
+++ b/tests/test_dash_cooldown_weapon.py
@@ -7,7 +7,7 @@ from typing import cast
 
 from app.ai.stateful_policy import StatefulPolicy
 from app.audio import BallAudio
-from app.core.types import Damage, EntityId
+from app.core.types import Damage, EntityId, TeamId
 from app.game.controller import Player
 from app.game.dash import Dash
 from app.weapons.base import Weapon
@@ -24,8 +24,8 @@ def test_dash_cooldown_depends_on_weapon_range() -> None:
     contact_weapon = Weapon("contact", 0.0, Damage(1.0), range_type="contact")
     distant_weapon = Weapon("distant", 0.0, Damage(1.0), range_type="distant")
 
-    contact_player = Player(EntityId(1), ball, contact_weapon, policy, (0.0, 0.0), (0, 0, 0), audio)
-    distant_player = Player(EntityId(2), ball, distant_weapon, policy, (0.0, 0.0), (0, 0, 0), audio)
+    contact_player = Player(EntityId(1), ball, contact_weapon, policy, (0.0, 0.0), (0, 0, 0), TeamId(0), audio)
+    distant_player = Player(EntityId(2), ball, distant_weapon, policy, (0.0, 0.0), (0, 0, 0), TeamId(1), audio)
 
     base = Dash().cooldown
     assert contact_player.dash.cooldown == base

--- a/tests/test_dash_sound.py
+++ b/tests/test_dash_sound.py
@@ -6,7 +6,7 @@ from typing import Any, cast
 
 from app.ai.stateful_policy import StatefulPolicy
 from app.audio import AudioEngine, BallAudio
-from app.core.types import EntityId
+from app.core.types import EntityId, TeamId
 from app.game.controller import GameController, Player
 from app.intro import IntroManager
 from app.render.hud import Hud
@@ -103,7 +103,7 @@ def _make_player() -> Player:
     weapon = cast(Weapon, DummyWeapon())
     policy = cast(StatefulPolicy, DummyPolicy())
     audio = cast(BallAudio, DummyBallAudio())
-    return Player(EntityId(1), ball, weapon, policy, (1.0, 0.0), (0, 0, 0), audio)
+    return Player(EntityId(1), ball, weapon, policy, (1.0, 0.0), (0, 0, 0), TeamId(0), audio)
 
 
 def test_dash_triggers_sound() -> None:

--- a/tests/test_match_apply_impulse.py
+++ b/tests/test_match_apply_impulse.py
@@ -4,7 +4,7 @@ from typing import Any, cast
 
 import pytest
 
-from app.core.types import EntityId
+from app.core.types import EntityId, TeamId
 from app.game.match import Player, _MatchView
 from app.world.entities import Ball
 from app.world.physics import PhysicsWorld
@@ -20,6 +20,7 @@ def test_apply_impulse_raises_for_unknown_entity() -> None:
         policy=cast(Any, object()),
         face=(1.0, 0.0),
         color=(255, 255, 255),
+        team=TeamId(0),
         audio=cast(Any, object()),
     )
     view = _MatchView([player], [], world, cast(Any, object()), cast(Any, object()))

--- a/tests/test_match_logging.py
+++ b/tests/test_match_logging.py
@@ -12,7 +12,7 @@ import pytest
 
 from app.ai.stateful_policy import StatefulPolicy
 from app.audio import AudioEngine, BallAudio
-from app.core.types import EntityId
+from app.core.types import EntityId, TeamId
 from app.game.controller import GameController, MatchTimeout, Player
 from app.intro import IntroManager
 from app.render.hud import Hud
@@ -90,7 +90,7 @@ def _make_player(eid: int) -> Player:
     weapon = cast(Weapon, DummyWeapon())
     policy = cast(StatefulPolicy, DummyPolicy())
     audio = cast(BallAudio, DummyBallAudio())
-    return Player(EntityId(eid), ball, weapon, policy, (1.0, 0.0), (0, 0, 0), audio)
+    return Player(EntityId(eid), ball, weapon, policy, (1.0, 0.0), (0, 0, 0), TeamId(eid % 2), audio)
 
 
 def test_logs_each_second(

--- a/tests/test_match_stop_idle.py
+++ b/tests/test_match_stop_idle.py
@@ -9,7 +9,7 @@ from typing import Any, cast
 from app.audio import AudioEngine, reset_default_engine
 from app.audio.balls import BallAudio
 from app.audio.weapons import WeaponAudio
-from app.core.types import Color, Damage, EntityId, Vec2
+from app.core.types import Color, Damage, EntityId, TeamId, Vec2
 from app.game.match import Player, _MatchView
 from app.world.entities import Ball
 from app.world.physics import PhysicsWorld
@@ -56,6 +56,7 @@ def test_idle_sound_truncated_on_death() -> None:
         policy=cast(Any, DummyPolicy()),
         face=(1.0, 0.0),
         color=(255, 255, 255),
+        team=TeamId(0),
         audio=BallAudio(engine=engine),
     )
     renderer = cast(Any, StubRenderer())

--- a/tests/test_match_view_team_filter.py
+++ b/tests/test_match_view_team_filter.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+from app.core.types import Damage, TeamId
+from app.game.controller import Player, _MatchView
+from app.world.entities import Ball
+from app.world.physics import PhysicsWorld
+from app.world.projectiles import Projectile
+
+
+def _make_player(world: PhysicsWorld, x: float, team: int) -> Player:
+    ball = Ball.spawn(world, (x, 0.0))
+    return Player(
+        ball.eid,
+        ball,
+        cast(Any, object()),
+        cast(Any, object()),
+        (1.0, 0.0),
+        (0, 0, 0),
+        TeamId(team),
+        cast(Any, object()),
+    )
+
+
+def test_get_enemy_returns_opponent_only() -> None:
+    world = PhysicsWorld()
+    player_a = _make_player(world, 0.0, 0)
+    player_b = _make_player(world, 10.0, 1)
+    view = _MatchView([player_a, player_b], [], world, cast(Any, object()), cast(Any, object()))
+
+    assert view.get_enemy(player_a.eid) == player_b.eid
+    assert view.get_enemy(player_b.eid) == player_a.eid
+
+
+def test_iter_projectiles_filters_by_team() -> None:
+    world = PhysicsWorld()
+    player_a = _make_player(world, 0.0, 0)
+    player_b = _make_player(world, 10.0, 1)
+    proj_a = Projectile.spawn(world, player_a.eid, (0.0, 0.0), (1.0, 0.0), 1.0, Damage(1.0), 0.0, 1.0)
+    proj_b = Projectile.spawn(world, player_b.eid, (10.0, 0.0), (1.0, 0.0), 1.0, Damage(1.0), 0.0, 1.0)
+    view = _MatchView([player_a, player_b], [proj_a, proj_b], world, cast(Any, object()), cast(Any, object()))
+
+    infos = list(view.iter_projectiles(excluding=player_a.eid))
+    assert [info.owner for info in infos] == [player_b.eid]

--- a/tests/test_orbiting_sprite_collision.py
+++ b/tests/test_orbiting_sprite_collision.py
@@ -9,8 +9,8 @@ from tests.helpers import make_controller, make_player
 
 def test_orbiting_sprite_hits_enemy() -> None:
     pygame.init()
-    player_a = make_player(1, 0.0)
-    player_b = make_player(2, 60.0)
+    player_a = make_player(1, 0.0, team=0)
+    player_b = make_player(2, 60.0, team=1)
     controller = make_controller(player_a, player_b)
     sprite = pygame.Surface((10, 10))
     blade = OrbitingSprite(

--- a/tests/test_update_players_velocity.py
+++ b/tests/test_update_players_velocity.py
@@ -8,7 +8,7 @@ import pytest
 from app.ai.stateful_policy import StatefulPolicy
 from app.audio import AudioEngine, BallAudio
 from app.core.config import settings
-from app.core.types import EntityId
+from app.core.types import EntityId, TeamId
 from app.game.controller import GameController, Player
 from app.intro import IntroManager
 from app.render.hud import Hud
@@ -90,7 +90,7 @@ def _make_player(accel: tuple[float, float], initial_velocity: tuple[float, floa
     weapon = cast(Weapon, DummyWeapon())
     policy = cast(StatefulPolicy, DummyPolicy(accel))
     audio = cast(BallAudio, DummyBallAudio())
-    return Player(EntityId(1), ball, weapon, policy, (1.0, 0.0), (0, 0, 0), audio)
+    return Player(EntityId(1), ball, weapon, policy, (1.0, 0.0), (0, 0, 0), TeamId(0), audio)
 
 
 def test_player_velocity_updates_from_acceleration() -> None:

--- a/tests/weapons/test_bazooka_effect_respawn.py
+++ b/tests/weapons/test_bazooka_effect_respawn.py
@@ -83,9 +83,9 @@ from tests.helpers import make_controller, make_player  # noqa: E402
 def test_bazooka_effect_respawns(enemy_x: float) -> None:
     weapon = Bazooka()
     weapon._timer = 1.0  # prevent automatic firing during the test
-    player_a = make_player(1, 0.0)
+    player_a = make_player(1, 0.0, team=0)
     player_a.weapon = weapon
-    player_b = make_player(2, enemy_x)
+    player_b = make_player(2, enemy_x, team=1)
 
     class _Policy:
         def decide(


### PR DESCRIPTION
## Summary
- add team id to Player and restrict MatchView queries to opposing teams
- track team membership when spawning players in matches
- cover team filtering logic with dedicated tests

## Testing
- `uv run ruff check app/game/controller.py app/game/match.py app/core/types.py tests/test_match_apply_impulse.py tests/test_match_stop_idle.py tests/test_update_players_velocity.py tests/test_match_logging.py tests/test_dash_sound.py tests/test_dash_cooldown_weapon.py tests/test_ball_death_sound.py tests/test_ball_hit_sound.py tests/helpers.py tests/test_orbiting_sprite_collision.py tests/test_dash_collision.py tests/weapons/test_bazooka_effect_respawn.py tests/test_match_view_team_filter.py`
- `uv run mypy app/game/controller.py app/game/match.py app/core/types.py tests/helpers.py tests/test_match_apply_impulse.py tests/test_match_stop_idle.py tests/test_update_players_velocity.py tests/test_match_logging.py tests/test_dash_sound.py tests/test_dash_cooldown_weapon.py tests/test_ball_death_sound.py tests/test_ball_hit_sound.py tests/test_orbiting_sprite_collision.py tests/test_dash_collision.py tests/weapons/test_bazooka_effect_respawn.py tests/test_match_view_team_filter.py`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'imageio')*
- `uv run pytest tests/test_match_view_team_filter.py -q` *(fails: ModuleNotFoundError: No module named 'imageio')*

------
https://chatgpt.com/codex/tasks/task_e_68ba9e9c2634832ab9c02d605f71501a