### PR TITLE
Add team-based match integration tests and document configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,20 @@ uv run python -m app.cli batch \
 - **FPS / résolution** : ajuster `canvas` dans `app/config.json`.
 - **Seeds** : `config.yml` peut contenir `seed: 42` pour un combat unique ou `seeds: [1, 2, 3]` pour générer plusieurs vidéos l'une après l'autre.
 
+### Taille des équipes
+
+Les paramètres `team_a_count` et `team_b_count` dans `config.yml` contrôlent le nombre de joueurs par camp. La valeur par défaut `1` correspond à un duel classique.
+
+```yaml
+# Match 2v2
+team_a_count: 2
+team_b_count: 2
+
+# Match 1v2
+team_a_count: 1
+team_b_count: 2
+```
+
 ## 🎬 Intro animation
 
 Avant chaque match, une courte séquence présente les armes en jeu.

--- a/app/video/recorder.py
+++ b/app/video/recorder.py
@@ -6,9 +6,10 @@ import wave
 from pathlib import Path
 from typing import Protocol
 
+import numpy as np
+
 import imageio
 import imageio_ffmpeg
-import numpy as np
 
 logger = logging.getLogger(__name__)
 

--- a/config.yml
+++ b/config.yml
@@ -5,5 +5,10 @@ seeds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
 # seed: 666
 ai_transition_seconds: 20
 debug: false
+# Number of players on team A. Set to 2 for a 2v2 match.
 team_a_count: 1
+# Number of players on team B. Set to 2 for a 2v2 or 1 for 1v2.
 team_b_count: 1
+# Example configurations:
+#   2v2 -> team_a_count: 2, team_b_count: 2
+#   1v2 -> team_a_count: 1, team_b_count: 2

--- a/tests/integration/test_headless_match.py
+++ b/tests/integration/test_headless_match.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
-import imageio_ffmpeg
 import pytest
 
+import imageio_ffmpeg
 from app.core.config import settings
 from app.game.match import MatchTimeout, run_match
 from app.render.renderer import Renderer

