### PR TITLE
Handle video writer initialization errors explicitly

### DIFF
--- a/app/video/recorder.py
+++ b/app/video/recorder.py
@@ -68,7 +68,8 @@ class Recorder(RecorderProtocol):
                 codec="libx264",
                 macro_block_size=1,
             )
-        except Exception:
+        except (OSError, imageio.core.FormatError) as exc:
+            logger.warning("MP4 writer unavailable, falling back to GIF", exc_info=exc)
             self._format = "gif"
             self._video_path = self.path.with_suffix(".gif")
             self.path = self._video_path

--- a/imageio/__init__.py
+++ b/imageio/__init__.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
+
+import numpy as np
 
 
 class _Writer:
@@ -16,3 +19,26 @@ class _Writer:
 def get_writer(*_args: Any, **_kwargs: Any) -> _Writer:  # pragma: no cover - stub
     """Return a dummy writer that discards frames."""
     return _Writer()
+
+
+class _Reader:
+    def get_data(self, _index: int) -> np.ndarray:  # pragma: no cover - stub
+        return np.zeros((1, 1, 3), dtype=np.uint8)
+
+    def __enter__(self) -> _Reader:  # pragma: no cover - stub
+        return self
+
+    def __exit__(self, *_exc: object) -> None:  # pragma: no cover - stub
+        return None
+
+
+def get_reader(*_args: Any, **_kwargs: Any) -> _Reader:  # pragma: no cover - stub
+    """Return a dummy reader that yields a single black frame."""
+    return _Reader()
+
+
+class FormatError(RuntimeError):
+    """Stub ``imageio`` format error."""
+
+
+core = SimpleNamespace(FormatError=FormatError)


### PR DESCRIPTION
## Summary
- Catch `OSError` and `imageio.core.FormatError` when initializing MP4 writer and log the original failure before falling back to GIF
- Add a minimal `FormatError` to the bundled `imageio` stub
- Cover GIF fallback and unexpected error propagation with dedicated recorder tests

## Testing
- `uv run ruff check app/video/recorder.py imageio/__init__.py tests/test_recorder.py`
- `uv run mypy app/video/recorder.py imageio/__init__.py tests/test_recorder.py`
- `uv run pytest tests/test_recorder.py::test_recorder_fallback_to_gif tests/test_recorder.py::test_recorder_unexpected_error -vv`


------
https://chatgpt.com/codex/tasks/task_e_68bc9f675f18832aa06fc38144687c49