### PR TITLE
fix: raise error for missing slowmo video path

### DIFF
--- a/app/video/slowmo.py
+++ b/app/video/slowmo.py
@@ -41,6 +41,12 @@ def append_slowmo_ending(
     min_start:
         Minimum timestamp, in seconds, from which extraction can start. Must be
         non-negative and typically corresponds to the intro duration.
+    Raises
+    ------
+    FileNotFoundError
+        If ``path`` does not exist.
+    ValueError
+        If ``slow_factor`` is not positive or ``min_start`` is negative.
     """
     if slow_factor <= 0:
         msg = "slow_factor must be positive"
@@ -48,6 +54,10 @@ def append_slowmo_ending(
     if min_start < 0:
         msg = "min_start must be non-negative"
         raise ValueError(msg)
+
+    if not path.exists():
+        msg = f"Video file not found: {path}"
+        raise FileNotFoundError(msg)
 
     ffmpeg = imageio_ffmpeg.get_ffmpeg_exe()
     start = max(min_start, death_ts - pre_s)

--- a/tests/video/test_slowmo.py
+++ b/tests/video/test_slowmo.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.video.slowmo import append_slowmo_ending
+
+
+def test_append_slowmo_ending_missing_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """append_slowmo_ending raises FileNotFoundError for an unknown path."""
+    path = tmp_path / "missing.mp4"
+    monkeypatch.setattr(
+        "app.video.slowmo.subprocess.run",
+        lambda *a, **k: pytest.fail("subprocess.run should not be called"),
+    )
+    with pytest.raises(FileNotFoundError, match="Video file not found"):
+        append_slowmo_ending(
+            path=path,
+            death_ts=1.0,
+            pre_s=0.5,
+            post_s=0.5,
+            slow_factor=0.5,
+        )


### PR DESCRIPTION
## Summary
- validate video path existence in `append_slowmo_ending`
- document and test error on missing path

## Testing
- `uv run ruff check app/video/slowmo.py tests/video/test_slowmo.py`
- `uv run mypy app/video/slowmo.py tests/video/test_slowmo.py`
- `uv run pytest tests/video/test_slowmo.py`

------
https://chatgpt.com/codex/tasks/task_e_68bd5dda2a08832a96d16fe792f79568