### PR TITLE
fix: skip muxing when no video frames

### DIFF
--- a/app/video/recorder.py
+++ b/app/video/recorder.py
@@ -70,6 +70,10 @@ class Recorder(RecorderProtocol):
     def close(self, audio: np.ndarray | None = None, rate: int = 48_000) -> None:
         """Finalize the video and optionally mux an audio track.
 
+        The method returns early if no frames were recorded or if the temporary
+        video file is missing. In that case a warning is logged and any provided
+        audio is ignored.
+
         Parameters
         ----------
         audio:
@@ -83,6 +87,9 @@ class Recorder(RecorderProtocol):
             If ``ffmpeg`` fails to combine audio and video streams.
         """
         self.writer.close()
+        if self._frame_count == 0 or not self._video_path.exists():
+            logger.warning("No video frames recorded; skipping muxing")
+            return
         if self._format != "mp4":
             return
         if audio is None or audio.size == 0:


### PR DESCRIPTION
## Summary
- avoid ffmpeg muxing when no frames were recorded
- warn and return early when closing an empty recording
- test that closing without frames logs warning and skips muxing

## Testing
- `ruff check app/video/recorder.py tests/video/test_recorder.py`
- `mypy app/video/recorder.py tests/video/test_recorder.py`
- `pytest tests/video/test_recorder.py`
- `pre-commit run --files app/video/recorder.py tests/video/test_recorder.py` *(fails: Failed to fetch `https://pypi.org/simple/pre-commit/`)*

------
https://chatgpt.com/codex/tasks/task_e_68bafd8a9ee8832a97e3ea0dddef59e3