### PR TITLE
fix(cli): apply team counts from config.yml

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -36,8 +36,8 @@ def _load_run_defaults_from_yaml(path: Path = Path("config.yml")) -> dict[str, s
     except for ``seeds`` which accepts a comma-separated list on a single line.
 
     Recognised keys include ``weapon_a``, ``weapon_b``, ``seed``,
-    ``seeds``, ``max_simulation_seconds``, ``ai_transition_seconds`` and
-    ``debug``.
+    ``seeds``, ``max_simulation_seconds``, ``ai_transition_seconds``,
+    ``team_a_count``, ``team_b_count`` and ``debug``.
 
     Parameters
     ----------
@@ -69,6 +69,18 @@ def _load_run_defaults_from_yaml(path: Path = Path("config.yml")) -> dict[str, s
         else:
             data[key] = value
     return data
+
+
+def _apply_team_counts(cfg: dict[str, str | list[str]]) -> None:
+    """Apply team sizes from configuration mapping to runtime settings."""
+    from app.core.config import settings
+
+    for key in ("team_a_count", "team_b_count"):
+        if key in cfg:
+            try:
+                setattr(settings, key, int(str(cfg[key])))
+            except ValueError:
+                continue
 
 
 def _resolve_run_parameters(
@@ -107,6 +119,7 @@ def _resolve_run_parameters(
             ai_transition_seconds = None
     if debug is None and "debug" in cfg:
         debug = str(cfg["debug"]).lower() in {"1", "true", "yes", "on"}
+    _apply_team_counts(cfg)
 
     weapon_a = weapon_a or "katana"
     weapon_b = weapon_b or "shuriken"

--- a/tests/test_cli_team_counts_from_config.py
+++ b/tests/test_cli_team_counts_from_config.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from typer.testing import CliRunner
+
+import app.cli as cli_module
+from app.cli import app
+from app.core.config import settings
+from app.video.recorder import NullRecorder
+
+
+def test_run_applies_team_counts_from_config(monkeypatch: Any) -> None:
+    """CLI overrides team sizes using values from ``config.yml``."""
+    captured: dict[str, int] = {}
+
+    monkeypatch.setattr(cli_module, "Recorder", NullRecorder)
+
+    def fake_renderer(
+        width: int,
+        height: int,
+        display: bool = False,
+        *,
+        debug: bool = False,
+    ) -> Any:
+        return object()
+
+    monkeypatch.setattr(cli_module, "Renderer", fake_renderer)
+
+    def fake_create_controller(
+        weapon_a: str,
+        weapon_b: str,
+        recorder: Any,
+        renderer: Any,
+        *,
+        max_seconds: int = 120,
+        ai_transition_seconds: int = 20,
+        display: bool = False,
+        intro_config: Any = None,
+        rng: Any = None,
+    ) -> Any:
+        captured["team_a_count"] = settings.team_a_count
+        captured["team_b_count"] = settings.team_b_count
+
+        class _C:
+            def run(self) -> str:
+                return weapon_a
+
+        return _C()
+
+    from app.game import match as match_module
+
+    monkeypatch.setattr(match_module, "create_controller", fake_create_controller)
+    monkeypatch.setattr(settings, "team_a_count", 1)
+    monkeypatch.setattr(settings, "team_b_count", 1)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path("config.yml").write_text(
+            "\n".join([
+                "team_a_count: 2",
+                "team_b_count: 2",
+            ]),
+            encoding="utf-8",
+        )
+        result = runner.invoke(app, ["run"])
+
+    assert result.exit_code == 0
+    assert captured["team_a_count"] == 2
+    assert captured["team_b_count"] == 2


### PR DESCRIPTION
## Summary
- ensure CLI reads `team_a_count` and `team_b_count` from config.yml
- cover team-count override with new CLI test

## Testing
- `uv run ruff check app/cli.py tests/test_cli_team_counts_from_config.py`
- `uv run mypy app/cli.py tests/test_cli_team_counts_from_config.py`
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'pygame')*
- `uv run pytest tests/test_cli_team_counts_from_config.py` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_68bd2d6ba290832a95ffe358987277b2