### PR TITLE
feat: add tiktok export pipeline

### DIFF
--- a/app/video/__init__.py
+++ b/app/video/__init__.py
@@ -1,0 +1,5 @@
+"""Video utilities."""
+
+from .export import export_tiktok
+
+__all__ = ["export_tiktok"]

--- a/app/video/export.py
+++ b/app/video/export.py
@@ -1,0 +1,85 @@
+"""Video export helpers for TikTok-friendly encoding."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from moviepy import vfx
+from moviepy.video.VideoClip import VideoClip
+
+TARGET_WIDTH = 1080
+TARGET_HEIGHT = 1920
+
+
+def _pad_clip(clip: VideoClip) -> VideoClip:
+    """Return ``clip`` scaled and padded to 1080×1920 without distortion."""
+
+    scale = min(TARGET_WIDTH / clip.w, TARGET_HEIGHT / clip.h)
+    new_w = int(round(clip.w * scale))
+    new_h = int(round(clip.h * scale))
+    resized = clip.resize((new_w, new_h), method="bicubic")
+
+    pad_left = (TARGET_WIDTH - new_w) // 2
+    pad_right = TARGET_WIDTH - new_w - pad_left
+    pad_top = (TARGET_HEIGHT - new_h) // 2
+    pad_bottom = TARGET_HEIGHT - new_h - pad_top
+
+    return resized.margin(
+        left=pad_left,
+        right=pad_right,
+        top=pad_top,
+        bottom=pad_bottom,
+        color=(0, 0, 0),
+    )
+
+
+def export_tiktok(
+    clip: VideoClip,
+    out_path: str,
+    fps: int,
+    bitrate: str = "15M",
+    boost_tiktok: bool = True,
+) -> str:
+    """Encode ``clip`` with parameters suitable for TikTok."""
+
+    processed = _pad_clip(clip)
+    if boost_tiktok:
+        processed = processed.fx(vfx.lum_contrast, contrast=1.03)
+
+    ffmpeg_params = [
+        "-pix_fmt",
+        "yuv420p",
+        "-movflags",
+        "+faststart",
+        "-profile:v",
+        "high",
+        "-level",
+        "4.1",
+        "-colorspace",
+        "bt709",
+        "-color_primaries",
+        "bt709",
+        "-color_trc",
+        "bt709",
+        "-color_range",
+        "tv",
+    ]
+    if boost_tiktok:
+        ffmpeg_params.extend(["-vf", "hue=s=1.05"])
+
+    processed.write_videofile(
+        out_path,
+        codec="libx264",
+        audio_codec="aac",
+        bitrate=bitrate,
+        fps=fps,
+        audio_bitrate="320k",
+        audio_fps=48_000,
+        threads=os.cpu_count(),
+        ffmpeg_params=ffmpeg_params,
+    )
+    return str(Path(out_path))
+
+
+__all__ = ["export_tiktok"]

--- a/app/video/recorder.py
+++ b/app/video/recorder.py
@@ -72,9 +72,7 @@ class Recorder(RecorderProtocol):
 
         if self._using_stub_imageio:
             # Fallback: record frames as PNGs in a temporary folder and encode with ffmpeg later.
-            self._frames_dir = Path(
-                tempfile.mkdtemp(prefix="frames_", dir=str(self.path.parent))
-            )
+            self._frames_dir = Path(tempfile.mkdtemp(prefix="frames_", dir=str(self.path.parent)))
 
             class _PngSeqWriter:
                 def __init__(self, out_dir: Path) -> None:
@@ -150,11 +148,11 @@ class Recorder(RecorderProtocol):
                 logger.warning("No video frames recorded; skipping muxing")
                 # Cleanup temp dir
                 if hasattr(self, "_frames_dir"):
-                    shutil.rmtree(getattr(self, "_frames_dir"), ignore_errors=True)
+                    shutil.rmtree(self._frames_dir, ignore_errors=True)
                 self.path = None
                 return
             ffmpeg = imageio_ffmpeg.get_ffmpeg_exe()
-            pattern = str(getattr(self, "_frames_dir") / "frame_%06d.png")
+            pattern = str(self._frames_dir / "frame_%06d.png")
             cmd = [
                 ffmpeg,
                 "-y",
@@ -172,11 +170,11 @@ class Recorder(RecorderProtocol):
                 subprocess.run(cmd, check=True, capture_output=True, text=True)
             except subprocess.CalledProcessError as exc:  # pragma: no cover - depends on env
                 logger.error("ffmpeg encoding failed: %s", exc.stderr)
-                shutil.rmtree(getattr(self, "_frames_dir"), ignore_errors=True)
+                shutil.rmtree(self._frames_dir, ignore_errors=True)
                 self.path = None
                 return
             finally:
-                shutil.rmtree(getattr(self, "_frames_dir"), ignore_errors=True)
+                shutil.rmtree(self._frames_dir, ignore_errors=True)
 
         if self._frame_count == 0 or not self._video_path.exists():
             logger.warning("No video frames recorded; skipping muxing")

--- a/app/weapons/bazooka.py
+++ b/app/weapons/bazooka.py
@@ -53,7 +53,7 @@ class Bazooka(Weapon):
         # Align audio capture with simulation time for consistent muxing.
         timestamp: float | None
         try:
-            timestamp = float(getattr(view, "get_time")())
+            timestamp = float(view.get_time())
         except Exception:
             timestamp = None
         self.audio.on_throw(timestamp)
@@ -85,10 +85,7 @@ class Bazooka(Weapon):
 
     def _ensure_effect(self, owner: EntityId, view: WorldView) -> None:
         """Ensure the aiming sprite exists within the view's effect list."""
