### PR TITLE
fix: guard slowmo when recording missing

### DIFF
--- a/app/game/controller.py
+++ b/app/game/controller.py
@@ -633,14 +633,16 @@ class GameController:
         audio = self.engine.end_capture() if not self.display else None
         self.engine.stop_all()
         self.recorder.close(audio)
+        path = self.recorder.path
         if (
             not self.display
             and self.death_ts is not None
-            and self.recorder.path is not None
-            and self.recorder.path.suffix == ".mp4"
+            and path is not None
+            and path.suffix == ".mp4"
+            and path.exists()
         ):
             append_slowmo_ending(
-                self.recorder.path,
+                path,
                 self.death_ts,
                 settings.end_screen.pre_s,
                 settings.end_screen.post_s,


### PR DESCRIPTION
## Summary
- check that recorder path exists before appending slow-mo ending
- ensure tests create recording file and cover missing-file scenario

## Testing
- `uv run ruff check app/game/controller.py tests/test_match_slowmo_timestamp.py`
- `uv run mypy app tests` *(fails: No overload variant of "int" matches argument type "EntityId")*
- `uv run pytest` *(fails: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_68bd5a3f1f9c832aa3bb16172fd2a17c