### PR TITLE
Skip slow-mo when recorder outputs GIF

### DIFF
--- a/app/game/controller.py
+++ b/app/game/controller.py
@@ -621,7 +621,11 @@ class GameController:
         self.phase = Phase.FINISHED
 
     def _teardown(self, intro_elapsed: float) -> None:
-        """Release resources and finalize recording."""
+        """Release resources and finalize recording.
+
+        Slow-motion post-processing is applied only when the recorder writes an
+        MP4 file. Recorders that fall back to GIF output skip this step.
+        """
         for player in self.players:
             weapon_audio = getattr(player.weapon, "audio", None)
             if weapon_audio is not None:
@@ -629,7 +633,12 @@ class GameController:
         audio = self.engine.end_capture() if not self.display else None
         self.engine.stop_all()
         self.recorder.close(audio)
-        if not self.display and self.death_ts is not None and self.recorder.path is not None:
+        if (
+            not self.display
+            and self.death_ts is not None
+            and self.recorder.path is not None
+            and self.recorder.path.suffix == ".mp4"
+        ):
             append_slowmo_ending(
                 self.recorder.path,
                 self.death_ts,

--- a/tests/integration/test_gif_fallback_skips_slowmo.py
+++ b/tests/integration/test_gif_fallback_skips_slowmo.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import imageio
+from app.core.config import settings
+from app.game.match import run_match
+from app.render.renderer import Renderer
+from app.video.recorder import Recorder
+from app.weapons import weapon_registry
+from tests.integration.helpers import InstantKillWeapon
+
+
+def test_gif_fallback_skips_slowmo(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Slow-motion is skipped when the recorder outputs a GIF."""
+    if "instakill" not in weapon_registry.names():
+        weapon_registry.register("instakill", InstantKillWeapon)
+
+    original_get_writer = imageio.get_writer
+
+    def fail_mp4(*args: object, **kwargs: object) -> object:
+        if kwargs.get("codec") == "libx264":
+            raise OSError("mp4 writer unavailable")
+        return original_get_writer(*args, **kwargs)
+
+    monkeypatch.setattr(imageio, "get_writer", fail_mp4)
+
+    called = False
+
+    def fake_append(*_args: object, **_kwargs: object) -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr("app.game.controller.append_slowmo_ending", fake_append)
+
+    out = tmp_path / "out.mp4"
+    recorder = Recorder(settings.width, settings.height, settings.fps, out)
+    assert recorder.path is not None and recorder.path.suffix == ".gif"
+
+    renderer = Renderer(settings.width, settings.height)
+    run_match("instakill", "instakill", recorder, renderer, max_seconds=1)
+
+    assert recorder.path.exists()
+    assert not called


### PR DESCRIPTION
## Summary
- ensure slow-motion post-processing only runs for MP4 recordings
- add regression test for GIF recorder fallback skipping slow-mo

## Testing
- `uv run ruff check app/game/controller.py tests/integration/test_gif_fallback_skips_slowmo.py`
- `uv run mypy app/game/controller.py tests/integration/test_gif_fallback_skips_slowmo.py`
- `uv run pytest` *(fails: No module named 'pygame')*


------
https://chatgpt.com/codex/tasks/task_e_68bcb2a574e8832a8bd0cdaad39c5645