-        is_active = (
-            self._effect is not None
-            and self._effect in getattr(view, "effects", [])
-        )
+        is_active = self._effect is not None and self._effect in getattr(view, "effects", [])
         if not is_active:
             effect = AimedSprite(
                 owner=owner,

--- a/app/weapons/shuriken.py
+++ b/app/weapons/shuriken.py
@@ -32,7 +32,7 @@ class Shuriken(Weapon):
         # Provide deterministic timestamp for audio capture.
         timestamp: float | None
         try:
-            timestamp = float(getattr(view, "get_time")())
+            timestamp = float(view.get_time())
         except Exception:
             timestamp = None
         self.audio.on_throw(timestamp)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
   "pymunk>=7,<8",
   "imageio>=2.36.0",
   "imageio-ffmpeg>=0.5.0",
+  "moviepy>=1.0.0",
   "typer>=0.12.0",
   "pydantic-settings>=2.4.0",
   "numpy>=2.3.0",

--- a/tests/test_cli_multiple_seeds.py
+++ b/tests/test_cli_multiple_seeds.py
@@ -69,17 +69,20 @@ def test_run_multiple_seeds(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
         intro_weapons: tuple[str, str] | None,
         display: bool,
         debug_flag: bool,
+        boost_tiktok: bool,
     ) -> bool:
         captured.append(seed)
         return True
 
     monkeypatch.setattr(cli, "_run_single_match", fake_run)
 
-    config = "\n".join([
-        "weapon_a: katana",
-        "weapon_b: shuriken",
-        "seeds: [1, 2]",
-    ])
+    config = "\n".join(
+        [
+            "weapon_a: katana",
+            "weapon_b: shuriken",
+            "seeds: [1, 2]",
+        ]
+    )
     (tmp_path / "config.yml").write_text(config, encoding="utf-8")
     monkeypatch.chdir(tmp_path)
 

--- a/tests/test_cli_timeout_continuation.py
+++ b/tests/test_cli_timeout_continuation.py
@@ -70,17 +70,20 @@ def test_run_continues_after_timeout(tmp_path: Path, monkeypatch: pytest.MonkeyP
         intro_weapons: tuple[str, str] | None,
         display: bool,
         debug_flag: bool,
+        boost_tiktok: bool,
     ) -> bool:
         captured.append(seed)
         return seed != 1
 
     monkeypatch.setattr(cli, "_run_single_match", fake_run)
 
-    config = "\n".join([
-        "weapon_a: katana",
-        "weapon_b: shuriken",
-        "seeds: [1, 2]",
-    ])
+    config = "\n".join(
+        [
+            "weapon_a: katana",
+            "weapon_b: shuriken",
+            "seeds: [1, 2]",
+        ]
+    )
     (tmp_path / "config.yml").write_text(config, encoding="utf-8")
     monkeypatch.chdir(tmp_path)
 

--- a/tests/video/test_export.py
+++ b/tests/video/test_export.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.video.export import export_tiktok
+
+
+class _DummyClip:
+    def __init__(self, w: int, h: int) -> None:
+        self.w = w
+        self.h = h
+        self.calls: list[tuple[str, object]] = []
+
+    def resize(self, size: tuple[int, int], method: str = "") -> _DummyClip:
+        self.calls.append(("resize", size))
+        self.w, self.h = size
+        return self
+
+    def margin(
+        self,
+        *,
+        left: int = 0,
+        right: int = 0,
+        top: int = 0,
+        bottom: int = 0,
+        color: tuple[int, int, int] | None = None,
+    ) -> _DummyClip:
+        self.calls.append(("margin", (left, right, top, bottom)))
+        self.w += left + right
+        self.h += top + bottom
+        return self
+
+    def fx(self, _func: object, **kwargs: object) -> _DummyClip:
+        self.calls.append(("fx", kwargs))
+        return self
+
+    def write_videofile(self, out_path: str, **kwargs: object) -> str:
+        self.calls.append(("write", out_path, kwargs))
+        Path(out_path).write_bytes(b"")
+        return out_path
+
+
+def test_export_tiktok_scales_and_pads(tmp_path: Path) -> None:
+    clip = _DummyClip(800, 600)
+    out = tmp_path / "out.mp4"
+    export_tiktok(clip, str(out), fps=30)
+
+    assert clip.calls[0] == ("resize", (1080, 810))
+    assert clip.calls[1] == ("margin", (0, 0, 555, 555))
+    assert clip.calls[2][0] == "fx"
+    write_call = clip.calls[-1]
+    assert write_call[0] == "write"
+    params = write_call[2]
+    assert params["codec"] == "libx264"
+    assert "-pix_fmt" in params["ffmpeg_params"]
+    assert out.exists()


### PR DESCRIPTION
## Summary
- add `export_tiktok` helper for scaling, padding and color boosting
- wire TikTok export into CLI run and batch commands
- document TikTok export parameters in code and tests

## Testing
- `ruff check .`
- `mypy .` *(fails: many missing modules such as moviepy, pygame)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'moviepy', 'pygame')*


------
https://chatgpt.com/codex/tasks/task_e_68c33d12e6f4832a98702e691776e290