--- a/tests/integration/test_team_modes.py
+++ b/tests/integration/test_team_modes.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import pygame
+import pytest
+
+from app.core.config import settings
+from app.core.types import Damage, EntityId, TeamId, Vec2
+from app.game.match import create_controller
+from app.video.recorder import NullRecorder
+from app.weapons import weapon_registry
+from app.weapons.base import Weapon, WorldView
+
+
+class _NoopWeapon(Weapon):
+    """Weapon that never fires."""
+
+    def __init__(self) -> None:
+        super().__init__(name="noop", cooldown=0.0, damage=Damage(0))
+
+    def _fire(self, owner: EntityId, view: WorldView, direction: Vec2) -> None:  # pragma: no cover - interface
+        """No-op fire method."""
+        return None
+
+
+def _noop_factory() -> Weapon:
+    return _NoopWeapon()
+
+
+_noop_factory.range_type = "contact"  # type: ignore[attr-defined]
+
+
+def _register_noop_weapon() -> None:
+    weapon_registry.register("noop_test", _noop_factory)
+
+
+def _unregister_noop_weapon() -> None:
+    weapon_registry._factories.pop("noop_test", None)
+
+
+def test_match_2v2_heal_and_victory(monkeypatch: pytest.MonkeyPatch) -> None:
+    """2v2 matches spawn players correctly and handle ally collisions."""
+
+    monkeypatch.setattr(settings, "team_a_count", 2)
+    monkeypatch.setattr(settings, "team_b_count", 2)
+    _register_noop_weapon()
+
+    try:
+        controller = create_controller("noop_test", "noop_test", NullRecorder(), renderer=None, max_seconds=1)
+        assert len(controller.players) == 4
+
+        step = settings.height / 3.0
+        expected_y = [step, step * 2]
+
+        for idx, player in enumerate(controller.players[:2]):
+            assert player.ball.body.position.x == pytest.approx(settings.width * 0.25)
+            assert player.ball.body.position.y == pytest.approx(expected_y[idx])
+
+        for idx, player in enumerate(controller.players[2:]):
+            assert player.ball.body.position.x == pytest.approx(settings.width * 0.75)
+            assert player.ball.body.position.y == pytest.approx(expected_y[idx])
+
+        healer, target = controller.players[0], controller.players[1]
+        target.ball.health = 90.0
+        healer.ball.body.position = target.ball.body.position
+        healer.ball.body.velocity = (healer.dash.speed, 0.0)
+        healer.dash.is_dashing = True
+        healer.dash._direction = (1.0, 0.0)  # type: ignore[attr-defined]
+
+        controller._resolve_dash_collision(healer, 0.0)
+
+        assert target.ball.health == pytest.approx(95.0)
+
+        for foe in controller.players[2:]:
+            foe.alive = False
+
+        monkeypatch.setattr(controller, "_play_winner_sequence", lambda: None)
+        monkeypatch.setattr(pygame.event, "get", lambda: [])
+        controller._run_match_loop(0.0)
+        assert controller.winner_team == TeamId(0)
+    finally:
+        _unregister_noop_weapon()
+
+
+def test_match_1v2_heal_and_victory(monkeypatch: pytest.MonkeyPatch) -> None:
+    """1v2 matches support asymmetric team sizes and healing."""
+
+    monkeypatch.setattr(settings, "team_a_count", 1)
+    monkeypatch.setattr(settings, "team_b_count", 2)
+    _register_noop_weapon()
+
+    try:
+        controller = create_controller("noop_test", "noop_test", NullRecorder(), renderer=None, max_seconds=1)
+        assert len(controller.players) == 3
+
+        assert controller.players[0].ball.body.position.x == pytest.approx(settings.width * 0.25)
+        assert controller.players[0].ball.body.position.y == pytest.approx(settings.height / 2.0)
+
+        step = settings.height / 3.0
+        expected_y = [step, step * 2]
+        for idx, player in enumerate(controller.players[1:]):
+            assert player.ball.body.position.x == pytest.approx(settings.width * 0.75)
+            assert player.ball.body.position.y == pytest.approx(expected_y[idx])
+
+        healer, target = controller.players[1], controller.players[2]
+        target.ball.health = 90.0
+        healer.ball.body.position = target.ball.body.position
+        healer.ball.body.velocity = (healer.dash.speed, 0.0)
+        healer.dash.is_dashing = True
+        healer.dash._direction = (1.0, 0.0)  # type: ignore[attr-defined]
+
+        controller._resolve_dash_collision(healer, 0.0)
+
+        assert target.ball.health == pytest.approx(95.0)
+
+        controller.players[0].alive = False
+        monkeypatch.setattr(controller, "_play_winner_sequence", lambda: None)
+        monkeypatch.setattr(pygame.event, "get", lambda: [])
+        controller._run_match_loop(0.0)
+        assert controller.winner_team == TeamId(1)
+    finally:
+        _unregister_noop_weapon()

--- a/tests/test_recorder.py
+++ b/tests/test_recorder.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-import imageio
 import numpy as np
 from pytest import CaptureFixture, LogCaptureFixture
 
+import imageio
 from app.video.recorder import NullRecorder, Recorder
 
 

--- a/tests/world/test_ball_collision_no_damage.py
+++ b/tests/world/test_ball_collision_no_damage.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import pytest
-
 from app.world.entities import Ball
 from app.world.physics import PhysicsWorld, _resolve_ball_collision
 

--- a/tests/world/test_projectile_aura.py
+++ b/tests/world/test_projectile_aura.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from typing import cast
 
 from app.core.types import Damage, EntityId
-from app.world.physics import PhysicsWorld
-from app.world.projectiles import Projectile
 from app.render.renderer import Renderer
 from app.weapons.base import WorldView
+from app.world.physics import PhysicsWorld
+from app.world.projectiles import Projectile
 
 
 class DummyRenderer:


### PR DESCRIPTION
## Summary
- cover 2v2 and 1v2 scenarios with integration tests checking spawns, ally healing, and match end
- explain `team_a_count` and `team_b_count` in README with examples
- describe team size options directly in `config.yml`
- sort imports to satisfy ruff

## Testing
- `uv run ruff check .`
- `uv run mypy app`
- `uv run pytest` *(fails: No module named 'typer')*
- `uv run bandit -r app tests` *(fails: bandit not installed)*
- `uv run pip-audit` *(fails: pip-audit not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68bab698d674832a948728c20a8dfff9